### PR TITLE
Add support for serializing KeyValue lists

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added support for serializing attribute values that are key/value lists
+  (`IEnumerable<KeyValuePair<string, object?>>`). These attributes will be
+  serialized as JSON arrays of objects.
+  ([#7015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7015))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes](../../RELEASENOTES.md).
 
 * Added support for serializing attribute values that are key/value lists
   (`IEnumerable<KeyValuePair<string, object?>>`). These attributes will be
-  serialized as JSON arrays of objects.
+  serialized as JSON objects.
   ([#7015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7015))
 
 ## 1.17.0

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using Microsoft.Extensions.Primitives;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter;
@@ -83,6 +84,18 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
         consoleTag.Key = key;
         consoleTag.Value = null;
         return true;
+    }
+
+    protected override void WriteKvListTag(ref ConsoleTag state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
+    {
+        var stringValue = Convert.ToString(kvList, CultureInfo.InvariantCulture);
+
+        if (stringValue is null)
+        {
+            return;
+        }
+
+        this.TryWriteTag(ref state, key, stringValue);
     }
 
     internal struct ConsoleTag

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -85,6 +85,113 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
         return true;
     }
 
+    protected override void WriteKvListTag(ref ConsoleTag state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
+    {
+        var sb = new StringBuilder();
+        sb.Append('{');
+        var first = true;
+        foreach (var kvp in kvList)
+        {
+            ConsoleTag nestedTag = default;
+            if (this.TryWriteTag(ref nestedTag, kvp.Key, kvp.Value, tagValueMaxLength))
+            {
+                if (!first)
+                {
+                    sb.Append(',');
+                }
+
+                first = false;
+                sb.Append('"');
+                AppendJsonEscaped(sb, kvp.Key);
+                sb.Append("\":");
+
+                var tagValue = nestedTag.Value;
+                if (tagValue == null)
+                {
+                    sb.Append("null");
+                }
+                else if (IsRawJsonValue(kvp.Value, tagValue))
+                {
+                    sb.Append(tagValue);
+                }
+                else
+                {
+                    sb.Append('"');
+                    AppendJsonEscaped(sb, tagValue);
+                    sb.Append('"');
+                }
+            }
+        }
+
+        sb.Append('}');
+        state.Key = key;
+        state.Value = sb.ToString();
+    }
+
+    /// <summary>
+    /// Determines whether tagValue is already a valid JSON literal
+    /// that should be embedded without surrounding quotes.
+    /// </summary>
+    private static bool IsRawJsonValue(object? originalValue, string tagValue)
+    {
+        if (originalValue is bool
+            or byte or sbyte or short or ushort or int or uint or long
+            or float or double)
+        {
+            return true;
+        }
+
+        // KV lists and arrays produce JSON objects/arrays via TryWriteTag.
+        // However, when the recursion depth limit is reached, TryWriteTag
+        // falls back to a plain string (the type name). Detect this by
+        // checking whether the output starts with '{' or '['.
+        if ((originalValue is IEnumerable<KeyValuePair<string, object?>> or Array)
+            && tagValue.Length > 0
+            && (tagValue[0] == '{' || tagValue[0] == '['))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void AppendJsonEscaped(StringBuilder sb, string value)
+    {
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '"':
+                    sb.Append("\\\"");
+                    break;
+                case '\\':
+                    sb.Append("\\\\");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                default:
+                    if (c < ' ')
+                    {
+                        sb.Append("\\u");
+                        sb.Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+
+                    break;
+            }
+        }
+    }
+
     internal struct ConsoleTag
     {
         public string? Key;

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -87,14 +87,109 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
 
     protected override void WriteKvListTag(ref ConsoleTag state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
     {
-        var stringValue = Convert.ToString(kvList, CultureInfo.InvariantCulture);
-
-        if (stringValue is null)
+        var sb = new StringBuilder();
+        sb.Append('{');
+        var first = true;
+        foreach (var kvp in kvList)
         {
-            return;
+            ConsoleTag nestedTag = default;
+            if (this.TryWriteTag(ref nestedTag, kvp.Key, kvp.Value, tagValueMaxLength))
+            {
+                if (!first)
+                {
+                    sb.Append(',');
+                }
+
+                first = false;
+                sb.Append('"');
+                AppendJsonEscaped(sb, kvp.Key);
+                sb.Append("\":");
+
+                var tagValue = nestedTag.Value;
+                if (tagValue == null)
+                {
+                    sb.Append("null");
+                }
+                else if (IsRawJsonValue(kvp.Value, tagValue))
+                {
+                    sb.Append(tagValue);
+                }
+                else
+                {
+                    sb.Append('"');
+                    AppendJsonEscaped(sb, tagValue);
+                    sb.Append('"');
+                }
+            }
         }
 
-        this.TryWriteTag(ref state, key, stringValue);
+        sb.Append('}');
+        state.Key = key;
+        state.Value = sb.ToString();
+    }
+
+    /// <summary>
+    /// Determines whether tagValue is already a valid JSON literal
+    /// that should be embedded without surrounding quotes.
+    /// </summary>
+    private static bool IsRawJsonValue(object? originalValue, string tagValue)
+    {
+        if (originalValue is bool
+            or byte or sbyte or short or ushort or int or uint or long
+            or float or double)
+        {
+            return true;
+        }
+
+        // KV lists and arrays produce JSON objects/arrays via TryWriteTag.
+        // However, when the recursion depth limit is reached, TryWriteTag
+        // falls back to a plain string (the type name). Detect this by
+        // checking whether the output starts with '{' or '['.
+        if ((originalValue is IEnumerable<KeyValuePair<string, object?>> or Array)
+            && tagValue.Length > 0
+            && (tagValue[0] == '{' || tagValue[0] == '['))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void AppendJsonEscaped(StringBuilder sb, string value)
+    {
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '"':
+                    sb.Append("\\\"");
+                    break;
+                case '\\':
+                    sb.Append("\\\\");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                default:
+                    if (c < ' ')
+                    {
+                        sb.Append("\\u");
+                        sb.Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+
+                    break;
+            }
+        }
     }
 
     internal struct ConsoleTag

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-using Microsoft.Extensions.Primitives;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter;

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter;
@@ -87,45 +88,43 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
 
     protected override void WriteKvListTag(ref ConsoleTag state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
     {
-        var sb = new StringBuilder();
-        sb.Append('{');
-        var first = true;
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        writer.WriteStartObject();
         foreach (var kvp in kvList)
         {
             ConsoleTag nestedTag = default;
             if (this.TryWriteTag(ref nestedTag, kvp.Key, kvp.Value, tagValueMaxLength))
             {
-                if (!first)
-                {
-                    sb.Append(',');
-                }
-
-                first = false;
-                sb.Append('"');
-                AppendJsonEscaped(sb, kvp.Key);
-                sb.Append("\":");
+                writer.WritePropertyName(kvp.Key);
 
                 var tagValue = nestedTag.Value;
                 if (tagValue == null)
                 {
-                    sb.Append("null");
+                    writer.WriteNullValue();
                 }
                 else if (IsRawJsonValue(kvp.Value, tagValue))
                 {
-                    sb.Append(tagValue);
+#if NET
+                    writer.WriteRawValue(tagValue);
+#else
+                    using var doc = JsonDocument.Parse(tagValue);
+                    doc.RootElement.WriteTo(writer);
+#endif
                 }
                 else
                 {
-                    sb.Append('"');
-                    AppendJsonEscaped(sb, tagValue);
-                    sb.Append('"');
+                    writer.WriteStringValue(tagValue);
                 }
             }
         }
 
-        sb.Append('}');
+        writer.WriteEndObject();
+        writer.Flush();
+
         state.Key = key;
-        state.Value = sb.ToString();
+        state.Value = Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
     }
 
     /// <summary>
@@ -134,9 +133,13 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
     /// </summary>
     private static bool IsRawJsonValue(object? originalValue, string tagValue)
     {
+        if (originalValue is float or double)
+        {
+            return tagValue is not ("NaN" or "Infinity" or "-Infinity");
+        }
+
         if (originalValue is bool
-            or byte or sbyte or short or ushort or int or uint or long
-            or float or double)
+            or byte or sbyte or short or ushort or int or uint or long)
         {
             return true;
         }
@@ -153,43 +156,6 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
         }
 
         return false;
-    }
-
-    private static void AppendJsonEscaped(StringBuilder sb, string value)
-    {
-        foreach (var c in value)
-        {
-            switch (c)
-            {
-                case '"':
-                    sb.Append("\\\"");
-                    break;
-                case '\\':
-                    sb.Append("\\\\");
-                    break;
-                case '\n':
-                    sb.Append("\\n");
-                    break;
-                case '\r':
-                    sb.Append("\\r");
-                    break;
-                case '\t':
-                    sb.Append("\\t");
-                    break;
-                default:
-                    if (c < ' ')
-                    {
-                        sb.Append("\\u");
-                        sb.Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
-                    }
-                    else
-                    {
-                        sb.Append(c);
-                    }
-
-                    break;
-            }
-        }
     }
 
     internal struct ConsoleTag

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -44,24 +44,30 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
     {
         consoleTag.Key = key;
         consoleTag.Value = value.ToString(CultureInfo.InvariantCulture);
+        consoleTag.IsJsonLiteral = true;
     }
 
     protected override void WriteFloatingPointTag(ref ConsoleTag consoleTag, string key, double value)
     {
         consoleTag.Key = key;
         consoleTag.Value = value.ToString(CultureInfo.InvariantCulture);
+
+        // JSON has no representation for NaN or infinity, so those are emitted as strings.
+        consoleTag.IsJsonLiteral = !double.IsNaN(value) && !double.IsInfinity(value);
     }
 
     protected override void WriteBooleanTag(ref ConsoleTag consoleTag, string key, bool value)
     {
         consoleTag.Key = key;
         consoleTag.Value = value ? "true" : "false";
+        consoleTag.IsJsonLiteral = true;
     }
 
     protected override void WriteStringTag(ref ConsoleTag consoleTag, string key, ReadOnlySpan<char> value)
     {
         consoleTag.Key = key;
         consoleTag.Value = value.ToString();
+        consoleTag.IsJsonLiteral = false;
     }
 
     protected override void WriteArrayTag(ref ConsoleTag consoleTag, string key, ArraySegment<byte> arrayUtf8JsonBytes)
@@ -72,6 +78,7 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
 #else
         consoleTag.Value = Encoding.UTF8.GetString(arrayUtf8JsonBytes.Array, 0, arrayUtf8JsonBytes.Count);
 #endif
+        consoleTag.IsJsonLiteral = true;
     }
 
     protected override void OnUnsupportedTagDropped(
@@ -83,6 +90,7 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
     {
         consoleTag.Key = key;
         consoleTag.Value = null;
+        consoleTag.IsJsonLiteral = false;
         return true;
     }
 
@@ -104,8 +112,11 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
                 {
                     writer.WriteNullValue();
                 }
-                else if (IsRawJsonValue(kvp.Value, tagValue))
+                else if (nestedTag.IsJsonLiteral)
                 {
+                    // The nested write produced JSON (a number, a boolean, an
+                    // array or an object), so it is embedded as-is rather than
+                    // being quoted as a string.
 #if NET
                     writer.WriteRawValue(tagValue);
 #else
@@ -125,36 +136,7 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
 
         state.Key = key;
         state.Value = Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
-    }
-
-    /// <summary>
-    /// Determines whether tagValue is already a valid JSON literal
-    /// that should be embedded without surrounding quotes.
-    /// </summary>
-    private static bool IsRawJsonValue(object? originalValue, string tagValue)
-    {
-        if (originalValue is float or double)
-        {
-            return tagValue is not ("NaN" or "Infinity" or "-Infinity");
-        }
-
-        if (originalValue is bool or byte or sbyte or short or ushort or int or uint or long)
-        {
-            return true;
-        }
-
-        // KV lists and arrays produce JSON objects/arrays via TryWriteTag.
-        // However, when the recursion depth limit is reached, TryWriteTag
-        // falls back to a plain string (the type name). Detect this by
-        // checking whether the output starts with '{' or '['.
-        if ((originalValue is IEnumerable<KeyValuePair<string, object?>> or Array)
-            && tagValue.Length > 0
-            && (tagValue[0] is '{' or '['))
-        {
-            return true;
-        }
-
-        return false;
+        state.IsJsonLiteral = true;
     }
 
     internal struct ConsoleTag
@@ -162,5 +144,11 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
         public string? Key;
 
         public string? Value;
+
+        // Set when Value is already a JSON literal (a number, a boolean, an
+        // array or an object) as opposed to text which has to be quoted when
+        // embedded in JSON. Written by the tag writing methods so that nested
+        // values do not have to be inferred from the serialized text.
+        public bool IsJsonLiteral;
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -138,8 +138,7 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
             return tagValue is not ("NaN" or "Infinity" or "-Infinity");
         }
 
-        if (originalValue is bool
-            or byte or sbyte or short or ushort or int or uint or long)
+        if (originalValue is bool or byte or sbyte or short or ushort or int or uint or long)
         {
             return true;
         }
@@ -150,7 +149,7 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
         // checking whether the output starts with '{' or '['.
         if ((originalValue is IEnumerable<KeyValuePair<string, object?>> or Array)
             && tagValue.Length > 0
-            && (tagValue[0] == '{' || tagValue[0] == '['))
+            && (tagValue[0] is '{' or '['))
         {
             return true;
         }

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -22,4 +22,8 @@
     <Compile Include="$(RepoRoot)\src\Shared\TagWriter\*.cs" Link="Includes\TagWriter\%(Filename).cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="OpenTelemetry.Exporter.Console.Tests" PublicKey="$(StrongNamePublicKey)" />
+  </ItemGroup>
+
 </Project>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,12 +7,6 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Added support for serializing attribute values that are key/value lists
-  (`IEnumerable<KeyValuePair<string, object?>>`) as nested OTLP `kvlist` values.
-  Nesting is limited to a maximum recursion depth of 3; deeper values fall back
-  to their string representation.
-  ([#7015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7015))
-
 * Fixed `UseOtlpExporter` to respect options configured through
   `services.Configure<OtlpExporterOptions>(...)`.
   ([#7540](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7540))
@@ -34,6 +28,12 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed the OTLP exporter from retrying certain non-transient HTTP failures.
   ([#7600](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7600))
+
+* Added support for serializing attribute values that are key/value lists
+  (`IEnumerable<KeyValuePair<string, object?>>`) as nested OTLP `kvlist` values.
+  Nesting is limited to a maximum recursion depth of 3; deeper values fall back
+  to their string representation.
+  ([#7015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7015))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,12 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added support for serializing attribute values that are key/value lists
+  (`IEnumerable<KeyValuePair<string, object?>>`) as nested OTLP `kvlist` values.
+  Nesting is limited to a maximum recursion depth of 3; deeper values fall back
+  to their string representation.
+  ([#7015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7015))
+
 * Fixed `UseOtlpExporter` to respect options configured through
   `services.Configure<OtlpExporterOptions>(...)`.
   ([#7540](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7540))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpCommonFieldNumberConstants.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpCommonFieldNumberConstants.cs
@@ -29,4 +29,6 @@ internal static class ProtobufOtlpCommonFieldNumberConstants
     internal const int AnyValue_Bytes_Value = 7;
 
     internal const int ArrayValue_Value = 1;
+
+    internal const int KeyValueList_Values = 1;
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
@@ -7,6 +7,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer
 
 internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.OtlpTagWriterState, ProtobufOtlpTagWriter.OtlpTagWriterArrayState>
 {
+    private const int ReserveSizeForLength = 4;
+
     private ProtobufOtlpTagWriter()
         : base(new OtlpArrayTagWriter())
     {
@@ -99,6 +101,55 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
         state.WritePosition = ProtobufSerializer.WriteByteArrayWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bytes_Value, value);
 
         return true;
+    }
+
+    protected override void WriteKvListTag(ref OtlpTagWriterState state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
+    {
+        var startPosition = state.WritePosition;
+
+        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+
+        // Reserve space for KeyValue.value (AnyValue wrapper)
+        state.WritePosition = ProtobufSerializer.WriteTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
+        int anyValueLengthPos = state.WritePosition;
+        state.WritePosition += ReserveSizeForLength;
+
+        // Reserve space for AnyValue.kvlist_value (KeyValueList wrapper)
+        state.WritePosition = ProtobufSerializer.WriteTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Kvlist_Value, ProtobufWireType.LEN);
+        int kvlistLengthPos = state.WritePosition;
+        state.WritePosition += ReserveSizeForLength;
+
+        try
+        {
+            foreach (var kvp in kvList)
+            {
+                var startEntryPosition = state.WritePosition;
+
+                // Write KeyValueList.values tag (field 1, LEN) + reserve length per entry
+                state.WritePosition = ProtobufSerializer.WriteTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValueList_Values, ProtobufWireType.LEN);
+                int entryLengthPos = state.WritePosition;
+                state.WritePosition += ReserveSizeForLength;
+
+                // Drop a tag if we fail to write it, and reset the position to the start of the entry to overwrite the reserved tag and length for the next entry.
+                if (!this.TryWriteTag(ref state, kvp.Key, kvp.Value, tagValueMaxLength))
+                {
+                    state.WritePosition = startEntryPosition;
+                    continue;
+                }
+
+                ProtobufSerializer.WriteReservedLength(state.Buffer, entryLengthPos, state.WritePosition - (entryLengthPos + ReserveSizeForLength));
+            }
+        }
+        catch (Exception)
+        {
+            state.WritePosition = startPosition;
+
+            throw;
+        }
+
+        // Fill in reserved lengths
+        ProtobufSerializer.WriteReservedLength(state.Buffer, kvlistLengthPos, state.WritePosition - (kvlistLengthPos + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(state.Buffer, anyValueLengthPos, state.WritePosition - (anyValueLengthPos + ReserveSizeForLength));
     }
 
     internal struct OtlpTagWriterState

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
@@ -8,6 +8,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer
 
 internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.OtlpTagWriterState, ProtobufOtlpTagWriter.OtlpTagWriterArrayState>
 {
+    private const int ReserveSizeForLength = 4;
+
     private readonly OtlpArrayTagWriter arrayTagWriter;
 
     internal ProtobufOtlpTagWriter(OtlpArrayTagWriter arrayTagWriter)
@@ -158,6 +160,55 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
         state.WritePosition = ProtobufSerializer.WriteByteArrayWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bytes_Value, value);
 
         return true;
+    }
+
+    protected override void WriteKvListTag(ref OtlpTagWriterState state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
+    {
+        var startPosition = state.WritePosition;
+
+        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+
+        // Reserve space for KeyValue.value (AnyValue wrapper)
+        state.WritePosition = ProtobufSerializer.WriteTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
+        int anyValueLengthPos = state.WritePosition;
+        state.WritePosition += ReserveSizeForLength;
+
+        // Reserve space for AnyValue.kvlist_value (KeyValueList wrapper)
+        state.WritePosition = ProtobufSerializer.WriteTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Kvlist_Value, ProtobufWireType.LEN);
+        int kvlistLengthPos = state.WritePosition;
+        state.WritePosition += ReserveSizeForLength;
+
+        try
+        {
+            foreach (var kvp in kvList)
+            {
+                var startEntryPosition = state.WritePosition;
+
+                // Write KeyValueList.values tag (field 1, LEN) + reserve length per entry
+                state.WritePosition = ProtobufSerializer.WriteTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValueList_Values, ProtobufWireType.LEN);
+                int entryLengthPos = state.WritePosition;
+                state.WritePosition += ReserveSizeForLength;
+
+                // Drop a tag if we fail to write it, and reset the position to the start of the entry to overwrite the reserved tag and length for the next entry.
+                if (!this.TryWriteTag(ref state, kvp.Key, kvp.Value, tagValueMaxLength))
+                {
+                    state.WritePosition = startEntryPosition;
+                    continue;
+                }
+
+                ProtobufSerializer.WriteReservedLength(state.Buffer, entryLengthPos, state.WritePosition - (entryLengthPos + ReserveSizeForLength));
+            }
+        }
+        catch (Exception)
+        {
+            state.WritePosition = startPosition;
+
+            throw;
+        }
+
+        // Fill in reserved lengths
+        ProtobufSerializer.WriteReservedLength(state.Buffer, kvlistLengthPos, state.WritePosition - (kvlistLengthPos + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(state.Buffer, anyValueLengthPos, state.WritePosition - (anyValueLengthPos + ReserveSizeForLength));
     }
 
     internal struct OtlpTagWriterState

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -12,6 +12,10 @@ Notes](../../RELEASENOTES.md).
   the response body in memory when it is not actually used.
   ([#7582](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7582))
 
+* Added support for serializing attribute values that are key/value lists
+  (`IEnumerable<KeyValuePair<string, object?>>`). No change to existing behavior.
+  ([#7015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7015))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -13,7 +13,7 @@ Notes](../../RELEASENOTES.md).
   ([#7582](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7582))
 
 * Added support for serializing attribute values that are key/value lists
-  (`IEnumerable<KeyValuePair<string, object?>>`). No change to existing behavior.
+  (`IEnumerable<KeyValuePair<string, object?>>`).
   ([#7015](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7015))
 
 ## 1.17.0

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Buffers.Text;
-using System.Collections;
 using System.Globalization;
 using System.Text.Json;
 using OpenTelemetry.Internal;

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Buffers.Text;
+using System.Collections;
 using System.Globalization;
 using System.Text.Json;
 using OpenTelemetry.Internal;
@@ -66,4 +67,16 @@ internal sealed class ZipkinTagWriter : JsonStringArrayTagWriter<Utf8JsonWriter>
     }
 
     protected override bool TryWriteEmptyTag(ref Utf8JsonWriter state, string key, object? value) => false;
+
+    protected override void WriteKvListTag(ref Utf8JsonWriter writer, string key, IEnumerable<KeyValuePair<string, object?>> value, int? tagValueMaxLength)
+    {
+        var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+
+        if (stringValue is null)
+        {
+            return;
+        }
+
+        this.TryWriteTag(ref writer, key, stringValue);
+    }
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
@@ -66,4 +66,16 @@ internal sealed class ZipkinTagWriter : JsonStringArrayTagWriter<Utf8JsonWriter>
     }
 
     protected override bool TryWriteEmptyTag(ref Utf8JsonWriter state, string key, object? value) => false;
+
+    protected override void WriteKvListTag(ref Utf8JsonWriter writer, string key, IEnumerable<KeyValuePair<string, object?>> value, int? tagValueMaxLength)
+    {
+        var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+
+        if (stringValue is null)
+        {
+            return;
+        }
+
+        this.TryWriteTag(ref writer, key, stringValue);
+    }
 }

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -64,6 +64,22 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case double:
                 this.WriteFloatingPointTag(ref state, key, Convert.ToDouble(value, CultureInfo.InvariantCulture));
                 break;
+            case IEnumerable<KeyValuePair<string, object?>> kvList:
+                try
+                {
+                    this.WriteKvListTag(ref state, key, kvList, tagValueMaxLength);
+                }
+                catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
+                {
+                    throw;
+                }
+                catch
+                {
+                    return this.LogUnsupportedTagTypeAndReturnFalse(key, value);
+                }
+
+                break;
+
             case Array array:
                 if (value.GetType() == typeof(byte[]) && this.TryWriteByteArrayTag(ref state, key, ((byte[])value).AsSpan()))
                 {
@@ -133,6 +149,8 @@ internal abstract class TagWriter<TTagState, TArrayState>
     protected abstract void WriteStringTag(ref TTagState state, string key, ReadOnlySpan<char> value);
 
     protected abstract void WriteArrayTag(ref TTagState state, string key, ref TArrayState value);
+
+    protected abstract void WriteKvListTag(ref TTagState state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength);
 
     protected abstract void OnUnsupportedTagDropped(
         string tagKey,

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -10,7 +10,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
     where TTagState : notnull
     where TArrayState : notnull
 {
-    internal const int MaxRecursionDepth = 3;
+    internal const int MaxRecursionDepth = 3; // TODO https://github.com/open-telemetry/semantic-conventions/issues/3648
 
     [ThreadStatic]
     private static int recursionDepth;

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -10,6 +10,11 @@ internal abstract class TagWriter<TTagState, TArrayState>
     where TTagState : notnull
     where TArrayState : notnull
 {
+    internal const int MaxRecursionDepth = 3;
+
+    [ThreadStatic]
+    private static int recursionDepth;
+
     private readonly ArrayTagWriter<TArrayState> arrayWriter;
 
     protected TagWriter(
@@ -67,14 +72,32 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case IEnumerable<KeyValuePair<string, object?>> kvList:
                 try
                 {
+                    if (recursionDepth >= MaxRecursionDepth)
+                    {
+                        var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+                        this.WriteStringTag(
+                            ref state,
+                            key,
+                            TruncateString(stringValue.AsSpan(), tagValueMaxLength));
+
+                        break;
+                    }
+                    else
+                    {
+                        recursionDepth++;
+                    }
+
                     this.WriteKvListTag(ref state, key, kvList, tagValueMaxLength);
+                    recursionDepth--;
                 }
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                 {
+                    recursionDepth = 0;
                     throw;
                 }
                 catch
                 {
+                    recursionDepth--;
                     return this.LogUnsupportedTagTypeAndReturnFalse(key, value);
                 }
 

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -10,6 +10,11 @@ internal abstract class TagWriter<TTagState, TArrayState>
     where TTagState : notnull
     where TArrayState : notnull
 {
+    internal const int MaxRecursionDepth = 3; // TODO https://github.com/open-telemetry/semantic-conventions/issues/3648
+
+    [ThreadStatic]
+    private static int recursionDepth;
+
     private readonly ArrayTagWriter<TArrayState> arrayWriter;
 
     protected TagWriter(
@@ -87,6 +92,43 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case float f:
                 this.WriteFloatingPointTag(ref state, key, f);
                 break;
+            case double d:
+                this.WriteFloatingPointTag(ref state, key, d);
+                break;
+            case IEnumerable<KeyValuePair<string, object?>> kvList:
+                try
+                {
+                    if (recursionDepth >= MaxRecursionDepth)
+                    {
+                        var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+                        this.WriteStringTag(
+                            ref state,
+                            key,
+                            TruncateString(stringValue.AsSpan(), tagValueMaxLength));
+
+                        break;
+                    }
+                    else
+                    {
+                        recursionDepth++;
+                    }
+
+                    this.WriteKvListTag(ref state, key, kvList, tagValueMaxLength);
+                    recursionDepth--;
+                }
+                catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
+                {
+                    recursionDepth = 0;
+                    throw;
+                }
+                catch
+                {
+                    recursionDepth--;
+                    return this.LogUnsupportedTagTypeAndReturnFalse(key, value);
+                }
+
+                break;
+
             case Array array:
                 if (value.GetType() == typeof(byte[]) && this.TryWriteByteArrayTag(ref state, key, ((byte[])value).AsSpan()))
                 {
@@ -161,9 +203,16 @@ internal abstract class TagWriter<TTagState, TArrayState>
 
     protected abstract void WriteArrayTag(ref TTagState state, string key, ref TArrayState value);
 
+    protected abstract void WriteKvListTag(ref TTagState state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength);
+
     protected abstract void OnUnsupportedTagDropped(
         string tagKey,
         string tagValueTypeFullName);
+
+    private static ReadOnlySpan<char> TruncateString(ReadOnlySpan<char> value, int? maxLength)
+        => maxLength.HasValue && value.Length > maxLength
+           ? value.Slice(0, maxLength.Value)
+           : value;
 
     private void WriteCharTag(ref TTagState state, string key, char value)
     {

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -93,25 +93,39 @@ internal abstract class TagWriter<TTagState, TArrayState>
                 this.WriteFloatingPointTag(ref state, key, f);
                 break;
             case IEnumerable<KeyValuePair<string, object?>> kvList:
-                try
+                if (recursionDepth >= MaxRecursionDepth)
                 {
-                    if (recursionDepth >= MaxRecursionDepth)
+                    // Note: The nesting limit has been reached so the value is
+                    // written as a string instead of recursing any further.
+                    // This branch does not take part in the recursion so it
+                    // must not touch the depth.
+                    try
                     {
                         var stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
                         this.WriteStringTag(
                             ref state,
                             key,
                             TruncateString(stringValue.AsSpan(), tagValueMaxLength));
-
-                        break;
                     }
-                    else
+                    catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                     {
-                        recursionDepth++;
+                        recursionDepth = 0;
+                        throw;
+                    }
+                    catch
+                    {
+                        // If ToString throws an exception then the tag is ignored.
+                        return this.LogUnsupportedTagTypeAndReturnFalse(key, value);
                     }
 
+                    break;
+                }
+
+                recursionDepth++;
+
+                try
+                {
                     this.WriteKvListTag(ref state, key, kvList, tagValueMaxLength);
-                    recursionDepth--;
                 }
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                 {
@@ -123,6 +137,8 @@ internal abstract class TagWriter<TTagState, TArrayState>
                     recursionDepth--;
                     return this.LogUnsupportedTagTypeAndReturnFalse(key, value);
                 }
+
+                recursionDepth--;
 
                 break;
 

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -223,8 +223,8 @@ internal abstract class TagWriter<TTagState, TArrayState>
         string tagValueTypeFullName);
 
     private static ReadOnlySpan<char> TruncateString(ReadOnlySpan<char> value, int? maxLength)
-        => maxLength.HasValue && value.Length > maxLength
-           ? value.Slice(0, maxLength.Value)
+        => maxLength is { } maxLengthValue && value.Length > maxLengthValue
+           ? value.Slice(0, maxLengthValue)
            : value;
 
     private void WriteCharTag(ref TTagState state, string key, char value)

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -92,9 +92,6 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case float f:
                 this.WriteFloatingPointTag(ref state, key, f);
                 break;
-            case double d:
-                this.WriteFloatingPointTag(ref state, key, d);
-                break;
             case IEnumerable<KeyValuePair<string, object?>> kvList:
                 try
                 {

--- a/test/Benchmarks/Exporter/ProtobufOtlpLogSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ProtobufOtlpLogSerializerBenchmarks.cs
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+extern alias OpenTelemetryProtocol;
+
+using BenchmarkDotNet.Attributes;
+using Benchmarks.Helper;
+using OpenTelemetry.Logs;
+using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
+
+namespace Benchmarks.Exporter;
+
+[MemoryDiagnoser(false)]
+public class ProtobufOtlpLogSerializerBenchmarks
+{
+    private static readonly KeyValuePair<string, object?>[] AllAttributes =
+    [
+        new("http.request.method", "GET"),
+        new("http.route", "/api/orders/{id}"),
+        new("http.response.status_code", 200L),
+        new("url.full", "https://shop.example.com/api/orders/42"),
+        new("url.scheme", "https"),
+        new("server.address", "shop.example.com"),
+        new("server.port", 443L),
+        new("client.address", "203.0.113.7"),
+        new("user_agent.original", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
+        new("network.protocol.version", "1.1"),
+        new("enduser.id", "user-8f3a7b4c"),
+        new("session.id", "9a8d1f3e-4b2c-4e15-9a4f-1b2c3d4e5f6a"),
+        new("db.system", "postgresql"),
+        new("db.namespace", "orders"),
+        new("db.operation.name", "SELECT"),
+        new("db.query.text", "SELECT * FROM orders WHERE id = $1"),
+        new("messaging.system", "rabbitmq"),
+        new("messaging.destination.name", "orders.events"),
+        new("messaging.message.id", "msg-0abcdef1234567890"),
+        new("exception.type", "System.TimeoutException"),
+        new("exception.message", "The operation has timed out."),
+        new("code.function", "ProcessOrder"),
+        new("code.namespace", "Checkout.Api.Orders"),
+        new("code.filepath", "/src/Checkout.Api/Orders/OrderProcessor.cs"),
+        new("code.lineno", 142L),
+        new("thread.id", 27L),
+        new("thread.name", "worker-3"),
+        new("retry.count", 2L),
+        new("cache.hit", true),
+        new("response.latency_ms", 18.7),
+        new("feature.flag.new_checkout", true),
+        new("tenant.id", "tenant-123456789012"),
+    ];
+
+    private readonly byte[] buffer = new byte[64 * 1024];
+    private readonly SdkLimitOptions sdkLimitOptions = new();
+    private readonly ExperimentalOptions experimentalOptions = new();
+    private LogRecord logRecord = null!;
+
+    [Params(4, 8, 16)]
+    public int AttributeCount { get; set; }
+
+    // 0 means no kvlist attribute is added; otherwise a single flat (depth-1)
+    // kvlist attribute with this many entries is appended to the scalar ones.
+    [Params(0, 2, 4, 8)]
+    public int KvListAttributeCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.logRecord = LogRecordHelper.CreateTestLogRecord();
+
+        var includeKvList = this.KvListAttributeCount > 0;
+        var attributes = new KeyValuePair<string, object?>[this.AttributeCount + (includeKvList ? 1 : 0)];
+
+        var count = Math.Min(this.AttributeCount, AllAttributes.Length);
+        for (var i = 0; i < count; i++)
+        {
+            attributes[i] = AllAttributes[i];
+        }
+
+        for (var i = count; i < this.AttributeCount; i++)
+        {
+            attributes[i] = new KeyValuePair<string, object?>($"custom.attribute.{i}", Guid.NewGuid().ToString());
+        }
+
+        if (includeKvList)
+        {
+            attributes[this.AttributeCount] = new KeyValuePair<string, object?>("kvlist", BuildKvList(this.KvListAttributeCount));
+        }
+
+        this.logRecord.Attributes = attributes;
+    }
+
+    [Benchmark]
+    public int WriteLogRecord()
+        => ProtobufOtlpLogSerializer.WriteLogRecord(this.buffer, 0, this.sdkLimitOptions, this.experimentalOptions, this.logRecord);
+
+    private static List<KeyValuePair<string, object?>> BuildKvList(int entryCount)
+    {
+        var list = new List<KeyValuePair<string, object?>>(entryCount);
+        for (var i = 0; i < entryCount; i++)
+        {
+            object value = (i % 4) switch
+            {
+                0 => "value",
+                1 => (long)i,
+                2 => i % 2 == 0,
+                _ => i * 1.5,
+            };
+
+            list.Add(new KeyValuePair<string, object?>($"key.{i}", value));
+        }
+
+        return list;
+    }
+}

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
@@ -1,0 +1,293 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using System.Text.Json;
+
+namespace OpenTelemetry.Exporter.Console.Tests;
+
+public class ConsoleKvListAttributeTests
+{
+    private readonly List<KeyValuePair<string, string>> droppedTags = [];
+    private readonly ConsoleTagWriter tagWriter;
+
+    public ConsoleKvListAttributeTests()
+    {
+        this.tagWriter = new ConsoleTagWriter((key, type) => this.droppedTags.Add(new(key, type)));
+    }
+
+    [Fact]
+    public void EmptyKvList()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>();
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal("key", result.Key);
+        Assert.Equal("{}", result.Value);
+    }
+
+    [Fact]
+    public void KvListWithStringEntries()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("innerKey", "innerValue"),
+            new("other", "value"),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal("key", result.Key);
+        Assert.Equal("""{"innerKey":"innerValue","other":"value"}""", result.Value);
+    }
+
+    [Fact]
+    public void KvListWithNumericAndBooleanEntriesAreWrittenAsJsonLiterals()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("int", 1),
+            new("long", 2L),
+            new("byte", (byte)3),
+            new("sbyte", (sbyte)-4),
+            new("short", (short)5),
+            new("ushort", (ushort)6),
+            new("uint", 7u),
+            new("double", 1.5d),
+            new("float", 2.5f),
+            new("boolTrue", true),
+            new("boolFalse", false),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal(
+            """{"int":1,"long":2,"byte":3,"sbyte":-4,"short":5,"ushort":6,"uint":7,"double":1.5,"float":2.5,"boolTrue":true,"boolFalse":false}""",
+            result.Value);
+    }
+
+    [Fact]
+    public void KvListWithNonFiniteFloatingPointEntriesAreWrittenAsStrings()
+    {
+        // NaN and infinity have no JSON representation, so they are quoted.
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("nan", double.NaN),
+            new("positiveInfinity", double.PositiveInfinity),
+            new("negativeInfinity", double.NegativeInfinity),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal(
+            """{"nan":"NaN","positiveInfinity":"Infinity","negativeInfinity":"-Infinity"}""",
+            result.Value);
+    }
+
+    [Fact]
+    public void KvListWithNullValue()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("nullKey", null),
+            new("stringKey", "value"),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal("""{"nullKey":null,"stringKey":"value"}""", result.Value);
+    }
+
+    [Fact]
+    public void KvListWithTypesConvertedToStrings()
+    {
+        // Types the tag writer has no dedicated representation for fall back to
+        // Convert.ToString and are quoted.
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("char", 'x'),
+            new("decimal", 1.5m),
+            new("ulong", 8ul),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal("""{"char":"x","decimal":"1.5","ulong":"8"}""", result.Value);
+    }
+
+    [Fact]
+    public void KvListWithArrayValues()
+    {
+        int[] ints = [1, 2, 3];
+        string?[] strings = ["a", null];
+        bool[] bools = [true, false];
+
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("ints", ints),
+            new("strings", strings),
+            new("bools", bools),
+            new("empty", Array.Empty<int>()),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal(
+            """{"ints":[1,2,3],"strings":["a",null],"bools":[true,false],"empty":[]}""",
+            result.Value);
+    }
+
+    [Fact]
+    public void KvListWithByteArrayValue()
+    {
+        // The console exporter has no byte array representation, so a byte[] is
+        // written as a JSON array of numbers rather than being dropped.
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("bytes", new byte[] { 1, 2, 3 }),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+        Assert.Equal("""{"bytes":[1,2,3]}""", result.Value);
+        Assert.Empty(this.droppedTags);
+    }
+
+    [Fact]
+    public void NestedKvList()
+    {
+        var innerKvList = new List<KeyValuePair<string, object?>>
+        {
+            new("nestedKey", "nestedValue"),
+        };
+        var outerKvList = new List<KeyValuePair<string, object?>>
+        {
+            new("inner", innerKvList),
+            new("int", 1),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", outerKvList, out var result));
+        Assert.Equal("""{"inner":{"nestedKey":"nestedValue"},"int":1}""", result.Value);
+    }
+
+    [Fact]
+    public void DictionaryAsKvList()
+    {
+        var dict = new Dictionary<string, object?>
+        {
+            ["alpha"] = "a",
+            ["beta"] = 2L,
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", dict, out var result));
+        Assert.Equal("""{"alpha":"a","beta":2}""", result.Value);
+    }
+
+    [Fact]
+    public void KvListKeysAndValuesAreEscaped()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("quo\"te", "back\\slash"),
+            new("new\nline", "<html>"),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+
+        // The exact escape sequences are an implementation detail of the JSON
+        // encoder, so the value is asserted after decoding.
+        using var document = JsonDocument.Parse(result.Value);
+        Assert.Equal("back\\slash", document.RootElement.GetProperty("quo\"te").GetString());
+        Assert.Equal("<html>", document.RootElement.GetProperty("new\nline").GetString());
+    }
+
+    [Fact]
+    public void KvListNestedUpToTheDepthLimitIsWrittenAsJson()
+    {
+        var level3 = new List<KeyValuePair<string, object?>> { new("value", "leaf") };
+        var level2 = new List<KeyValuePair<string, object?>> { new("level3", level3) };
+        var level1 = new List<KeyValuePair<string, object?>> { new("level2", level2) };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", level1, out var result));
+        Assert.Equal("""{"level2":{"level3":{"value":"leaf"}}}""", result.Value);
+    }
+
+    [Fact]
+    public void KvListBeyondTheDepthLimitFallsBackToAString()
+    {
+        // A list which contains itself recurses until MaxRecursionDepth is
+        // reached, at which point the value is written as a plain string.
+        var kvList = SelfReferencingKvList();
+        var expectedFallback = Convert.ToString(kvList, CultureInfo.InvariantCulture);
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+
+        using var document = JsonDocument.Parse(result.Value);
+        var element = document.RootElement;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(1L, element.GetProperty("int").GetInt64());
+
+            var self = element.GetProperty("self");
+            if (i < 2)
+            {
+                Assert.Equal(JsonValueKind.Object, self.ValueKind);
+                element = self;
+                continue;
+            }
+
+            // The fallback is a string and not embedded as JSON.
+            Assert.Equal(JsonValueKind.String, self.ValueKind);
+            Assert.Equal(expectedFallback, self.GetString());
+        }
+    }
+
+    [Fact]
+    public void KvListDepthIsResetBetweenTags()
+    {
+        // The recursion counter is shared per thread, so writing the same tag
+        // twice has to produce the same output.
+        var kvList = SelfReferencingKvList();
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var first));
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var second));
+
+        Assert.Equal(first.Value, second.Value);
+    }
+
+    [Fact]
+    public void KvListEnumerationFailureDropsTag()
+    {
+        Assert.False(this.tagWriter.TryTransformTag("key", FaultyKvList(), out var result));
+        Assert.Equal(default, result);
+
+        var droppedTag = Assert.Single(this.droppedTags);
+        Assert.Equal("key", droppedTag.Key);
+    }
+
+    [Fact]
+    public void KvListNestedEnumerationFailureDropsEntry()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("key1", "value1"),
+            new("faulty", FaultyKvList()),
+            new("key2", 2),
+        };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
+
+        // Only the faulty entry is dropped.
+        Assert.Equal("""{"key1":"value1","key2":2}""", result.Value);
+
+        var droppedTag = Assert.Single(this.droppedTags);
+        Assert.Equal("faulty", droppedTag.Key);
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> FaultyKvList()
+    {
+        yield return new KeyValuePair<string, object?>("key1", "value1");
+        throw new InvalidOperationException("simulated failure");
+    }
+
+    private static List<KeyValuePair<string, object?>> SelfReferencingKvList()
+    {
+        var list = new List<KeyValuePair<string, object?>>();
+        list.Add(new("int", 1));
+        list.Add(new("self", list));
+        return list;
+    }
+}

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections;
 using System.Globalization;
 using System.Text.Json;
 
@@ -277,6 +278,33 @@ public class ConsoleKvListAttributeTests
         Assert.Equal("faulty", droppedTag.Key);
     }
 
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("""{"fake":1}""")]
+    [InlineData("[1,2]")]
+    [InlineData("{oops")]
+    public void KvListBeyondTheDepthLimitWithJsonLikeToStringIsWrittenAsAString(string toStringValue)
+    {
+        // The depth limit fallback writes Convert.ToString of the value. A type
+        // whose ToString returns text which looks like JSON has to be quoted
+        // like any other fallback string instead of being embedded as JSON.
+        var fake = new KvListWithCustomToString(toStringValue);
+        var level3 = new List<KeyValuePair<string, object?>> { new("fake", fake) };
+        var level2 = new List<KeyValuePair<string, object?>> { new("level3", level3) };
+        var level1 = new List<KeyValuePair<string, object?>> { new("level2", level2) };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", level1, out var result));
+
+        using var document = JsonDocument.Parse(result.Value);
+        var fakeElement = document.RootElement
+            .GetProperty("level2")
+            .GetProperty("level3")
+            .GetProperty("fake");
+
+        Assert.Equal(JsonValueKind.String, fakeElement.ValueKind);
+        Assert.Equal(toStringValue, fakeElement.GetString());
+    }
+
     private static IEnumerable<KeyValuePair<string, object?>> FaultyKvList()
     {
         yield return new KeyValuePair<string, object?>("key1", "value1");
@@ -289,5 +317,24 @@ public class ConsoleKvListAttributeTests
         list.Add(new("int", 1));
         list.Add(new("self", list));
         return list;
+    }
+
+    private sealed class KvListWithCustomToString : IEnumerable<KeyValuePair<string, object?>>
+    {
+        private readonly string toStringValue;
+
+        public KvListWithCustomToString(string toStringValue)
+        {
+            this.toStringValue = toStringValue;
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            yield return new KeyValuePair<string, object?>("inner", "value");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        public override string ToString() => this.toStringValue;
     }
 }

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
@@ -250,6 +250,34 @@ public class ConsoleKvListAttributeTests
     }
 
     [Fact]
+    public void KvListDepthIsNotCorruptedByAThrowingFallback()
+    {
+        // The value at the depth limit throws while it is being converted to a
+        // string. The frame it is written from never increased the recursion
+        // depth, so the failure must not decrease it either.
+        var throwing = new KvListWithCustomToString(toStringValue: null);
+        var level3 = new List<KeyValuePair<string, object?>> { new("throwing", throwing) };
+        var level2 = new List<KeyValuePair<string, object?>> { new("level3", level3) };
+        var level1 = new List<KeyValuePair<string, object?>> { new("level2", level2) };
+
+        Assert.True(this.tagWriter.TryTransformTag("key", level1, out var result));
+        Assert.Equal("""{"level2":{"level3":{}}}""", result.Value);
+
+        // A subsequent tag still stops recursing at the depth limit.
+        var kvList = SelfReferencingKvList();
+
+        Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var afterFailure));
+
+        using var document = JsonDocument.Parse(afterFailure.Value);
+        var deepest = document.RootElement
+            .GetProperty("self")
+            .GetProperty("self")
+            .GetProperty("self");
+
+        Assert.Equal(JsonValueKind.String, deepest.ValueKind);
+    }
+
+    [Fact]
     public void KvListEnumerationFailureDropsTag()
     {
         Assert.False(this.tagWriter.TryTransformTag("key", FaultyKvList(), out var result));
@@ -321,9 +349,10 @@ public class ConsoleKvListAttributeTests
 
     private sealed class KvListWithCustomToString : IEnumerable<KeyValuePair<string, object?>>
     {
-        private readonly string toStringValue;
+        private readonly string? toStringValue;
 
-        public KvListWithCustomToString(string toStringValue)
+        // A null toStringValue makes ToString throw.
+        public KvListWithCustomToString(string? toStringValue)
         {
             this.toStringValue = toStringValue;
         }
@@ -335,6 +364,7 @@ public class ConsoleKvListAttributeTests
 
         IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
-        public override string ToString() => this.toStringValue;
+        public override string ToString()
+            => this.toStringValue ?? throw new InvalidOperationException("simulated failure");
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
@@ -34,6 +34,17 @@ internal static class Generators
         LogRecordSeverity.Warn,
     ]);
 
+    private static readonly Gen<object?> KvListLeafValueGen = Gen.OneOf(
+        Gen.Constant<object?>(null),
+        Gen.Elements<object?>(string.Empty, "value", "multi\nline", "with spaces", new string('x', 256)),
+        Gen.Choose(int.MinValue, int.MaxValue).Select(x => (object?)(long)x),
+        Gen.Choose(-1000, 1000).Select(x => (object?)x),
+        Gen.Elements<object?>(0.0, 3.14, -1.5, double.NaN, double.PositiveInfinity, double.MinValue, double.MaxValue),
+        Gen.Elements<object?>(true, false),
+        Gen.Constant<object?>(new[] { 1, 2, 3 }),
+        Gen.Constant<object?>(new[] { "a", "b", "c" }),
+        Gen.Constant<object?>(new byte[] { 0, 1, 2, 3 }));
+
     public static Arbitrary<SdkLimitOptions> SdkLimitOptionsArbitrary()
     {
         var gen = from spanAttributesLimit in Gen.Choose(0, 1000).Select(x => (int?)x)
@@ -243,4 +254,96 @@ internal static class Generators
     public static Arbitrary<int> BufferSizeArbitrary() => Gen.Choose(64, 10 * 1024 * 1024).ToArbitrary();
 
     public static Arbitrary<LogRecordSeverity> LogRecordSeverityArbitrary() => LogRecordSeverities.ToArbitrary();
+
+    // Depth up to 5 exceeds TagWriter.MaxRecursionDepth (3) so the stringify-fallback path is also exercised.
+    public static Arbitrary<List<KeyValuePair<string, object?>>> KvListArbitrary() => KvListGen(5).ToArbitrary();
+
+    public static Arbitrary<Activity[]> ActivityWithKvListBatchArbitrary()
+    {
+        var gen = Gen.Sized(size =>
+        {
+            var batchSize = Math.Min(Math.Max(size / 4, 1), 20);
+            return Gen.ArrayOf(ActivityWithKvListGen(), batchSize);
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<LogRecord[]> LogRecordsWithKvListArbitrary()
+    {
+        var gen = Gen.Sized(size =>
+        {
+            var count = Math.Min(Math.Max(size / 4, 1), 10);
+            return Gen.ArrayOf(LogRecordWithKvListGen(), count);
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    private static Gen<List<KeyValuePair<string, object?>>> KvListGen(int maxDepth) =>
+        Gen.Sized(size =>
+        {
+            var count = Math.Min(Math.Max(size / 4, 0), 8);
+
+            Gen<object?> valueGen = maxDepth > 0
+                ? Gen.Frequency(
+                    (4, KvListLeafValueGen),
+                    (1, KvListGen(maxDepth - 1).Select(l => (object?)l)))
+                : KvListLeafValueGen;
+
+            var entryGen = from keyIndex in Gen.Choose(0, 1_000_000)
+                           from value in valueGen
+                           select new KeyValuePair<string, object?>($"k{keyIndex}", value);
+
+            return Gen.ArrayOf(entryGen, count).Select(arr => arr.ToList());
+        });
+
+    private static Gen<Activity> ActivityWithKvListGen() =>
+        from activity in ActivityArbitrary().Generator
+        from kvListCount in Gen.Choose(0, 5)
+        from kvLists in Gen.ArrayOf(KvListGen(5), kvListCount)
+        select AttachKvListTags(activity, kvLists);
+
+    private static Gen<LogRecord> LogRecordWithKvListGen() =>
+        from severity in Gen.Elements(
+            LogRecordSeverity.Debug,
+            LogRecordSeverity.Error,
+            LogRecordSeverity.Fatal,
+            LogRecordSeverity.Info,
+            LogRecordSeverity.Trace,
+            LogRecordSeverity.Unspecified,
+            LogRecordSeverity.Warn)
+        from kvListCount in Gen.Choose(0, 5)
+        from kvLists in Gen.ArrayOf(KvListGen(5), kvListCount)
+        select BuildLogRecordWithKvLists(severity, kvLists);
+
+    private static Activity AttachKvListTags(Activity activity, List<KeyValuePair<string, object?>>[] kvLists)
+    {
+        for (var i = 0; i < kvLists.Length; i++)
+        {
+            activity.SetTag($"kvlist.{i}", kvLists[i]);
+        }
+
+        return activity;
+    }
+
+    private static LogRecord BuildLogRecordWithKvLists(LogRecordSeverity severity, List<KeyValuePair<string, object?>>[] kvLists)
+    {
+        var logRecord = LogRecordSharedPool.Current.Rent();
+        logRecord.Severity = severity;
+        logRecord.Timestamp = DateTime.UtcNow;
+
+        if (kvLists.Length > 0)
+        {
+            var attributes = new List<KeyValuePair<string, object?>>(kvLists.Length);
+            for (var i = 0; i < kvLists.Length; i++)
+            {
+                attributes.Add(new KeyValuePair<string, object?>($"kvlist.{i}", kvLists[i]));
+            }
+
+            logRecord.Attributes = attributes;
+        }
+
+        return logRecord;
+    }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
@@ -34,6 +34,17 @@ internal static class Generators
         LogRecordSeverity.Warn,
     ]);
 
+    private static readonly Gen<object?> KvListLeafValueGen = Gen.OneOf(
+        Gen.Constant<object?>(null),
+        Gen.Elements<object?>(string.Empty, "value", "multi\nline", "with spaces", new string('x', 256)),
+        Gen.Choose(int.MinValue, int.MaxValue).Select(x => (object?)(long)x),
+        Gen.Choose(-1000, 1000).Select(x => (object?)x),
+        Gen.Elements<object?>(0.0, 3.14, -1.5, double.NaN, double.PositiveInfinity, double.MinValue, double.MaxValue),
+        Gen.Elements<object?>(true, false),
+        Gen.Constant<object?>(new[] { 1, 2, 3 }),
+        Gen.Constant<object?>(new[] { "a", "b", "c" }),
+        Gen.Constant<object?>(new byte[] { 0, 1, 2, 3 }));
+
     private static readonly Gen<string?> SchemaUrls = Gen.Elements(
     [
         null,
@@ -263,4 +274,96 @@ internal static class Generators
     public static Arbitrary<int> BufferSizeArbitrary() => Gen.Choose(64, 10 * 1024 * 1024).ToArbitrary();
 
     public static Arbitrary<LogRecordSeverity> LogRecordSeverityArbitrary() => LogRecordSeverities.ToArbitrary();
+
+    // Depth up to 5 exceeds TagWriter.MaxRecursionDepth (3) so the stringify-fallback path is also exercised.
+    public static Arbitrary<List<KeyValuePair<string, object?>>> KvListArbitrary() => KvListGen(5).ToArbitrary();
+
+    public static Arbitrary<Activity[]> ActivityWithKvListBatchArbitrary()
+    {
+        var gen = Gen.Sized(size =>
+        {
+            var batchSize = Math.Min(Math.Max(size / 4, 1), 20);
+            return Gen.ArrayOf(ActivityWithKvListGen(), batchSize);
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<LogRecord[]> LogRecordsWithKvListArbitrary()
+    {
+        var gen = Gen.Sized(size =>
+        {
+            var count = Math.Min(Math.Max(size / 4, 1), 10);
+            return Gen.ArrayOf(LogRecordWithKvListGen(), count);
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    private static Gen<List<KeyValuePair<string, object?>>> KvListGen(int maxDepth) =>
+        Gen.Sized(size =>
+        {
+            var count = Math.Min(Math.Max(size / 4, 0), 8);
+
+            Gen<object?> valueGen = maxDepth > 0
+                ? Gen.Frequency(
+                    (4, KvListLeafValueGen),
+                    (1, KvListGen(maxDepth - 1).Select(l => (object?)l)))
+                : KvListLeafValueGen;
+
+            var entryGen = from keyIndex in Gen.Choose(0, 1_000_000)
+                           from value in valueGen
+                           select new KeyValuePair<string, object?>($"k{keyIndex}", value);
+
+            return Gen.ArrayOf(entryGen, count).Select(arr => arr.ToList());
+        });
+
+    private static Gen<Activity> ActivityWithKvListGen() =>
+        from activity in ActivityArbitrary().Generator
+        from kvListCount in Gen.Choose(0, 5)
+        from kvLists in Gen.ArrayOf(KvListGen(5), kvListCount)
+        select AttachKvListTags(activity, kvLists);
+
+    private static Gen<LogRecord> LogRecordWithKvListGen() =>
+        from severity in Gen.Elements(
+            LogRecordSeverity.Debug,
+            LogRecordSeverity.Error,
+            LogRecordSeverity.Fatal,
+            LogRecordSeverity.Info,
+            LogRecordSeverity.Trace,
+            LogRecordSeverity.Unspecified,
+            LogRecordSeverity.Warn)
+        from kvListCount in Gen.Choose(0, 5)
+        from kvLists in Gen.ArrayOf(KvListGen(5), kvListCount)
+        select BuildLogRecordWithKvLists(severity, kvLists);
+
+    private static Activity AttachKvListTags(Activity activity, List<KeyValuePair<string, object?>>[] kvLists)
+    {
+        for (var i = 0; i < kvLists.Length; i++)
+        {
+            activity.SetTag($"kvlist.{i}", kvLists[i]);
+        }
+
+        return activity;
+    }
+
+    private static LogRecord BuildLogRecordWithKvLists(LogRecordSeverity severity, List<KeyValuePair<string, object?>>[] kvLists)
+    {
+        var logRecord = LogRecordSharedPool.Current.Rent();
+        logRecord.Severity = severity;
+        logRecord.Timestamp = DateTime.UtcNow;
+
+        if (kvLists.Length > 0)
+        {
+            var attributes = new List<KeyValuePair<string, object?>>(kvLists.Length);
+            for (var i = 0; i < kvLists.Length; i++)
+            {
+                attributes.Add(new KeyValuePair<string, object?>($"kvlist.{i}", kvLists[i]));
+            }
+
+            logRecord.Attributes = attributes;
+        }
+
+        return logRecord;
+    }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpLogSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpLogSerializerTests.cs
@@ -234,6 +234,76 @@ public class ProtobufOtlpLogSerializerTests
             }
         });
 
+    [Property(MaxTest = 100)]
+    public Property KvListAttributesStayInBounds() => Prop.ForAll(
+        Generators.LogRecordsWithKvListArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        (logRecords, sdkLimits) =>
+        {
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<LogRecord>(logRecords, logRecords.Length);
+                var experimentalOptions = new ExperimentalOptions();
+
+                var writePos = ProtobufOtlpLogSerializer.WriteLogsData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    experimentalOptions,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+        });
+
+    [Property(MaxTest = 100)]
+    public Property KvListAttributesRoundTrip() => Prop.ForAll(
+        Generators.LogRecordsWithKvListArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        Generators.ResourceArbitrary(),
+        (logRecords, sdkLimits, resource) =>
+        {
+            if (logRecords == null || logRecords.Length == 0)
+            {
+                return true;
+            }
+
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<LogRecord>(logRecords, logRecords.Length);
+                var experimentalOptions = new ExperimentalOptions();
+
+                var writePos = ProtobufOtlpLogSerializer.WriteLogsData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    experimentalOptions,
+                    resource,
+                    batch);
+
+                if (writePos <= 0)
+                {
+                    return true;
+                }
+
+                using var stream = new MemoryStream(buffer, 0, writePos);
+                var request = OtlpCollector.ExportLogsServiceRequest.Parser.ParseFrom(stream);
+
+                return request != null && request.ResourceLogs.Count > 0;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+        });
+
     private static LogRecord[] CreateLogRecords(LogRecordSeverity severity)
         => Generators.LogRecordArbitrary(severity).Generator.ArrayOf().Sample(1, 10).First();
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpLogSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpLogSerializerTests.cs
@@ -235,6 +235,76 @@ public class ProtobufOtlpLogSerializerTests
         });
 
     [Property(MaxTest = 100)]
+    public Property KvListAttributesStayInBounds() => Prop.ForAll(
+        Generators.LogRecordsWithKvListArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        (logRecords, sdkLimits) =>
+        {
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<LogRecord>(logRecords, logRecords.Length);
+                var experimentalOptions = new ExperimentalOptions();
+
+                var writePos = ProtobufOtlpLogSerializer.WriteLogsData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    experimentalOptions,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+        });
+
+    [Property(MaxTest = 100)]
+    public Property KvListAttributesRoundTrip() => Prop.ForAll(
+        Generators.LogRecordsWithKvListArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        Generators.ResourceArbitrary(),
+        (logRecords, sdkLimits, resource) =>
+        {
+            if (logRecords == null || logRecords.Length == 0)
+            {
+                return true;
+            }
+
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<LogRecord>(logRecords, logRecords.Length);
+                var experimentalOptions = new ExperimentalOptions();
+
+                var writePos = ProtobufOtlpLogSerializer.WriteLogsData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    experimentalOptions,
+                    resource,
+                    batch);
+
+                if (writePos <= 0)
+                {
+                    return true;
+                }
+
+                using var stream = new MemoryStream(buffer, 0, writePos);
+                var request = OtlpCollector.ExportLogsServiceRequest.Parser.ParseFrom(stream);
+
+                return request != null && request.ResourceLogs.Count > 0;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+        });
+
+    [Property(MaxTest = 100)]
     public Property ResourceSchemaUrlRoundTrips() => Prop.ForAll(
         Generators.SdkLimitOptionsArbitrary(),
         Generators.ResourceArbitrary(),

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
@@ -286,6 +286,231 @@ public class ProtobufOtlpTraceSerializerTests
             }
         });
 
+    [Property(MaxTest = 100)]
+    public Property KvListAttributesStayInBounds() => Prop.ForAll(
+        Generators.ActivityWithKvListBatchArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        (activities, sdkLimits) =>
+        {
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 100)]
+    public Property KvListAttributesRoundTrip() => Prop.ForAll(
+        Generators.ActivityWithKvListBatchArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        Generators.ResourceArbitrary(),
+        (activities, sdkLimits, resource) =>
+        {
+            if (activities == null || activities.Length == 0)
+            {
+                return true;
+            }
+
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    resource,
+                    batch);
+
+                if (writePos <= 0)
+                {
+                    return true;
+                }
+
+                using var stream = new MemoryStream(buffer, 0, writePos);
+                var request = OtlpCollector.ExportTraceServiceRequest.Parser.ParseFrom(stream);
+
+                return request != null && request.ResourceSpans.Count > 0;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 50)]
+    public Property KvListSerializationIsDeterministic() => Prop.ForAll(
+        Generators.ActivityWithKvListBatchArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        (activities, sdkLimits) =>
+        {
+            try
+            {
+                var buffer1 = new byte[10 * 1024 * 1024];
+                var buffer2 = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var pos1 = ProtobufOtlpTraceSerializer.WriteTraceData(ref buffer1, 0, sdkLimits, null, batch);
+                var pos2 = ProtobufOtlpTraceSerializer.WriteTraceData(ref buffer2, 0, sdkLimits, null, batch);
+
+                if (pos1 != pos2)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < pos1; i++)
+                {
+                    if (buffer1[i] != buffer2[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 50)]
+    public Property SelfReferencingKvListDoesNotCrash() => Prop.ForAll(
+        Generators.SdkLimitOptionsArbitrary(),
+        Gen.Choose(1, 10).ToArbitrary(),
+        (sdkLimits, selfRefCount) =>
+        {
+            var activities = Generators.ActivityArbitrary().Generator.Sample(1).ToArray();
+
+            try
+            {
+                foreach (var activity in activities)
+                {
+                    for (var i = 0; i < selfRefCount; i++)
+                    {
+                        activity.SetTag($"self_ref_{i}", BuildSelfReferencingKvList());
+                    }
+                }
+
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 50)]
+    public Property FaultyKvListEnumerableIsDropped() => Prop.ForAll(
+        Generators.SdkLimitOptionsArbitrary(),
+        Gen.Choose(1, 5).ToArbitrary(),
+        (sdkLimits, faultyCount) =>
+        {
+            var activities = Generators.ActivityArbitrary().Generator.Sample(1).ToArray();
+
+            try
+            {
+                foreach (var activity in activities)
+                {
+                    for (var i = 0; i < faultyCount; i++)
+                    {
+                        activity.SetTag($"faulty_{i}", FaultyKvList());
+                    }
+                }
+
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
     private static bool IsAllowedException(Exception ex)
         => ex is IndexOutOfRangeException or ArgumentException;
+
+    private static List<KeyValuePair<string, object?>> BuildSelfReferencingKvList()
+    {
+        var list = new List<KeyValuePair<string, object?>>
+        {
+            new("int", 1),
+        };
+        list.Add(new("self", list));
+        return list;
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> FaultyKvList()
+    {
+        yield return new KeyValuePair<string, object?>("before", "value");
+        throw new InvalidOperationException("fuzz simulated failure");
+    }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
@@ -287,6 +287,215 @@ public class ProtobufOtlpTraceSerializerTests
         });
 
     [Property(MaxTest = 100)]
+    public Property KvListAttributesStayInBounds() => Prop.ForAll(
+        Generators.ActivityWithKvListBatchArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        (activities, sdkLimits) =>
+        {
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 100)]
+    public Property KvListAttributesRoundTrip() => Prop.ForAll(
+        Generators.ActivityWithKvListBatchArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        Generators.ResourceArbitrary(),
+        (activities, sdkLimits, resource) =>
+        {
+            if (activities == null || activities.Length == 0)
+            {
+                return true;
+            }
+
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    resource,
+                    batch);
+
+                if (writePos <= 0)
+                {
+                    return true;
+                }
+
+                using var stream = new MemoryStream(buffer, 0, writePos);
+                var request = OtlpCollector.ExportTraceServiceRequest.Parser.ParseFrom(stream);
+
+                return request != null && request.ResourceSpans.Count > 0;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 50)]
+    public Property KvListSerializationIsDeterministic() => Prop.ForAll(
+        Generators.ActivityWithKvListBatchArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        (activities, sdkLimits) =>
+        {
+            try
+            {
+                var buffer1 = new byte[10 * 1024 * 1024];
+                var buffer2 = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var pos1 = ProtobufOtlpTraceSerializer.WriteTraceData(ref buffer1, 0, sdkLimits, null, batch);
+                var pos2 = ProtobufOtlpTraceSerializer.WriteTraceData(ref buffer2, 0, sdkLimits, null, batch);
+
+                if (pos1 != pos2)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < pos1; i++)
+                {
+                    if (buffer1[i] != buffer2[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 50)]
+    public Property SelfReferencingKvListDoesNotCrash() => Prop.ForAll(
+        Generators.SdkLimitOptionsArbitrary(),
+        Gen.Choose(1, 10).ToArbitrary(),
+        (sdkLimits, selfRefCount) =>
+        {
+            var activities = Generators.ActivityArbitrary().Generator.Sample(1).ToArray();
+
+            try
+            {
+                foreach (var activity in activities)
+                {
+                    for (var i = 0; i < selfRefCount; i++)
+                    {
+                        activity.SetTag($"self_ref_{i}", BuildSelfReferencingKvList());
+                    }
+                }
+
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 50)]
+    public Property FaultyKvListEnumerableIsDropped() => Prop.ForAll(
+        Generators.SdkLimitOptionsArbitrary(),
+        Gen.Choose(1, 5).ToArbitrary(),
+        (sdkLimits, faultyCount) =>
+        {
+            var activities = Generators.ActivityArbitrary().Generator.Sample(1).ToArray();
+
+            try
+            {
+                foreach (var activity in activities)
+                {
+                    for (var i = 0; i < faultyCount; i++)
+                    {
+                        activity.SetTag($"faulty_{i}", FaultyKvList());
+                    }
+                }
+
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    null,
+                    batch);
+
+                return writePos >= 0 && writePos <= buffer.Length;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
+    [Property(MaxTest = 100)]
     public Property ResourceSchemaUrlRoundTrips() => Prop.ForAll(
         Generators.ActivityBatchArbitrary(),
         Generators.SdkLimitOptionsArbitrary(),
@@ -350,4 +559,20 @@ public class ProtobufOtlpTraceSerializerTests
 
     private static bool IsAllowedException(Exception ex)
         => ex is IndexOutOfRangeException or ArgumentException;
+
+    private static List<KeyValuePair<string, object?>> BuildSelfReferencingKvList()
+    {
+        var list = new List<KeyValuePair<string, object?>>
+        {
+            new("int", 1),
+        };
+        list.Add(new("self", list));
+        return list;
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> FaultyKvList()
+    {
+        yield return new KeyValuePair<string, object?>("before", "value");
+        throw new InvalidOperationException("fuzz simulated failure");
+    }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
@@ -1,0 +1,403 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
+using OtlpTrace = OpenTelemetry.Proto.Trace.V1;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
+
+public sealed class OtlpKvListAttributeTests : IDisposable
+{
+    private readonly ActivityListener activityListener;
+
+    static OtlpKvListAttributeTests()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+    }
+
+    public OtlpKvListAttributeTests()
+    {
+        this.activityListener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+
+        ActivitySource.AddActivityListener(this.activityListener);
+    }
+
+    [Fact]
+    public void EmptyKvList()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>();
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal("key", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+        Assert.Empty(attribute.Value.KvlistValue.Values);
+    }
+
+    [Fact]
+    public void KvListWithSingleStringEntry()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("innerKey", "innerValue"),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal("key", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Single(values);
+        Assert.Equal("innerKey", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, values[0].Value.ValueCase);
+        Assert.Equal("innerValue", values[0].Value.StringValue);
+    }
+
+    [Fact]
+    public void KvListWithMixedValueTypes()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("stringKey", "stringValue"),
+            new("intKey", 42L),
+            new("boolKey", true),
+            new("doubleKey", 3.14),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal("key", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Equal(kvList.Count, values.Count);
+
+        Assert.Equal("stringKey", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, values[0].Value.ValueCase);
+        Assert.Equal("stringValue", values[0].Value.StringValue);
+
+        Assert.Equal("intKey", values[1].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, values[1].Value.ValueCase);
+        Assert.Equal(42L, values[1].Value.IntValue);
+
+        Assert.Equal("boolKey", values[2].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.BoolValue, values[2].Value.ValueCase);
+        Assert.True(values[2].Value.BoolValue);
+
+        Assert.Equal("doubleKey", values[3].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.DoubleValue, values[3].Value.ValueCase);
+        Assert.Equal(3.14, values[3].Value.DoubleValue);
+    }
+
+    [Fact]
+    public void KvListWithNullEntryValue()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("nullKey", null),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Single(values);
+        Assert.Equal("nullKey", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.None, values[0].Value.ValueCase);
+    }
+
+    [Fact]
+    public void NestedKvList()
+    {
+        var innerKvList = new List<KeyValuePair<string, object?>>
+        {
+            new("nestedKey", "nestedValue"),
+        };
+        var outerKvList = new List<KeyValuePair<string, object?>>
+        {
+            new("inner", innerKvList),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", outerKvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var outerValues = attribute.Value.KvlistValue.Values;
+        Assert.Single(outerValues);
+        Assert.Equal("inner", outerValues[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, outerValues[0].Value.ValueCase);
+
+        var innerValues = outerValues[0].Value.KvlistValue.Values;
+        Assert.Single(innerValues);
+        Assert.Equal("nestedKey", innerValues[0].Key);
+        Assert.Equal("nestedValue", innerValues[0].Value.StringValue);
+    }
+
+    [Fact]
+    public void KvListWithManyEntries()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>();
+        for (int i = 0; i < 50; i++)
+        {
+            kvList.Add(new($"key{i}", (long)i));
+        }
+
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Equal(50, values.Count);
+
+        for (int i = 0; i < 50; i++)
+        {
+            Assert.Equal($"key{i}", values[i].Key);
+            Assert.Equal((long)i, values[i].Value.IntValue);
+        }
+    }
+
+    [Fact]
+    public void DictionaryAsKvList()
+    {
+        var dict = new Dictionary<string, object?>
+        {
+            ["alpha"] = "a",
+            ["beta"] = 2L,
+        };
+        var kvp = new KeyValuePair<string, object?>("key", dict);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+        Assert.Equal(2, attribute.Value.KvlistValue.Values.Count);
+    }
+
+    [Fact]
+    public void KvListEnumerationFailureDropsTag()
+    {
+        var kvp = new KeyValuePair<string, object?>("key", FaultyKvList());
+
+        Assert.False(TryTransformTag(kvp, out var attribute));
+        Assert.Null(attribute);
+    }
+
+    [Fact]
+    public void KvListNestedEnumerationFailureDropsEntry()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("key", "value"),
+            new("faulty", FaultyKvList()),
+            new("intKey", 1),
+        };
+
+        var kvp = new KeyValuePair<string, object?>("list", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.NotNull(attribute);
+        Assert.Equal("list", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        // Faulty entry is dropped
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Equal(2, values.Count);
+
+        Assert.Equal("key", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, values[0].Value.ValueCase);
+        Assert.Equal("value", values[0].Value.StringValue);
+
+        Assert.Equal("intKey", values[1].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, values[1].Value.ValueCase);
+        Assert.Equal(1, values[1].Value.IntValue);
+    }
+
+    [Fact]
+    public void KvListAttributeTriggersMainBufferResize()
+    {
+        var largeString = new string('a', 500_000);
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("large", largeString),
+        };
+
+        var tags = new ActivityTagsCollection
+        {
+            new("kvList", kvList),
+        };
+
+        using var activitySource = new ActivitySource(nameof(this.KvListAttributeTriggersMainBufferResize));
+        using var activity = activitySource.StartActivity("test", ActivityKind.Server, default(ActivityContext), tags);
+
+        Assert.NotNull(activity);
+
+        var buffer = new byte[4096];
+        int writePosition;
+        while (true)
+        {
+            try
+            {
+                writePosition = ProtobufOtlpTraceSerializer.WriteSpan(buffer, 0, new SdkLimitOptions(), activity);
+                break;
+            }
+            catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
+            {
+                if (!ProtobufSerializer.IncreaseBufferSize(ref buffer, OtlpSignalType.Traces))
+                {
+                    throw;
+                }
+            }
+        }
+
+        Assert.True(buffer.Length > 4096);
+
+        using var stream = new MemoryStream(buffer, 0, writePosition);
+        var scopeSpans = OtlpTrace.ScopeSpans.Parser.ParseFrom(stream);
+        var span = scopeSpans.Spans.FirstOrDefault();
+
+        Assert.NotNull(span);
+
+        var kvListAttr = span.Attributes.FirstOrDefault(a => a.Key == "kvList");
+        Assert.NotNull(kvListAttr);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, kvListAttr.Value.ValueCase);
+
+        var values = kvListAttr.Value.KvlistValue.Values;
+        Assert.Single(values);
+
+        Assert.Equal("large", values[0].Key);
+        Assert.Equal(largeString, values[0].Value.StringValue);
+    }
+
+    [Fact]
+    public void RecursionHasMaxDepthAndRecursionDepthIsReset()
+    {
+        var tags = new ActivityTagsCollection
+        {
+            new("kvList", SelfReferencingKvList()),
+            new("kvList1", SelfReferencingKvList()),
+        };
+
+        using var activitySource = new ActivitySource(nameof(this.RecursionHasMaxDepthAndRecursionDepthIsReset));
+        using var activity = activitySource.StartActivity("test", ActivityKind.Server, default(ActivityContext), tags);
+
+        Assert.NotNull(activity);
+
+        var buffer = new byte[1_000_000];
+
+        var writePosition = ProtobufOtlpTraceSerializer.WriteSpan(buffer, 0, new SdkLimitOptions(), activity);
+
+        using var stream = new MemoryStream(buffer, 0, writePosition);
+        var scopeSpans = OtlpTrace.ScopeSpans.Parser.ParseFrom(stream);
+        Assert.Single(scopeSpans.Spans);
+        var span = scopeSpans.Spans.FirstOrDefault();
+
+        Assert.NotNull(span);
+        Assert.Equal(2, span.Attributes.Count);
+
+        var attribute = span.Attributes[0];
+        Assert.Equal("kvList", attribute.Key);
+
+        var attributeValue = attribute.Value;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.ValueCase);
+            Assert.Equal(2, attributeValue.KvlistValue.Values.Count);
+
+            Assert.Equal("int", attributeValue.KvlistValue.Values[0].Key);
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, attributeValue.KvlistValue.Values[0].Value.ValueCase);
+
+            Assert.Equal("self", attributeValue.KvlistValue.Values[1].Key);
+            if (i < 2)
+            {
+                Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+                attributeValue = attributeValue.KvlistValue.Values[1].Value;
+                continue;
+            }
+
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+            Assert.Equal(Convert.ToString(SelfReferencingKvList(), CultureInfo.InvariantCulture), attributeValue.KvlistValue.Values[1].Value.StringValue);
+        }
+
+        attribute = span.Attributes[1];
+        Assert.Equal("kvList1", attribute.Key);
+
+        attributeValue = attribute.Value;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.ValueCase);
+            Assert.Equal(2, attributeValue.KvlistValue.Values.Count);
+
+            Assert.Equal("int", attributeValue.KvlistValue.Values[0].Key);
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, attributeValue.KvlistValue.Values[0].Value.ValueCase);
+
+            Assert.Equal("self", attributeValue.KvlistValue.Values[1].Key);
+            if (i < 2)
+            {
+                Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+                attributeValue = attributeValue.KvlistValue.Values[1].Value;
+                continue;
+            }
+
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+            Assert.Equal(Convert.ToString(SelfReferencingKvList(), CultureInfo.InvariantCulture), attributeValue.KvlistValue.Values[1].Value.StringValue);
+        }
+    }
+
+    public void Dispose()
+    {
+        this.activityListener.Dispose();
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> FaultyKvList()
+    {
+        yield return new KeyValuePair<string, object?>("key1", "value1");
+        throw new InvalidOperationException("simulated failure");
+    }
+
+    private static List<KeyValuePair<string, object?>> SelfReferencingKvList()
+    {
+        var list = new List<KeyValuePair<string, object?>>();
+        list.Add(new("int", 1));
+        list.Add(new("self", list));
+        return list;
+    }
+
+    private static bool TryTransformTag(KeyValuePair<string, object?> tag, [NotNullWhen(true)] out OtlpCommon.KeyValue? attribute)
+    {
+        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        {
+            Buffer = new byte[4096],
+            WritePosition = 0,
+        };
+
+        if (ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag))
+        {
+            using var stream = new MemoryStream(otlpTagWriterState.Buffer, 0, otlpTagWriterState.WritePosition);
+            var keyValue = OtlpCommon.KeyValue.Parser.ParseFrom(stream);
+            Assert.NotNull(keyValue);
+            attribute = keyValue;
+            return true;
+        }
+
+        if (otlpTagWriterState.WritePosition > 0)
+        {
+            using var stream = new MemoryStream(otlpTagWriterState.Buffer, 0, otlpTagWriterState.WritePosition);
+            attribute = OtlpCommon.KeyValue.Parser.ParseFrom(stream);
+            return false;
+        }
+
+        attribute = null;
+        return false;
+    }
+}

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OtlpCommon = OpenTelemetry.Proto.Common.V1;
@@ -278,6 +279,81 @@ public sealed class OtlpKvListAttributeTests : IDisposable
         Assert.Equal(largeString, values[0].Value.StringValue);
     }
 
+    [Fact]
+    public void RecursionHasMaxDepthAndRecursionDepthIsReset()
+    {
+        var tags = new ActivityTagsCollection
+        {
+            new("kvList", SelfReferencingKvList()),
+            new("kvList1", SelfReferencingKvList()),
+        };
+
+        using var activitySource = new ActivitySource(nameof(this.RecursionHasMaxDepthAndRecursionDepthIsReset));
+        using var activity = activitySource.StartActivity("test", ActivityKind.Server, default(ActivityContext), tags);
+
+        Assert.NotNull(activity);
+
+        var buffer = new byte[1_000_000];
+
+        var writePosition = ProtobufOtlpTraceSerializer.WriteSpan(buffer, 0, new SdkLimitOptions(), activity);
+
+        using var stream = new MemoryStream(buffer, 0, writePosition);
+        var scopeSpans = OtlpTrace.ScopeSpans.Parser.ParseFrom(stream);
+        Assert.Single(scopeSpans.Spans);
+        var span = scopeSpans.Spans.FirstOrDefault();
+
+        Assert.NotNull(span);
+        Assert.Equal(2, span.Attributes.Count);
+
+        var attribute = span.Attributes[0];
+        Assert.Equal("kvList", attribute.Key);
+
+        var attributeValue = attribute.Value;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.ValueCase);
+            Assert.Equal(2, attributeValue.KvlistValue.Values.Count);
+
+            Assert.Equal("int", attributeValue.KvlistValue.Values[0].Key);
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, attributeValue.KvlistValue.Values[0].Value.ValueCase);
+
+            Assert.Equal("self", attributeValue.KvlistValue.Values[1].Key);
+            if (i < 2)
+            {
+                Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+                attributeValue = attributeValue.KvlistValue.Values[1].Value;
+                continue;
+            }
+
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+            Assert.Equal(Convert.ToString(SelfReferencingKvList(), CultureInfo.InvariantCulture), attributeValue.KvlistValue.Values[1].Value.StringValue);
+        }
+
+        attribute = span.Attributes[1];
+        Assert.Equal("kvList1", attribute.Key);
+
+        attributeValue = attribute.Value;
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.ValueCase);
+            Assert.Equal(2, attributeValue.KvlistValue.Values.Count);
+
+            Assert.Equal("int", attributeValue.KvlistValue.Values[0].Key);
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, attributeValue.KvlistValue.Values[0].Value.ValueCase);
+
+            Assert.Equal("self", attributeValue.KvlistValue.Values[1].Key);
+            if (i < 2)
+            {
+                Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+                attributeValue = attributeValue.KvlistValue.Values[1].Value;
+                continue;
+            }
+
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
+            Assert.Equal(Convert.ToString(SelfReferencingKvList(), CultureInfo.InvariantCulture), attributeValue.KvlistValue.Values[1].Value.StringValue);
+        }
+     }
+
     public void Dispose()
     {
         this.activityListener.Dispose();
@@ -287,6 +363,14 @@ public sealed class OtlpKvListAttributeTests : IDisposable
     {
         yield return new KeyValuePair<string, object?>("key1", "value1");
         throw new InvalidOperationException("simulated failure");
+    }
+
+    private static List<KeyValuePair<string, object?>> SelfReferencingKvList()
+    {
+        var list = new List<KeyValuePair<string, object?>>();
+        list.Add(new("int", 1));
+        list.Add(new("self", list));
+        return list;
     }
 
     private static bool TryTransformTag(KeyValuePair<string, object?> tag, [NotNullWhen(true)] out OtlpCommon.KeyValue? attribute)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
@@ -26,7 +26,7 @@ public sealed class OtlpKvListAttributeTests : IDisposable
         this.activityListener = new ActivityListener
         {
             ShouldListenTo = _ => true,
-            Sample = (ref options) => ActivitySamplingResult.AllDataAndRecorded,
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
         };
 
         ActivitySource.AddActivityListener(this.activityListener);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
@@ -1,0 +1,319 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
+using OtlpTrace = OpenTelemetry.Proto.Trace.V1;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
+
+public sealed class OtlpKvListAttributeTests : IDisposable
+{
+    private readonly ActivityListener activityListener;
+
+    static OtlpKvListAttributeTests()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+    }
+
+    public OtlpKvListAttributeTests()
+    {
+        this.activityListener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref options) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+
+        ActivitySource.AddActivityListener(this.activityListener);
+    }
+
+    [Fact]
+    public void EmptyKvList()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>();
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal("key", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+        Assert.Empty(attribute.Value.KvlistValue.Values);
+    }
+
+    [Fact]
+    public void KvListWithSingleStringEntry()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("innerKey", "innerValue"),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal("key", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Single(values);
+        Assert.Equal("innerKey", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, values[0].Value.ValueCase);
+        Assert.Equal("innerValue", values[0].Value.StringValue);
+    }
+
+    [Fact]
+    public void KvListWithMixedValueTypes()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("stringKey", "stringValue"),
+            new("intKey", 42L),
+            new("boolKey", true),
+            new("doubleKey", 3.14),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal("key", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Equal(kvList.Count, values.Count);
+
+        Assert.Equal("stringKey", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, values[0].Value.ValueCase);
+        Assert.Equal("stringValue", values[0].Value.StringValue);
+
+        Assert.Equal("intKey", values[1].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, values[1].Value.ValueCase);
+        Assert.Equal(42L, values[1].Value.IntValue);
+
+        Assert.Equal("boolKey", values[2].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.BoolValue, values[2].Value.ValueCase);
+        Assert.True(values[2].Value.BoolValue);
+
+        Assert.Equal("doubleKey", values[3].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.DoubleValue, values[3].Value.ValueCase);
+        Assert.Equal(3.14, values[3].Value.DoubleValue);
+    }
+
+    [Fact]
+    public void KvListWithNullEntryValue()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("nullKey", null),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Single(values);
+        Assert.Equal("nullKey", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.None, values[0].Value.ValueCase);
+    }
+
+    [Fact]
+    public void NestedKvList()
+    {
+        var innerKvList = new List<KeyValuePair<string, object?>>
+        {
+            new("nestedKey", "nestedValue"),
+        };
+        var outerKvList = new List<KeyValuePair<string, object?>>
+        {
+            new("inner", innerKvList),
+        };
+        var kvp = new KeyValuePair<string, object?>("key", outerKvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var outerValues = attribute.Value.KvlistValue.Values;
+        Assert.Single(outerValues);
+        Assert.Equal("inner", outerValues[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, outerValues[0].Value.ValueCase);
+
+        var innerValues = outerValues[0].Value.KvlistValue.Values;
+        Assert.Single(innerValues);
+        Assert.Equal("nestedKey", innerValues[0].Key);
+        Assert.Equal("nestedValue", innerValues[0].Value.StringValue);
+    }
+
+    [Fact]
+    public void KvListWithManyEntries()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>();
+        for (int i = 0; i < 50; i++)
+        {
+            kvList.Add(new($"key{i}", (long)i));
+        }
+
+        var kvp = new KeyValuePair<string, object?>("key", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Equal(50, values.Count);
+
+        for (int i = 0; i < 50; i++)
+        {
+            Assert.Equal($"key{i}", values[i].Key);
+            Assert.Equal((long)i, values[i].Value.IntValue);
+        }
+    }
+
+    [Fact]
+    public void DictionaryAsKvList()
+    {
+        var dict = new Dictionary<string, object?>
+        {
+            ["alpha"] = "a",
+            ["beta"] = 2L,
+        };
+        var kvp = new KeyValuePair<string, object?>("key", dict);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+        Assert.Equal(2, attribute.Value.KvlistValue.Values.Count);
+    }
+
+    [Fact]
+    public void KvListEnumerationFailureDropsTag()
+    {
+        var kvp = new KeyValuePair<string, object?>("key", FaultyKvList());
+
+        Assert.False(TryTransformTag(kvp, out var attribute));
+        Assert.Null(attribute);
+    }
+
+    [Fact]
+    public void KvListNestedEnumerationFailureDropsEntry()
+    {
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("key", "value"),
+            new("faulty", FaultyKvList()),
+            new("intKey", 1),
+        };
+
+        var kvp = new KeyValuePair<string, object?>("list", kvList);
+
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.NotNull(attribute);
+        Assert.Equal("list", attribute.Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, attribute.Value.ValueCase);
+
+        // Faulty entry is dropped
+        var values = attribute.Value.KvlistValue.Values;
+        Assert.Equal(2, values.Count);
+
+        Assert.Equal("key", values[0].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, values[0].Value.ValueCase);
+        Assert.Equal("value", values[0].Value.StringValue);
+
+        Assert.Equal("intKey", values[1].Key);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.IntValue, values[1].Value.ValueCase);
+        Assert.Equal(1, values[1].Value.IntValue);
+    }
+
+    [Fact]
+    public void KvListAttributeTriggersMainBufferResize()
+    {
+        var largeString = new string('a', 500_000);
+        var kvList = new List<KeyValuePair<string, object?>>
+        {
+            new("large", largeString),
+        };
+
+        var tags = new ActivityTagsCollection
+        {
+            new("kvList", kvList),
+        };
+
+        using var activitySource = new ActivitySource(nameof(this.KvListAttributeTriggersMainBufferResize));
+        using var activity = activitySource.StartActivity("test", ActivityKind.Server, default(ActivityContext), tags);
+
+        Assert.NotNull(activity);
+
+        var buffer = new byte[4096];
+        int writePosition;
+        while (true)
+        {
+            try
+            {
+                writePosition = ProtobufOtlpTraceSerializer.WriteSpan(buffer, 0, new SdkLimitOptions(), activity);
+                break;
+            }
+            catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
+            {
+                if (!ProtobufSerializer.IncreaseBufferSize(ref buffer, OtlpSignalType.Traces))
+                {
+                    throw;
+                }
+            }
+        }
+
+        Assert.True(buffer.Length > 4096);
+
+        using var stream = new MemoryStream(buffer, 0, writePosition);
+        var scopeSpans = OtlpTrace.ScopeSpans.Parser.ParseFrom(stream);
+        var span = scopeSpans.Spans.FirstOrDefault();
+
+        Assert.NotNull(span);
+
+        var kvListAttr = span.Attributes.FirstOrDefault(a => a.Key == "kvList");
+        Assert.NotNull(kvListAttr);
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.KvlistValue, kvListAttr.Value.ValueCase);
+
+        var values = kvListAttr.Value.KvlistValue.Values;
+        Assert.Single(values);
+
+        Assert.Equal("large", values[0].Key);
+        Assert.Equal(largeString, values[0].Value.StringValue);
+    }
+
+    public void Dispose()
+    {
+        this.activityListener.Dispose();
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> FaultyKvList()
+    {
+        yield return new KeyValuePair<string, object?>("key1", "value1");
+        throw new InvalidOperationException("simulated failure");
+    }
+
+    private static bool TryTransformTag(KeyValuePair<string, object?> tag, [NotNullWhen(true)] out OtlpCommon.KeyValue? attribute)
+    {
+        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        {
+            Buffer = new byte[4096],
+            WritePosition = 0,
+        };
+
+        if (ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag))
+        {
+            using var stream = new MemoryStream(otlpTagWriterState.Buffer, 0, otlpTagWriterState.WritePosition);
+            var keyValue = OtlpCommon.KeyValue.Parser.ParseFrom(stream);
+            Assert.NotNull(keyValue);
+            attribute = keyValue;
+            return true;
+        }
+
+        if (otlpTagWriterState.WritePosition > 0)
+        {
+            using var stream = new MemoryStream(otlpTagWriterState.Buffer, 0, otlpTagWriterState.WritePosition);
+            attribute = OtlpCommon.KeyValue.Parser.ParseFrom(stream);
+            return false;
+        }
+
+        attribute = null;
+        return false;
+    }
+}

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpKvListAttributeTests.cs
@@ -352,7 +352,7 @@ public sealed class OtlpKvListAttributeTests : IDisposable
             Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, attributeValue.KvlistValue.Values[1].Value.ValueCase);
             Assert.Equal(Convert.ToString(SelfReferencingKvList(), CultureInfo.InvariantCulture), attributeValue.KvlistValue.Values[1].Value.StringValue);
         }
-     }
+    }
 
     public void Dispose()
     {

--- a/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
@@ -195,6 +195,9 @@ public class JsonStringArrayTagWriterTests
 
         protected override bool TryWriteByteArrayTag(ref Tag consoleTag, string key, ReadOnlySpan<byte> value) => false;
 
+        protected override void WriteKvListTag(ref Tag state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
+            => throw new NotImplementedException();
+
         public struct Tag
         {
             public string? Key;

--- a/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
@@ -194,6 +194,9 @@ public class JsonStringArrayTagWriterTests
 
         protected override bool TryWriteByteArrayTag(ref Tag consoleTag, string key, ReadOnlySpan<byte> value) => false;
 
+        protected override void WriteKvListTag(ref Tag state, string key, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
+            => throw new NotImplementedException();
+
         public struct Tag
         {
             public string? Key;


### PR DESCRIPTION
According to the spec, attribute values should be `AnyValue`. One of the possible values of `AnyValue` is `KeyValueList`, which we currently aren't able to serialize properly.
## Changes

This PR adds support for serializing KeyValue lists to the OTLP exporter.


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
