### PR TITLE
[OpenTelemetry] Optimize trace sampling

### DIFF
--- a/src/OpenTelemetry/Trace/Sampler/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/Sampler/SamplingResult.cs
@@ -8,6 +8,10 @@ namespace OpenTelemetry.Trace;
 /// </summary>
 public readonly struct SamplingResult : IEquatable<SamplingResult>
 {
+    // Null when no attributes were supplied; avoids a GetEnumerator() call (and enumerator boxing)
+    // on the hot path inside TracerProviderSdk when the sampler returns no attributes.
+    private readonly IEnumerable<KeyValuePair<string, object>>? attributesField;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SamplingResult"/> struct.
     /// </summary>
@@ -61,7 +65,8 @@ public readonly struct SamplingResult : IEquatable<SamplingResult>
         // Note: Decision object takes ownership of the collection.
         // Current implementation has no means to ensure the collection will not be modified by the caller.
         // If this behavior will be abused we must switch to cloning of the collection.
-        this.Attributes = attributes ?? [];
+        // Stored as null when empty so the SDK can skip GetEnumerator() entirely in the common no-attributes case.
+        this.attributesField = attributes;
 
         this.TraceStateString = traceStateString;
     }
@@ -74,12 +79,15 @@ public readonly struct SamplingResult : IEquatable<SamplingResult>
     /// <summary>
     /// Gets a map of attributes associated with the sampling decision.
     /// </summary>
-    public IEnumerable<KeyValuePair<string, object>> Attributes { get; }
+    public IEnumerable<KeyValuePair<string, object>> Attributes => this.attributesField ?? [];
 
     /// <summary>
     /// Gets the tracestate.
     /// </summary>
     public string? TraceStateString { get; }
+
+    // Internal accessor used by TracerProviderSdk to skip iteration entirely when null.
+    internal IEnumerable<KeyValuePair<string, object>>? AttributesOrNull => this.attributesField;
 
     /// <summary>
     /// Compare two <see cref="SamplingResult"/> for equality.

--- a/src/OpenTelemetry/Trace/Sampler/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/Sampler/SamplingResult.cs
@@ -65,7 +65,6 @@ public readonly struct SamplingResult : IEquatable<SamplingResult>
         // Note: Decision object takes ownership of the collection.
         // Current implementation has no means to ensure the collection will not be modified by the caller.
         // If this behavior will be abused we must switch to cloning of the collection.
-        // Stored as null when empty so the SDK can skip GetEnumerator() entirely in the common no-attributes case.
         this.attributesField = attributes;
 
         this.TraceStateString = traceStateString;

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -222,7 +222,7 @@ internal sealed class TracerProviderSdk : TracerProvider
 
         if (this.Sampler is AlwaysOnSampler)
         {
-            activityListener.Sample = (ref options) =>
+            activityListener.Sample = static (ref _) =>
                 !Sdk.SuppressInstrumentation ? ActivitySamplingResult.AllDataAndRecorded : ActivitySamplingResult.None;
             this.getRequestedDataAction = this.RunGetRequestedDataAlwaysOnSampler;
         }
@@ -290,6 +290,69 @@ internal sealed class TracerProviderSdk : TracerProvider
     internal BaseProcessor<Activity>? Processor { get; private set; }
 
     internal Sampler Sampler { get; }
+
+    internal static ActivitySamplingResult ComputeActivitySamplingResult(
+        ref ActivityCreationOptions<ActivityContext> options,
+        Sampler sampler)
+    {
+        var samplingParameters = new SamplingParameters(
+            options.Parent,
+            options.TraceId,
+            options.Name,
+            options.Kind,
+            options.Tags,
+            options.Links);
+
+        var samplingResult = sampler.ShouldSample(samplingParameters);
+
+        var activitySamplingResult = samplingResult.Decision switch
+        {
+            SamplingDecision.RecordAndSample => ActivitySamplingResult.AllDataAndRecorded,
+            SamplingDecision.RecordOnly => ActivitySamplingResult.AllData,
+            SamplingDecision.Drop or _ => PropagateOrIgnoreData(ref options),
+        };
+
+        if (activitySamplingResult > ActivitySamplingResult.PropagationData)
+        {
+            if (samplingResult.AttributesOrNull is { } attributes)
+            {
+                if (attributes is KeyValuePair<string, object?>[] array)
+                {
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        options.SamplingTags.Add(array[i].Key, array[i].Value);
+                    }
+                }
+                else
+                {
+                    foreach (var att in attributes)
+                    {
+                        options.SamplingTags.Add(att.Key, att.Value);
+                    }
+                }
+            }
+        }
+
+        if (activitySamplingResult != ActivitySamplingResult.None
+            && samplingResult.TraceStateString != null)
+        {
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler
+            // Spec requires clearing Tracestate if empty Tracestate is returned.
+            // Since .NET did not have this capability, it'll break
+            // existing samplers if we did that. So the following is
+            // adopted to remain spec-compliant and backward compat.
+            // The behavior is:
+            // if sampler returns null, its treated as if it has not intended
+            // to change Tracestate. Existing SamplingResult ctors will put null as default TraceStateString,
+            // so all existing samplers will get this behavior.
+            // if sampler returns non-null, then it'll be used as the
+            // new value for Tracestate
+            // A sampler can return string.Empty if it intends to clear the state.
+            options = options with { TraceState = samplingResult.TraceStateString };
+        }
+
+        return activitySamplingResult;
+    }
 
     internal TracerProviderSdk AddProcessor(BaseProcessor<Activity> processor)
     {
@@ -456,56 +519,6 @@ internal sealed class TracerProviderSdk : TracerProvider
         return 1.0;
     }
 
-    private static ActivitySamplingResult ComputeActivitySamplingResult(
-        ref ActivityCreationOptions<ActivityContext> options,
-        Sampler sampler)
-    {
-        var samplingParameters = new SamplingParameters(
-            options.Parent,
-            options.TraceId,
-            options.Name,
-            options.Kind,
-            options.Tags,
-            options.Links);
-
-        var samplingResult = sampler.ShouldSample(samplingParameters);
-
-        var activitySamplingResult = samplingResult.Decision switch
-        {
-            SamplingDecision.RecordAndSample => ActivitySamplingResult.AllDataAndRecorded,
-            SamplingDecision.RecordOnly => ActivitySamplingResult.AllData,
-            SamplingDecision.Drop or _ => PropagateOrIgnoreData(ref options),
-        };
-
-        if (activitySamplingResult > ActivitySamplingResult.PropagationData)
-        {
-            foreach (var att in samplingResult.Attributes)
-            {
-                options.SamplingTags.Add(att.Key, att.Value);
-            }
-        }
-
-        if (activitySamplingResult != ActivitySamplingResult.None
-            && samplingResult.TraceStateString != null)
-        {
-            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler
-            // Spec requires clearing Tracestate if empty Tracestate is returned.
-            // Since .NET did not have this capability, it'll break
-            // existing samplers if we did that. So the following is
-            // adopted to remain spec-compliant and backward compat.
-            // The behavior is:
-            // if sampler returns null, its treated as if it has not intended
-            // to change Tracestate. Existing SamplingResult ctors will put null as default TraceStateString,
-            // so all existing samplers will get this behavior.
-            // if sampler returns non-null, then it'll be used as the
-            // new value for Tracestate
-            // A sampler can return string.Empty if it intends to clear the state.
-            options = options with { TraceState = samplingResult.TraceStateString };
-        }
-
-        return activitySamplingResult;
-    }
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ActivitySamplingResult PropagateOrIgnoreData(ref ActivityCreationOptions<ActivityContext> options)
     {
@@ -575,9 +588,22 @@ internal sealed class TracerProviderSdk : TracerProvider
 
         if (samplingResult.Decision != SamplingDecision.Drop)
         {
-            foreach (var att in samplingResult.Attributes)
+            if (samplingResult.AttributesOrNull is { } attributes)
             {
-                activity.SetTag(att.Key, att.Value);
+                if (attributes is KeyValuePair<string, object?>[] array)
+                {
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        activity.SetTag(array[i].Key, array[i].Value);
+                    }
+                }
+                else
+                {
+                    foreach (var att in attributes)
+                    {
+                        activity.SetTag(att.Key, att.Value);
+                    }
+                }
             }
         }
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -291,69 +291,6 @@ internal sealed class TracerProviderSdk : TracerProvider
 
     internal Sampler Sampler { get; }
 
-    internal static ActivitySamplingResult ComputeActivitySamplingResult(
-        ref ActivityCreationOptions<ActivityContext> options,
-        Sampler sampler)
-    {
-        var samplingParameters = new SamplingParameters(
-            options.Parent,
-            options.TraceId,
-            options.Name,
-            options.Kind,
-            options.Tags,
-            options.Links);
-
-        var samplingResult = sampler.ShouldSample(samplingParameters);
-
-        var activitySamplingResult = samplingResult.Decision switch
-        {
-            SamplingDecision.RecordAndSample => ActivitySamplingResult.AllDataAndRecorded,
-            SamplingDecision.RecordOnly => ActivitySamplingResult.AllData,
-            SamplingDecision.Drop or _ => PropagateOrIgnoreData(ref options),
-        };
-
-        if (activitySamplingResult > ActivitySamplingResult.PropagationData)
-        {
-            if (samplingResult.AttributesOrNull is { } attributes)
-            {
-                if (attributes is KeyValuePair<string, object?>[] array)
-                {
-                    for (int i = 0; i < array.Length; i++)
-                    {
-                        options.SamplingTags.Add(array[i].Key, array[i].Value);
-                    }
-                }
-                else
-                {
-                    foreach (var att in attributes)
-                    {
-                        options.SamplingTags.Add(att.Key, att.Value);
-                    }
-                }
-            }
-        }
-
-        if (activitySamplingResult != ActivitySamplingResult.None
-            && samplingResult.TraceStateString != null)
-        {
-            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler
-            // Spec requires clearing Tracestate if empty Tracestate is returned.
-            // Since .NET did not have this capability, it'll break
-            // existing samplers if we did that. So the following is
-            // adopted to remain spec-compliant and backward compat.
-            // The behavior is:
-            // if sampler returns null, its treated as if it has not intended
-            // to change Tracestate. Existing SamplingResult ctors will put null as default TraceStateString,
-            // so all existing samplers will get this behavior.
-            // if sampler returns non-null, then it'll be used as the
-            // new value for Tracestate
-            // A sampler can return string.Empty if it intends to clear the state.
-            options = options with { TraceState = samplingResult.TraceStateString };
-        }
-
-        return activitySamplingResult;
-    }
-
     internal TracerProviderSdk AddProcessor(BaseProcessor<Activity> processor)
     {
         Guard.ThrowIfNull(processor);
@@ -517,6 +454,69 @@ internal sealed class TracerProviderSdk : TracerProvider
         }
 
         return 1.0;
+    }
+
+    private static ActivitySamplingResult ComputeActivitySamplingResult(
+        ref ActivityCreationOptions<ActivityContext> options,
+        Sampler sampler)
+    {
+        var samplingParameters = new SamplingParameters(
+            options.Parent,
+            options.TraceId,
+            options.Name,
+            options.Kind,
+            options.Tags,
+            options.Links);
+
+        var samplingResult = sampler.ShouldSample(samplingParameters);
+
+        var activitySamplingResult = samplingResult.Decision switch
+        {
+            SamplingDecision.RecordAndSample => ActivitySamplingResult.AllDataAndRecorded,
+            SamplingDecision.RecordOnly => ActivitySamplingResult.AllData,
+            SamplingDecision.Drop or _ => PropagateOrIgnoreData(ref options),
+        };
+
+        if (activitySamplingResult > ActivitySamplingResult.PropagationData)
+        {
+            if (samplingResult.AttributesOrNull is { } attributes)
+            {
+                if (attributes is KeyValuePair<string, object?>[] array)
+                {
+                    for (int i = 0; i < array.Length; i++)
+                    {
+                        options.SamplingTags.Add(array[i].Key, array[i].Value);
+                    }
+                }
+                else
+                {
+                    foreach (var att in attributes)
+                    {
+                        options.SamplingTags.Add(att.Key, att.Value);
+                    }
+                }
+            }
+        }
+
+        if (activitySamplingResult != ActivitySamplingResult.None
+            && samplingResult.TraceStateString != null)
+        {
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler
+            // Spec requires clearing Tracestate if empty Tracestate is returned.
+            // Since .NET did not have this capability, it'll break
+            // existing samplers if we did that. So the following is
+            // adopted to remain spec-compliant and backward compat.
+            // The behavior is:
+            // if sampler returns null, its treated as if it has not intended
+            // to change Tracestate. Existing SamplingResult ctors will put null as default TraceStateString,
+            // so all existing samplers will get this behavior.
+            // if sampler returns non-null, then it'll be used as the
+            // new value for Tracestate
+            // A sampler can return string.Empty if it intends to clear the state.
+            options = options with { TraceState = samplingResult.TraceStateString };
+        }
+
+        return activitySamplingResult;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -481,19 +481,9 @@ internal sealed class TracerProviderSdk : TracerProvider
         {
             if (samplingResult.AttributesOrNull is { } attributes)
             {
-                if (attributes is KeyValuePair<string, object?>[] array)
+                foreach (var att in attributes)
                 {
-                    for (int i = 0; i < array.Length; i++)
-                    {
-                        options.SamplingTags.Add(array[i].Key, array[i].Value);
-                    }
-                }
-                else
-                {
-                    foreach (var att in attributes)
-                    {
-                        options.SamplingTags.Add(att.Key, att.Value);
-                    }
+                    options.SamplingTags.Add(att.Key, att.Value);
                 }
             }
         }
@@ -590,19 +580,9 @@ internal sealed class TracerProviderSdk : TracerProvider
         {
             if (samplingResult.AttributesOrNull is { } attributes)
             {
-                if (attributes is KeyValuePair<string, object?>[] array)
+                foreach (var att in attributes)
                 {
-                    for (int i = 0; i < array.Length; i++)
-                    {
-                        activity.SetTag(array[i].Key, array[i].Value);
-                    }
-                }
-                else
-                {
-                    foreach (var att in attributes)
-                    {
-                        activity.SetTag(att.Key, att.Value);
-                    }
+                    activity.SetTag(att.Key, att.Value);
                 }
             }
         }

--- a/test/Benchmarks/Trace/SamplingResultBenchmarks.cs
+++ b/test/Benchmarks/Trace/SamplingResultBenchmarks.cs
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Benchmarks.Trace;
+
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
+[MemoryDiagnoser]
+public class SamplingResultBenchmarks
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
+{
+    private static readonly KeyValuePair<string, object>[] SamplingAttributes =
+    [
+        new("sampling.priority", 1),
+        new("sampling.rule", "always"),
+    ];
+
+    private ActivitySource? sourceNoAttributes;
+    private ActivitySource? sourceWithAttributeArray;
+    private ActivitySource? sourceWithAttributeList;
+    private ActivitySource? sourceDrop;
+    private ActivitySource? sourceParentBased;
+
+    private ActivityContext sampledRemoteParent;
+
+    private TracerProvider? providerNoAttributes;
+    private TracerProvider? providerWithAttributeArray;
+    private TracerProvider? providerWithAttributeList;
+    private TracerProvider? providerDrop;
+    private TracerProvider? providerParentBased;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.sourceNoAttributes = new ActivitySource("SamplingResult.NoAttributes");
+        this.sourceWithAttributeArray = new ActivitySource("SamplingResult.WithAttributeArray");
+        this.sourceWithAttributeList = new ActivitySource("SamplingResult.WithAttributeList");
+        this.sourceDrop = new ActivitySource("SamplingResult.Drop");
+        this.sourceParentBased = new ActivitySource("SamplingResult.ParentBased");
+
+        this.sampledRemoteParent = new ActivityContext(
+            ActivityTraceId.CreateRandom(),
+            ActivitySpanId.CreateRandom(),
+            ActivityTraceFlags.Recorded,
+            traceState: null,
+            isRemote: true);
+
+        // Sampler returns RecordAndSample with no attributes — the common case.
+        this.providerNoAttributes = Sdk.CreateTracerProviderBuilder()
+            .AddSource(this.sourceNoAttributes.Name)
+            .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.RecordAndSample)))
+            .Build();
+
+        // Sampler returns attributes as a T[] — exercises the array fast-path.
+        this.providerWithAttributeArray = Sdk.CreateTracerProviderBuilder()
+            .AddSource(this.sourceWithAttributeArray.Name)
+            .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.RecordAndSample, SamplingAttributes)))
+            .Build();
+
+        // Sampler returns attributes as a List<T> — exercises the IEnumerable fallback path.
+        this.providerWithAttributeList = Sdk.CreateTracerProviderBuilder()
+            .AddSource(this.sourceWithAttributeList.Name)
+            .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.RecordAndSample, [.. SamplingAttributes])))
+            .Build();
+
+        // Sampler drops the span — attribute loop is never entered.
+        this.providerDrop = Sdk.CreateTracerProviderBuilder()
+            .AddSource(this.sourceDrop.Name)
+            .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.Drop)))
+            .Build();
+
+        // ParentBasedSampler with AlwaysOnSampler root — realistic production default.
+        this.providerParentBased = Sdk.CreateTracerProviderBuilder()
+            .AddSource(this.sourceParentBased.Name)
+            .SetSampler(new ParentBasedSampler(new AlwaysOnSampler()))
+            .Build();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        this.sourceNoAttributes?.Dispose();
+        this.sourceWithAttributeArray?.Dispose();
+        this.sourceWithAttributeList?.Dispose();
+        this.sourceDrop?.Dispose();
+        this.sourceParentBased?.Dispose();
+
+        this.providerNoAttributes?.Dispose();
+        this.providerWithAttributeArray?.Dispose();
+        this.providerWithAttributeList?.Dispose();
+        this.providerDrop?.Dispose();
+        this.providerParentBased?.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void NoAttributes()
+    {
+        using var activity = this.sourceNoAttributes!.StartActivity("Benchmark", ActivityKind.Server, this.sampledRemoteParent);
+    }
+
+    [Benchmark]
+    public void WithAttributeArray()
+    {
+        using var activity = this.sourceWithAttributeArray!.StartActivity("Benchmark", ActivityKind.Server, this.sampledRemoteParent);
+    }
+
+    [Benchmark]
+    public void WithAttributeList()
+    {
+        using var activity = this.sourceWithAttributeList!.StartActivity("Benchmark", ActivityKind.Server, this.sampledRemoteParent);
+    }
+
+    [Benchmark]
+    public void Drop()
+    {
+        using var activity = this.sourceDrop!.StartActivity("Benchmark", ActivityKind.Server, this.sampledRemoteParent);
+    }
+
+    [Benchmark]
+    public void ParentBasedSampled()
+    {
+        using var activity = this.sourceParentBased!.StartActivity("Benchmark", ActivityKind.Server, this.sampledRemoteParent);
+    }
+
+    private sealed class DelegateSampler(Func<SamplingParameters, SamplingResult> sample) : Sampler
+    {
+        public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+            => sample(samplingParameters);
+    }
+}

--- a/test/Benchmarks/Trace/SamplingResultBenchmarks.cs
+++ b/test/Benchmarks/Trace/SamplingResultBenchmarks.cs
@@ -49,31 +49,31 @@ public class SamplingResultBenchmarks
             traceState: null,
             isRemote: true);
 
-        // Sampler returns RecordAndSample with no attributes — the common case.
+        // Sampler returns RecordAndSample with no attributes - the common case.
         this.providerNoAttributes = Sdk.CreateTracerProviderBuilder()
             .AddSource(this.sourceNoAttributes.Name)
             .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.RecordAndSample)))
             .Build();
 
-        // Sampler returns attributes as a T[] — exercises the array fast-path.
+        // Sampler returns attributes as a T[] - exercises the array fast-path.
         this.providerWithAttributeArray = Sdk.CreateTracerProviderBuilder()
             .AddSource(this.sourceWithAttributeArray.Name)
             .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.RecordAndSample, SamplingAttributes)))
             .Build();
 
-        // Sampler returns attributes as a List<T> — exercises the IEnumerable fallback path.
+        // Sampler returns attributes as a List<T> - exercises the IEnumerable fallback path.
         this.providerWithAttributeList = Sdk.CreateTracerProviderBuilder()
             .AddSource(this.sourceWithAttributeList.Name)
             .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.RecordAndSample, [.. SamplingAttributes])))
             .Build();
 
-        // Sampler drops the span — attribute loop is never entered.
+        // Sampler drops the span - attribute loop is never entered.
         this.providerDrop = Sdk.CreateTracerProviderBuilder()
             .AddSource(this.sourceDrop.Name)
             .SetSampler(new DelegateSampler(_ => new SamplingResult(SamplingDecision.Drop)))
             .Build();
 
-        // ParentBasedSampler with AlwaysOnSampler root — realistic production default.
+        // ParentBasedSampler with AlwaysOnSampler root - realistic production default.
         this.providerParentBased = Sdk.CreateTracerProviderBuilder()
             .AddSource(this.sourceParentBased.Name)
             .SetSampler(new ParentBasedSampler(new AlwaysOnSampler()))


### PR DESCRIPTION
## Changes

While looking at some profiles for an OTel instrumented application of mine, I noticed that `TraceProviderSdk.ComputeActivitySamplingResult()` came up in the top 10 OTel-related samples.

This PR adopts a Copilot-authored suggestion to avoid allocating an array in `SamplingResult` when there's no attributes so that `TraceProviderSdk` can skip enumeration.

## Benchmark results

### Copilot Summary

This PR is faster in every case, with allocation improvements in one case and unchanged allocations in the others:

| Method | `main` Mean | `pr-7057` Mean | Time delta | `main` Alloc | `pr-7057` Alloc | Alloc delta |
 |---|---:|---:|---:|---:|---:|---:|
 | NoAttributes | 122.1 ns | 110.2 ns | **-9.8%** | 328 B | 328 B | **0.0%** |
 | WithAttributeArray | 181.9 ns | 166.5 ns | **-8.5%** | 672 B | 640 B | **-4.8%** |
 | WithAttributeList | 277.0 ns | 275.5 ns | **-0.5%** | 752 B | 752 B | **0.0%** |
 | Drop | 104.7 ns | 101.0 ns | **-3.5%** | 328 B | 328 B | **0.0%** |
 | ParentBasedSampled | 114.3 ns | 109.5 ns | **-4.2%** | 328 B | 328 B | **0.0%** |

This PR improves latency by about 0.5% to 9.8% across all cases. Allocation is mostly unchanged, with a small improvement in `WithAttributeArray` (672 B -> 640 B).

<details>

<summary>Expand to see</summary>

### `main` + the new benchmarks

```text
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8117/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.201
  [Host]     : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
```

| Method             | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
| NoAttributes       | 122.1 ns | 1.09 ns | 1.02 ns |  1.00 |    0.01 | 0.0260 |     328 B |        1.00 |
| WithAttributeArray | 181.9 ns | 1.75 ns | 1.63 ns |  1.49 |    0.02 | 0.0534 |     672 B |        2.05 |
| WithAttributeList  | 277.0 ns | 2.85 ns | 2.53 ns |  2.27 |    0.03 | 0.0596 |     752 B |        2.29 |
| Drop               | 104.7 ns | 0.74 ns | 0.69 ns |  0.86 |    0.01 | 0.0261 |     328 B |        1.00 |
| ParentBasedSampled | 114.3 ns | 0.56 ns | 0.47 ns |  0.94 |    0.01 | 0.0261 |     328 B |        1.00 |

### This PR

```text
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8117/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.201
  [Host]     : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
```

| Method             | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
| NoAttributes       | 110.2 ns | 0.65 ns | 0.61 ns |  1.00 |    0.01 | 0.0261 |     328 B |        1.00 |
| WithAttributeArray | 166.5 ns | 1.11 ns | 0.99 ns |  1.51 |    0.01 | 0.0508 |     640 B |        1.95 |
| WithAttributeList  | 275.5 ns | 1.69 ns | 1.50 ns |  2.50 |    0.02 | 0.0596 |     752 B |        2.29 |
| Drop               | 101.0 ns | 0.75 ns | 0.70 ns |  0.92 |    0.01 | 0.0261 |     328 B |        1.00 |
| ParentBasedSampled | 109.5 ns | 2.18 ns | 2.04 ns |  0.99 |    0.02 | 0.0261 |     328 B |        1.00 |

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
