### PR TITLE
[OpenTelemetry] Benchmark BaggagePropagator

### DIFF
--- a/test/Benchmarks/Context/Propagation/BaggagePropagatorBenchmarks.cs
+++ b/test/Benchmarks/Context/Propagation/BaggagePropagatorBenchmarks.cs
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Benchmarks.Context.Propagation;
+
+[MemoryDiagnoser]
+public class BaggagePropagatorBenchmarks
+{
+    private static readonly BaggagePropagator Propagator = new();
+
+    private static readonly Func<Dictionary<string, string>, string, IEnumerable<string>> Getter =
+        static (carrier, name) => carrier.TryGetValue(name, out var value) ? [value] : [];
+
+    private static readonly Action<Dictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
+
+    /// <summary>Gets or sets the number of baggage entries used in each benchmark run.</summary>
+    [Params(1, 5, 20)]
+    public int ItemCount { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether keys and values contain characters that require URL-encoding.</summary>
+    [Params(false, true)]
+    public bool UseSpecialChars { get; set; }
+
+    public Dictionary<string, string> ExtractCarrier { get; private set; } = [];
+
+    public Dictionary<string, string> InjectCarrier { get; private set; } = [];
+
+    public PropagationContext InjectContext { get; private set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        IEnumerable<(string Key, string Value)> Items() =>
+            Enumerable.Range(0, this.ItemCount).Select(i =>
+                this.UseSpecialChars
+                    ? ($"key {i}", $"value {i} !@#$%^&*()")
+                    : ($"key{i}", $"value{i}"));
+
+        var baggageHeader = string.Join(",", Items().Select(p =>
+            $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value)}"));
+
+        this.ExtractCarrier = new Dictionary<string, string>
+        {
+            ["baggage"] = baggageHeader,
+        };
+
+        var baggageDict = Items().ToDictionary(p => p.Key, p => p.Value);
+        this.InjectContext = new PropagationContext(default, Baggage.Create(baggageDict));
+        this.InjectCarrier = [];
+    }
+
+    [Benchmark]
+    public PropagationContext Extract() =>
+        Propagator.Extract(default, this.ExtractCarrier, Getter);
+
+    [Benchmark]
+    public void Inject()
+    {
+        this.InjectCarrier.Clear();
+        Propagator.Inject(this.InjectContext, this.InjectCarrier, Setter);
+    }
+}

--- a/test/Benchmarks/Context/Propagation/TraceContextPropagatorBenchmarks.cs
+++ b/test/Benchmarks/Context/Propagation/TraceContextPropagatorBenchmarks.cs
@@ -16,15 +16,8 @@ public class TraceContextPropagatorBenchmarks
     private static readonly Random Random = new(455946);
     private static readonly TraceContextPropagator TraceContextPropagator = new();
 
-    private static readonly Func<IReadOnlyDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
-    {
-        if (headers.TryGetValue(name, out var value))
-        {
-            return [value];
-        }
-
-        return [];
-    };
+    private static readonly Func<IReadOnlyDictionary<string, string>, string, IEnumerable<string>> Getter =
+        static (headers, name) => headers.TryGetValue(name, out var value) ? [value] : [];
 
     [Params(true, false)]
     public bool LongListMember { get; set; }


### PR DESCRIPTION
## Changes

Add benchmarks for `BaggagePropagator`.

These will be useful to compare the impact of #7009 as well as some work I'm doing locally (that would come after that) to see if there's any optimisations we can make as BaggagePropagator shows up in the top 5 OTel-related items for memory allocations for an app of mine under load test.

### Benchmark results

<details>

<summary>Expand to see</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8117/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.201
  [Host]     : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3


```
| Method  | ItemCount | UseSpecialChars | Mean        | Error     | StdDev    | Median      | Gen0   | Gen1   | Allocated |
|-------- |---------- |---------------- |------------:|----------:|----------:|------------:|-------:|-------:|----------:|
| **Extract** | **1**         | **False**           |   **110.84 ns** |  **1.857 ns** |  **1.737 ns** |   **110.53 ns** | **0.0381** |      **-** |     **480 B** |
| Inject  | 1         | False           |    40.41 ns |  0.770 ns |  0.682 ns |    40.45 ns | 0.0121 |      - |     152 B |
| **Extract** | **1**         | **True**            |   **190.19 ns** |  **3.588 ns** |  **3.685 ns** |   **191.19 ns** | **0.0675** |      **-** |     **848 B** |
| Inject  | 1         | True            |   127.35 ns |  1.693 ns |  1.414 ns |   127.34 ns | 0.0458 |      - |     576 B |
| **Extract** | **5**         | **False**           |   **395.27 ns** |  **4.367 ns** |  **3.410 ns** |   **394.98 ns** | **0.1354** | **0.0005** |    **1704 B** |
| Inject  | 5         | False           |   152.97 ns | 15.618 ns | 45.805 ns |   128.16 ns | 0.0389 |      - |     488 B |
| **Extract** | **5**         | **True**            |   **812.22 ns** | **10.819 ns** |  **9.591 ns** |   **812.26 ns** | **0.3138** | **0.0019** |    **3944 B** |
| Inject  | 5         | True            |   431.29 ns |  5.359 ns |  5.013 ns |   430.02 ns | 0.1535 |      - |    1928 B |
| **Extract** | **20**        | **False**           | **1,457.75 ns** | **11.920 ns** | **22.965 ns** | **1,459.33 ns** | **0.5417** | **0.0114** |    **6800 B** |
| Inject  | 20        | False           |   432.86 ns |  6.930 ns |  6.482 ns |   433.55 ns | 0.1593 | 0.0005 |    2000 B |
| **Extract** | **20**        | **True**            | **3,092.39 ns** | **60.032 ns** | **58.959 ns** | **3,087.80 ns** | **1.2589** | **0.0381** |   **15840 B** |
| Inject  | 20        | True            | 1,527.28 ns | 29.403 ns | 39.253 ns | 1,533.17 ns | 0.5436 | 0.0038 |    6832 B |

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
