### PR TITLE
[Api] Optimize BaggagePropagator

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -20,8 +20,9 @@ public class BaggagePropagator : TextMapPropagator
     private const int MaxBaggageLength = 8192;
     private const int MaxBaggageItems = 180;
 
-    private static readonly char[] EqualSignSeparator = ['='];
+#if !NET
     private static readonly char[] CommaSignSeparator = [','];
+#endif
 
     /// <inheritdoc/>
     public override ISet<string> Fields => new HashSet<string> { BaggageHeaderName };
@@ -50,9 +51,9 @@ public class BaggagePropagator : TextMapPropagator
         try
         {
             var baggageCollection = getter(carrier, BaggageHeaderName);
-            if (baggageCollection?.Any() ?? false)
+            if (baggageCollection is not null)
             {
-                if (TryExtractBaggage([.. baggageCollection], out var baggageItems))
+                if (TryExtractBaggage(baggageCollection, out var baggageItems))
                 {
                     Baggage baggage =
 #if NET
@@ -113,7 +114,7 @@ public class BaggagePropagator : TextMapPropagator
     }
 
     internal static bool TryExtractBaggage(
-        string[] baggageCollection,
+        IEnumerable<string> baggageCollection,
 #if NET
         [NotNullWhen(true)]
 #endif
@@ -135,9 +136,25 @@ public class BaggagePropagator : TextMapPropagator
                 continue;
             }
 
-            foreach (var pair in item.Split(CommaSignSeparator))
+#if NET
+            var span = item.AsSpan();
+            while (!span.IsEmpty)
             {
-                baggageLength += pair.Length + 1; // pair and comma
+                ReadOnlySpan<char> pairSpan;
+
+                var index = span.IndexOf(',');
+                if (index < 0)
+                {
+                    pairSpan = span;
+                    span = default;
+                }
+                else
+                {
+                    pairSpan = span[..index];
+                    span = span[(index + 1)..];
+                }
+
+                baggageLength += pairSpan.Length + 1;
 
                 if (baggageLength >= MaxBaggageLength || baggageDictionary?.Count >= MaxBaggageItems)
                 {
@@ -145,23 +162,14 @@ public class BaggagePropagator : TextMapPropagator
                     break;
                 }
 
-#if NET
-                if (pair.IndexOf('=', StringComparison.Ordinal) < 0)
-#else
-                if (pair.IndexOf('=') < 0)
-#endif
+                index = pairSpan.IndexOf('=');
+                if (index < 0)
                 {
                     continue;
                 }
 
-                var parts = pair.Split(EqualSignSeparator, 2);
-                if (parts.Length != 2)
-                {
-                    continue;
-                }
-
-                var key = WebUtility.UrlDecode(parts[0]);
-                var value = WebUtility.UrlDecode(parts[1]);
+                var key = WebUtility.UrlDecode(pairSpan[..index].ToString());
+                var value = WebUtility.UrlDecode(pairSpan[(index + 1)..].ToString());
 
                 if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
                 {
@@ -169,9 +177,37 @@ public class BaggagePropagator : TextMapPropagator
                 }
 
                 baggageDictionary ??= [];
-
                 baggageDictionary[key] = value;
             }
+#else
+            foreach (var pair in item.Split(CommaSignSeparator))
+            {
+                baggageLength += pair.Length + 1;
+
+                if (baggageLength >= MaxBaggageLength || baggageDictionary?.Count >= MaxBaggageItems)
+                {
+                    done = true;
+                    break;
+                }
+
+                var index = pair.IndexOf('=');
+                if (index < 0)
+                {
+                    continue;
+                }
+
+                var key = WebUtility.UrlDecode(pair.Substring(0, index));
+                var value = WebUtility.UrlDecode(pair.Substring(index + 1));
+
+                if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
+                {
+                    continue;
+                }
+
+                baggageDictionary ??= [];
+                baggageDictionary[key] = value;
+            }
+#endif
         }
 
         baggage = baggageDictionary;


### PR DESCRIPTION
## Changes

While looking at some profiles for an OTel instrumented application of mine, I noticed that `BaggagePropagator.Extract()` came up in the top 5 OTel-related samples.

This makes some improvements by:

- Avoiding LINQ.
- Use spans where possible.

## Benchmark results

TL;DR:

- The results with the refactoring are a clear improvement for `Extract` at `ItemCount=5` and `20` (~14–32% faster and ~22–30% less allocated).
- `Inject` is mostly stable to slightly better, except for `ItemCount=1, UseSpecialChars=False` - I'm not sure if that's an artifact of the benchmarks or an actual impact of the refactoring.

<details>

<summary>Expand to see</summary>

### `main` + the new benchmarks

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8117/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.201
  [Host]     : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3


```
| Method  | ItemCount | UseSpecialChars | Mean        | Error     | StdDev    | Median      | Gen0   | Gen1   | Allocated |
|-------- |---------- |---------------- |------------:|----------:|----------:|------------:|-------:|-------:|----------:|
| **Extract** | **1**         | **False**           |   **110.84 ns** |  **1.857 ns** |  **1.737 ns** |   **110.53 ns** | **0.0381** |      **-** |     **480 B** |
| Inject  | 1         | False           |    40.41 ns |  0.770 ns |  0.682 ns |    40.45 ns | 0.0121 |      - |     152 B |
| **Extract** | **1**         | **True**            |   **190.19 ns** |  **3.588 ns** |  **3.685 ns** |   **191.19 ns** | **0.0675** |      **-** |     **848 B** |
| Inject  | 1         | True            |   127.35 ns |  1.693 ns |  1.414 ns |   127.34 ns | 0.0458 |      - |     576 B |
| **Extract** | **5**         | **False**           |   **395.27 ns** |  **4.367 ns** |  **3.410 ns** |   **394.98 ns** | **0.1354** | **0.0005** |    **1704 B** |
| Inject  | 5         | False           |   152.97 ns | 15.618 ns | 45.805 ns |   128.16 ns | 0.0389 |      - |     488 B |
| **Extract** | **5**         | **True**            |   **812.22 ns** | **10.819 ns** |  **9.591 ns** |   **812.26 ns** | **0.3138** | **0.0019** |    **3944 B** |
| Inject  | 5         | True            |   431.29 ns |  5.359 ns |  5.013 ns |   430.02 ns | 0.1535 |      - |    1928 B |
| **Extract** | **20**        | **False**           | **1,457.75 ns** | **11.920 ns** | **22.965 ns** | **1,459.33 ns** | **0.5417** | **0.0114** |    **6800 B** |
| Inject  | 20        | False           |   432.86 ns |  6.930 ns |  6.482 ns |   433.55 ns | 0.1593 | 0.0005 |    2000 B |
| **Extract** | **20**        | **True**            | **3,092.39 ns** | **60.032 ns** | **58.959 ns** | **3,087.80 ns** | **1.2589** | **0.0381** |   **15840 B** |
| Inject  | 20        | True            | 1,527.28 ns | 29.403 ns | 39.253 ns | 1,533.17 ns | 0.5436 | 0.0038 |    6832 B |

### This PR

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8117/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.201
  [Host]     : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3


```
| Method  | ItemCount | UseSpecialChars | Mean        | Error     | StdDev    | Median      | Gen0   | Gen1   | Allocated |
|-------- |---------- |---------------- |------------:|----------:|----------:|------------:|-------:|-------:|----------:|
| **Extract** | **1**         | **False**           |   **140.79 ns** |  **3.944 ns** | **11.251 ns** |   **140.75 ns** | **0.0324** |      **-** |     **408 B** |
| Inject  | 1         | False           |    73.32 ns |  4.222 ns | 12.383 ns |    77.57 ns | 0.0121 |      - |     152 B |
| **Extract** | **1**         | **True**            |   **149.19 ns** |  **2.218 ns** |  **1.966 ns** |   **149.55 ns** | **0.0618** |      **-** |     **776 B** |
| Inject  | 1         | True            |   117.19 ns |  1.700 ns |  1.507 ns |   116.82 ns | 0.0459 |      - |     576 B |
| **Extract** | **5**         | **False**           |   **267.31 ns** |  **5.059 ns** |  **4.485 ns** |   **266.76 ns** | **0.0954** |      **-** |    **1200 B** |
| Inject  | 5         | False           |   122.32 ns |  2.261 ns |  2.005 ns |   122.41 ns | 0.0389 |      - |     488 B |
| **Extract** | **5**         | **True**            |   **641.27 ns** |  **9.382 ns** |  **8.317 ns** |   **640.24 ns** | **0.2422** | **0.0010** |    **3040 B** |
| Inject  | 5         | True            |   406.21 ns |  6.804 ns |  6.364 ns |   403.91 ns | 0.1535 |      - |    1928 B |
| **Extract** | **20**        | **False**           | **1,018.62 ns** | **19.930 ns** | **23.725 ns** | **1,013.65 ns** | **0.3853** | **0.0076** |    **4856 B** |
| Inject  | 20        | False           |   416.45 ns |  7.795 ns |  7.291 ns |   417.78 ns | 0.1593 | 0.0005 |    2000 B |
| **Extract** | **20**        | **True**            | **2,645.72 ns** | **39.775 ns** | **37.206 ns** | **2,633.14 ns** | **0.9766** | **0.0229** |   **12296 B** |
| Inject  | 20        | True            | 1,528.43 ns |  7.347 ns |  6.135 ns | 1,528.92 ns | 0.5436 | 0.0038 |    6832 B |


</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
