### PR TITLE
[API] Add propagation fuzz tests and fix findings

### DIFF
--- a/OpenTelemetry.slnx
+++ b/OpenTelemetry.slnx
@@ -219,6 +219,7 @@
   <Project Path="src/OpenTelemetry/OpenTelemetry.csproj" />
   <Project Path="test/Benchmarks/Benchmarks.csproj" />
   <Project Path="test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj" />
+  <Project Path="test/OpenTelemetry.Api.FuzzTests/OpenTelemetry.Api.FuzzTests.csproj" />
   <Project Path="test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/OpenTelemetry.Api.ProviderBuilderExtensions.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Api.Tests/OpenTelemetry.Api.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.Console.Tests/OpenTelemetry.Exporter.Console.Tests.csproj" />

--- a/OpenTelemetry.slnx
+++ b/OpenTelemetry.slnx
@@ -229,6 +229,7 @@
   <Project Path="test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj" />
+  <Project Path="test/OpenTelemetry.Extensions.Propagators.FuzzTests/OpenTelemetry.Extensions.Propagators.FuzzTests.csproj" />
   <Project Path="test/OpenTelemetry.Extensions.Propagators.Tests/OpenTelemetry.Extensions.Propagators.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/OpenTelemetry.Instrumentation.W3cTraceContext.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj" />

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -9,6 +9,9 @@ Notes](../../RELEASENOTES.md).
 * Fix `baggage` header not respecting the maximum length in some cases.
   ([#7061](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7061))
 
+* Improve efficiency of parsing of baggage and B3 propagation headers.
+  ([#7061](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7061))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,7 +6,7 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Fix `baggage` header not respecting the maximum length in some cases.
+* Fix baggage and trace headers not respecting the maximum length in some cases.
   ([#7061](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7061))
 
 * Improve efficiency of parsing of baggage and B3 propagation headers.

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fix `baggage` header not respecting the maximum length in some cases.
+  ([#7061](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7061))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -201,59 +201,93 @@ public sealed class B3Propagator : TextMapPropagator
                 return context;
             }
 
-            var parts =
 #if NET
-                header.Split(XB3CombinedDelimiter);
+            var headerValue = header;
 #else
-                header!.Split(XB3CombinedDelimiter);
+            var headerValue = header!;
 #endif
-
-            if (parts.Length is < 2 or > 4)
-            {
-                return context;
-            }
-
-            var traceIdStr = parts[0];
-            if (string.IsNullOrWhiteSpace(traceIdStr))
-            {
-                return context;
-            }
-
-            if (traceIdStr.Length == 16)
-            {
-                // This is an 8-byte traceID.
-                traceIdStr = UpperTraceId + traceIdStr;
-            }
-
-            var traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
-
-            var spanIdStr = parts[1];
-            if (string.IsNullOrWhiteSpace(spanIdStr))
-            {
-                return context;
-            }
-
-            var spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
-
-            var traceOptions = ActivityTraceFlags.None;
-            if (parts.Length > 2)
-            {
-                var traceFlagsStr = parts[2];
-                if (SampledValues.Contains(traceFlagsStr)
-                    || FlagsValue.Equals(traceFlagsStr, StringComparison.Ordinal))
-                {
-                    traceOptions |= ActivityTraceFlags.Recorded;
-                }
-            }
-
-            return new PropagationContext(
-                new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
-                context.Baggage);
+            return
+                !TryExtractSingleHeaderContext(headerValue, out var traceId, out var spanId, out var traceOptions)
+                ? context
+                : new PropagationContext(
+                    new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
+                    context.Baggage);
         }
         catch (Exception e)
         {
             OpenTelemetryApiEventSource.Log.ActivityContextExtractException(nameof(B3Propagator), e);
             return context;
         }
+    }
+
+    private static bool TryExtractSingleHeaderContext(
+        string header,
+        out ActivityTraceId traceId,
+        out ActivitySpanId spanId,
+        out ActivityTraceFlags traceOptions)
+    {
+        traceId = default;
+        spanId = default;
+        traceOptions = ActivityTraceFlags.None;
+
+        var position = 0;
+        var traceIdStr = ReadNextPart(header, ref position);
+        if (position >= header.Length || traceIdStr.Length == 0)
+        {
+            return false;
+        }
+
+        var spanIdStr = ReadNextPart(header, ref position);
+        if (spanIdStr.Length == 0)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> traceFlagsStr = default;
+        if (position < header.Length)
+        {
+            traceFlagsStr = ReadNextPart(header, ref position);
+            if (position < header.Length)
+            {
+                _ = ReadNextPart(header, ref position);
+                if (position < header.Length)
+                {
+                    return false;
+                }
+            }
+        }
+
+        traceId = traceIdStr.Length == 16
+            ? ActivityTraceId.CreateFromString(string.Concat(UpperTraceId, traceIdStr).AsSpan())
+            : ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+
+        spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+
+        if (IsSampledValue(traceFlagsStr)
+            || traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))
+        {
+            traceOptions |= ActivityTraceFlags.Recorded;
+        }
+
+        return true;
+    }
+
+    private static bool IsSampledValue(ReadOnlySpan<char> value)
+        => value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal)
+            || value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
+
+    private static string ReadNextPart(string header, ref int position)
+    {
+        var separatorIndex = header.IndexOf(XB3CombinedDelimiter, position);
+        if (separatorIndex < 0)
+        {
+            var part = header.Substring(position);
+            position = header.Length;
+            return part;
+        }
+
+        var result = header.Substring(position, separatorIndex - position);
+        position = separatorIndex + 1;
+        return result;
     }
 }

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -195,19 +195,17 @@ public sealed class B3Propagator : TextMapPropagator
     {
         try
         {
-            var header = getter(carrier, XB3Combined)?.FirstOrDefault();
-            if (string.IsNullOrWhiteSpace(header))
+            var headers = getter(carrier, XB3Combined);
+            if (headers == null)
             {
                 return context;
             }
 
-#if NET
-            var headerValue = header;
-#else
-            var headerValue = header!;
-#endif
-            return
-                !TryExtractSingleHeaderContext(headerValue, out var traceId, out var spanId, out var traceOptions)
+            var header = headers.FirstOrDefault();
+
+            return string.IsNullOrWhiteSpace(header)
+                ? context
+                : !TryExtractSingleHeaderContext(header, out var traceId, out var spanId, out var traceOptions)
                 ? context
                 : new PropagationContext(
                     new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
@@ -230,41 +228,39 @@ public sealed class B3Propagator : TextMapPropagator
         spanId = default;
         traceOptions = ActivityTraceFlags.None;
 
+        var headerValue = header.AsSpan();
         var position = 0;
-        var traceIdStr = ReadNextPart(header, ref position);
-        if (position >= header.Length || traceIdStr.Length == 0)
+        var traceIdStr = ReadNextPart(headerValue, position, out position);
+        if (position >= headerValue.Length || traceIdStr.IsEmpty)
         {
             return false;
         }
 
-        var spanIdStr = ReadNextPart(header, ref position);
-        if (spanIdStr.Length == 0)
+        var spanIdStr = ReadNextPart(headerValue, position, out position);
+        if (spanIdStr.IsEmpty)
         {
             return false;
         }
 
         ReadOnlySpan<char> traceFlagsStr = default;
-        if (position < header.Length)
+        if (position < headerValue.Length)
         {
-            traceFlagsStr = ReadNextPart(header, ref position);
-            if (position < header.Length)
+            traceFlagsStr = ReadNextPart(headerValue, position, out position);
+            if (position < headerValue.Length)
             {
-                _ = ReadNextPart(header, ref position);
-                if (position < header.Length)
+                _ = ReadNextPart(headerValue, position, out position);
+                if (position < headerValue.Length)
                 {
                     return false;
                 }
             }
         }
 
-        traceId = traceIdStr.Length == 16
-            ? ActivityTraceId.CreateFromString(string.Concat(UpperTraceId, traceIdStr).AsSpan())
-            : ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+        traceId = CreateTraceId(traceIdStr);
+        spanId = ActivitySpanId.CreateFromString(spanIdStr);
 
-        spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
-
-        if (IsSampledValue(traceFlagsStr)
-            || traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))
+        if (IsSampledValue(traceFlagsStr) ||
+            traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))
         {
             traceOptions |= ActivityTraceFlags.Recorded;
         }
@@ -276,18 +272,34 @@ public sealed class B3Propagator : TextMapPropagator
         value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal) ||
         value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
 
-    private static string ReadNextPart(string header, ref int position)
+    private static ActivityTraceId CreateTraceId(ReadOnlySpan<char> traceId)
     {
-        var separatorIndex = header.IndexOf(XB3CombinedDelimiter, position);
+        if (traceId.Length == 16)
+        {
+            Span<char> fullTraceId = stackalloc char[UpperTraceId.Length + 16];
+
+            UpperTraceId.AsSpan().CopyTo(fullTraceId);
+            traceId.CopyTo(fullTraceId.Slice(UpperTraceId.Length));
+
+            return ActivityTraceId.CreateFromString(fullTraceId);
+        }
+
+        return ActivityTraceId.CreateFromString(traceId);
+    }
+
+    private static ReadOnlySpan<char> ReadNextPart(ReadOnlySpan<char> header, int position, out int nextPosition)
+    {
+        var remaining = header.Slice(position);
+        var separatorIndex = remaining.IndexOf(XB3CombinedDelimiter);
         if (separatorIndex < 0)
         {
-            var part = header.Substring(position);
-            position = header.Length;
+            nextPosition = header.Length;
+            var part = remaining;
             return part;
         }
 
-        var result = header.Substring(position, separatorIndex - position);
-        position = separatorIndex + 1;
+        var result = remaining.Slice(0, separatorIndex);
+        nextPosition = position + separatorIndex + 1;
         return result;
     }
 }

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -272,9 +272,9 @@ public sealed class B3Propagator : TextMapPropagator
         return true;
     }
 
-    private static bool IsSampledValue(ReadOnlySpan<char> value)
-        => value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal)
-            || value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
+    private static bool IsSampledValue(ReadOnlySpan<char> value) =>
+        value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal) ||
+        value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
 
     private static string ReadNextPart(string header, ref int position)
     {

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -189,8 +189,7 @@ public class BaggagePropagator : TextMapPropagator
                     continue;
                 }
 
-                baggageDictionary ??= new(MaxBaggageItems, StringComparer.Ordinal);
-
+                baggageDictionary ??= new(StringComparer.Ordinal);
                 baggageDictionary[key] = value;
             }
         }

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -54,9 +54,9 @@ public class BaggagePropagator : TextMapPropagator
         try
         {
             var baggageCollection = getter(carrier, BaggageHeaderName);
-            if (baggageCollection?.Any() ?? false)
+            if (baggageCollection is not null)
             {
-                if (TryExtractBaggage([.. baggageCollection], out var baggageItems))
+                if (TryExtractBaggage(baggageCollection, out var baggageItems))
                 {
                     Baggage baggage =
 #if NET
@@ -141,7 +141,7 @@ public class BaggagePropagator : TextMapPropagator
     }
 
     internal static bool TryExtractBaggage(
-        string[] baggageCollection,
+        IEnumerable<string> baggageCollection,
 #if NET
         [NotNullWhen(true)]
 #endif

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -20,9 +20,6 @@ public class BaggagePropagator : TextMapPropagator
     private const int MaxBaggageLength = 8192;
     private const int MaxBaggageItems = 180;
 
-    private static readonly char[] EqualSignSeparator = ['='];
-    private static readonly char[] CommaSignSeparator = [','];
-
     /// <inheritdoc/>
     public override ISet<string> Fields => new HashSet<string> { BaggageHeaderName };
 
@@ -159,8 +156,10 @@ public class BaggagePropagator : TextMapPropagator
                 continue;
             }
 
-            foreach (var pair in item.Split(CommaSignSeparator))
+            var remaining = item.AsSpan();
+            while (!remaining.IsEmpty)
             {
+                var pair = ReadNextSegment(ref remaining, ',');
                 baggageLength += pair.Length + 1; // pair and comma
 
                 if (baggageLength >= MaxBaggageLength || baggageDictionary?.Count >= MaxBaggageItems)
@@ -169,30 +168,21 @@ public class BaggagePropagator : TextMapPropagator
                     break;
                 }
 
-#if NET
-                if (pair.IndexOf('=', StringComparison.Ordinal) < 0)
-#else
-                if (pair.IndexOf('=') < 0)
-#endif
+                var separatorIndex = pair.IndexOf('=');
+                if (separatorIndex < 0)
                 {
                     continue;
                 }
 
-                var parts = pair.Split(EqualSignSeparator, 2);
-                if (parts.Length != 2)
-                {
-                    continue;
-                }
-
-                var key = WebUtility.UrlDecode(parts[0]);
-                var value = WebUtility.UrlDecode(parts[1]);
+                var key = DecodeIfNeeded(pair.Slice(0, separatorIndex));
+                var value = DecodeIfNeeded(pair.Slice(separatorIndex + 1));
 
                 if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
                 {
                     continue;
                 }
 
-                baggageDictionary ??= [];
+                baggageDictionary ??= new(MaxBaggageItems, StringComparer.Ordinal);
 
                 baggageDictionary[key] = value;
             }
@@ -201,4 +191,22 @@ public class BaggagePropagator : TextMapPropagator
         baggage = baggageDictionary;
         return baggageDictionary != null;
     }
+
+    private static ReadOnlySpan<char> ReadNextSegment(ref ReadOnlySpan<char> remaining, char separator)
+    {
+        var separatorIndex = remaining.IndexOf(separator);
+        if (separatorIndex < 0)
+        {
+            var segment = remaining;
+            remaining = [];
+            return segment;
+        }
+
+        var result = remaining.Slice(0, separatorIndex);
+        remaining = remaining.Slice(separatorIndex + 1);
+        return result;
+    }
+
+    private static string DecodeIfNeeded(ReadOnlySpan<char> value) =>
+        value.IndexOfAny('%', '+') < 0 ? value.ToString() : WebUtility.UrlDecode(value.ToString());
 }

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NET
+#if NET9_0_OR_GREATER
+using System.Buffers;
+#endif
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Net;
@@ -19,6 +22,10 @@ public class BaggagePropagator : TextMapPropagator
 
     private const int MaxBaggageLength = 8192;
     private const int MaxBaggageItems = 180;
+
+#if NET9_0_OR_GREATER
+    private static readonly SearchValues<char> DecodeHints = SearchValues.Create('%', '+');
+#endif
 
     /// <inheritdoc/>
     public override ISet<string> Fields => new HashSet<string> { BaggageHeaderName };
@@ -208,5 +215,9 @@ public class BaggagePropagator : TextMapPropagator
     }
 
     private static string DecodeIfNeeded(ReadOnlySpan<char> value) =>
+#if NET9_0_OR_GREATER
+        value.ContainsAny(DecodeHints) ? WebUtility.UrlDecode(value.ToString()) : value.ToString();
+#else
         value.IndexOfAny('%', '+') < 0 ? value.ToString() : WebUtility.UrlDecode(value.ToString());
+#endif
 }

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -104,11 +104,35 @@ public class BaggagePropagator : TextMapPropagator
                     continue;
                 }
 
-                baggage.Append(WebUtility.UrlEncode(item.Key)).Append('=').Append(WebUtility.UrlEncode(item.Value)).Append(',');
+                var encodedKey = WebUtility.UrlEncode(item.Key);
+                var encodedValue = WebUtility.UrlEncode(item.Value);
+                var baggageItemLength = encodedKey.Length + encodedValue.Length + 1;
+
+                if (baggage.Length > 0)
+                {
+                    baggageItemLength++;
+                }
+
+                if (baggage.Length + baggageItemLength > MaxBaggageLength)
+                {
+                    break;
+                }
+
+                if (baggage.Length > 0)
+                {
+                    baggage.Append(',');
+                }
+
+                baggage.Append(encodedKey)
+                       .Append('=')
+                       .Append(encodedValue);
             }
-            while (e.MoveNext() && ++itemCount < MaxBaggageItems && baggage.Length < MaxBaggageLength);
-            baggage.Remove(baggage.Length - 1, 1);
-            setter(carrier, BaggageHeaderName, baggage.ToString());
+            while (e.MoveNext() && ++itemCount < MaxBaggageItems);
+
+            if (baggage.Length > 0)
+            {
+                setter(carrier, BaggageHeaderName, baggage.ToString());
+            }
         }
     }
 

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -125,7 +125,15 @@ public class TraceContextPropagator : TextMapPropagator
         var tracestateStr = context.ActivityContext.TraceState;
         if (tracestateStr?.Length > 0)
         {
-            setter(carrier, TraceState, tracestateStr);
+            var tracestateEntries = new List<KeyValuePair<string, string>>();
+            if (TraceStateUtils.AppendTraceState(tracestateStr, tracestateEntries))
+            {
+                var normalizedTraceState = TraceStateUtils.GetString(tracestateEntries);
+                if (normalizedTraceState.Length > 0)
+                {
+                    setter(carrier, TraceState, normalizedTraceState);
+                }
+            }
         }
     }
 

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using System.Text;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Context.Propagation;
@@ -15,6 +14,8 @@ internal static class TraceStateUtils
     private const int KeyMaxSize = 256;
     private const int ValueMaxSize = 256;
     private const int MaxKeyValuePairsCount = 32;
+    private const int MaxTraceStateLength = 512;
+    private const int LargeEntryLength = 128;
 
     /// <summary>
     /// Extracts tracestate pairs from the given string and appends it to provided tracestate list.
@@ -106,37 +107,57 @@ internal static class TraceStateUtils
 
     internal static string GetString(IEnumerable<KeyValuePair<string, string>>? traceState)
     {
-#pragma warning disable CA1851 // Possible multiple enumerations of 'IEnumerable' collection
-        if (traceState == null || !traceState.Any())
+        if (traceState == null)
         {
             return string.Empty;
         }
 
-        // it's supposedly cheaper to iterate over very short collection a couple of times
-        // than to convert it to array.
-        var pairsCount = traceState.Count();
+        var entries = new List<string>();
+        var pairsCount = 0;
+        foreach (var entry in traceState)
+        {
+            pairsCount++;
+            if (entries.Count < MaxKeyValuePairsCount)
+            {
+                // Take the first MaxKeyValuePairsCount pairs and ignore older pairs after that.
+                entries.Add(string.Concat(entry.Key, "=", entry.Value));
+            }
+        }
+
+        if (entries.Count == 0)
+        {
+            return string.Empty;
+        }
+
         if (pairsCount > MaxKeyValuePairsCount)
         {
             OpenTelemetryApiEventSource.Log.TooManyItemsInTracestate();
         }
 
-        var sb = new StringBuilder();
+        TruncateEntries(entries);
 
-        var ind = 0;
-        foreach (var entry in traceState)
+        return string.Join(",", entries);
+    }
+
+    private static void TruncateEntries(List<string> entries)
+    {
+        if (GetCombinedLength(entries) <= MaxTraceStateLength)
         {
-            if (ind++ < MaxKeyValuePairsCount)
+            return;
+        }
+
+        for (var i = entries.Count - 1; i >= 0 && GetCombinedLength(entries) > MaxTraceStateLength; i--)
+        {
+            if (entries[i].Length > LargeEntryLength)
             {
-                // take last MaxKeyValuePairsCount pairs, ignore last (oldest) pairs
-                sb.Append(entry.Key)
-                    .Append('=')
-                    .Append(entry.Value)
-                    .Append(',');
+                entries.RemoveAt(i);
             }
         }
-#pragma warning restore CA1851 // Possible multiple enumerations of 'IEnumerable' collection
 
-        return sb.Remove(sb.Length - 1, 1).ToString();
+        while (entries.Count > 0 && GetCombinedLength(entries) > MaxTraceStateLength)
+        {
+            entries.RemoveAt(entries.Count - 1);
+        }
     }
 
     private static bool TryParseKeyValue(ReadOnlySpan<char> pair, out ReadOnlySpan<char> key, out ReadOnlySpan<char> value)
@@ -258,5 +279,22 @@ internal static class TraceStateUtils
         }
 
         return true;
+    }
+
+    private static int GetCombinedLength(List<string> entries)
+    {
+        var combinedLength = 0;
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (i > 0)
+            {
+                combinedLength++;
+            }
+
+            combinedLength += entries[i].Length;
+        }
+
+        return combinedLength;
     }
 }

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -253,8 +253,8 @@ public sealed class B3Propagator : TextMapPropagator
 
         spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
 
-        if (IsSampledValue(traceFlagsStr)
-            || traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))
+        if (IsSampledValue(traceFlagsStr) ||
+            traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))
         {
             traceOptions |= ActivityTraceFlags.Recorded;
         }
@@ -262,9 +262,9 @@ public sealed class B3Propagator : TextMapPropagator
         return true;
     }
 
-    private static bool IsSampledValue(ReadOnlySpan<char> value)
-        => value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal)
-            || value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
+    private static bool IsSampledValue(ReadOnlySpan<char> value) =>
+       value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal) ||
+       value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
 
     private static string ReadNextPart(string header, ref int position)
     {

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -220,38 +220,36 @@ public sealed class B3Propagator : TextMapPropagator
         spanId = default;
         traceOptions = ActivityTraceFlags.None;
 
+        var headerValue = header.AsSpan();
         var position = 0;
-        var traceIdStr = ReadNextPart(header, ref position);
-        if (position >= header.Length || traceIdStr.Length == 0)
+        var traceIdStr = ReadNextPart(headerValue, position, out position);
+        if (position >= headerValue.Length || traceIdStr.IsEmpty)
         {
             return false;
         }
 
-        var spanIdStr = ReadNextPart(header, ref position);
-        if (spanIdStr.Length == 0)
+        var spanIdStr = ReadNextPart(headerValue, position, out position);
+        if (spanIdStr.IsEmpty)
         {
             return false;
         }
 
         ReadOnlySpan<char> traceFlagsStr = default;
-        if (position < header.Length)
+        if (position < headerValue.Length)
         {
-            traceFlagsStr = ReadNextPart(header, ref position);
-            if (position < header.Length)
+            traceFlagsStr = ReadNextPart(headerValue, position, out position);
+            if (position < headerValue.Length)
             {
-                _ = ReadNextPart(header, ref position);
-                if (position < header.Length)
+                _ = ReadNextPart(headerValue, position, out position);
+                if (position < headerValue.Length)
                 {
                     return false;
                 }
             }
         }
 
-        traceId = traceIdStr.Length == 16
-            ? ActivityTraceId.CreateFromString(string.Concat(UpperTraceId, traceIdStr).AsSpan())
-            : ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
-
-        spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+        traceId = CreateTraceId(traceIdStr);
+        spanId = ActivitySpanId.CreateFromString(spanIdStr);
 
         if (IsSampledValue(traceFlagsStr) ||
             traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))
@@ -263,21 +261,37 @@ public sealed class B3Propagator : TextMapPropagator
     }
 
     private static bool IsSampledValue(ReadOnlySpan<char> value) =>
-       value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal) ||
-       value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
+        value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal) ||
+        value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
 
-    private static string ReadNextPart(string header, ref int position)
+    private static ActivityTraceId CreateTraceId(ReadOnlySpan<char> traceId)
     {
-        var separatorIndex = header.IndexOf(XB3CombinedDelimiter, position);
+        if (traceId.Length == 16)
+        {
+            Span<char> fullTraceId = stackalloc char[UpperTraceId.Length + 16];
+
+            UpperTraceId.AsSpan().CopyTo(fullTraceId);
+            traceId.CopyTo(fullTraceId.Slice(UpperTraceId.Length));
+
+            return ActivityTraceId.CreateFromString(fullTraceId);
+        }
+
+        return ActivityTraceId.CreateFromString(traceId);
+    }
+
+    private static ReadOnlySpan<char> ReadNextPart(ReadOnlySpan<char> header, int position, out int nextPosition)
+    {
+        var remaining = header.Slice(position);
+        var separatorIndex = remaining.IndexOf(XB3CombinedDelimiter);
         if (separatorIndex < 0)
         {
-            var part = header.Substring(position);
-            position = header.Length;
+            nextPosition = header.Length;
+            var part = remaining;
             return part;
         }
 
-        var result = header.Substring(position, separatorIndex - position);
-        position = separatorIndex + 1;
+        var result = remaining.Slice(0, separatorIndex);
+        nextPosition = position + separatorIndex + 1;
         return result;
     }
 }

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -195,58 +195,89 @@ public sealed class B3Propagator : TextMapPropagator
 
             var header = headers.FirstOrDefault();
 
-            if (string.IsNullOrWhiteSpace(header))
-            {
-                return context;
-            }
-
-            var parts = header.Split(XB3CombinedDelimiter);
-            if (parts.Length is < 2 or > 4)
-            {
-                return context;
-            }
-
-            var traceIdStr = parts[0];
-            if (string.IsNullOrWhiteSpace(traceIdStr))
-            {
-                return context;
-            }
-
-            if (traceIdStr.Length == 16)
-            {
-                // This is an 8-byte traceID.
-                traceIdStr = UpperTraceId + traceIdStr;
-            }
-
-            var traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
-
-            var spanIdStr = parts[1];
-            if (string.IsNullOrWhiteSpace(spanIdStr))
-            {
-                return context;
-            }
-
-            var spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
-
-            var traceOptions = ActivityTraceFlags.None;
-            if (parts.Length > 2)
-            {
-                var traceFlagsStr = parts[2];
-                if (SampledValues.Contains(traceFlagsStr)
-                    || FlagsValue.Equals(traceFlagsStr, StringComparison.Ordinal))
-                {
-                    traceOptions |= ActivityTraceFlags.Recorded;
-                }
-            }
-
-            return new PropagationContext(
-                new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
-                context.Baggage);
+            return string.IsNullOrWhiteSpace(header)
+                ? context
+                : !TryExtractSingleHeaderContext(header, out var traceId, out var spanId, out var traceOptions)
+                ? context
+                : new PropagationContext(
+                    new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
+                    context.Baggage);
         }
         catch (Exception e)
         {
             OpenTelemetryPropagatorsEventSource.Log.ActivityContextExtractException(nameof(B3Propagator), e);
             return context;
         }
+    }
+
+    private static bool TryExtractSingleHeaderContext(
+        string header,
+        out ActivityTraceId traceId,
+        out ActivitySpanId spanId,
+        out ActivityTraceFlags traceOptions)
+    {
+        traceId = default;
+        spanId = default;
+        traceOptions = ActivityTraceFlags.None;
+
+        var position = 0;
+        var traceIdStr = ReadNextPart(header, ref position);
+        if (position >= header.Length || traceIdStr.Length == 0)
+        {
+            return false;
+        }
+
+        var spanIdStr = ReadNextPart(header, ref position);
+        if (spanIdStr.Length == 0)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> traceFlagsStr = default;
+        if (position < header.Length)
+        {
+            traceFlagsStr = ReadNextPart(header, ref position);
+            if (position < header.Length)
+            {
+                _ = ReadNextPart(header, ref position);
+                if (position < header.Length)
+                {
+                    return false;
+                }
+            }
+        }
+
+        traceId = traceIdStr.Length == 16
+            ? ActivityTraceId.CreateFromString(string.Concat(UpperTraceId, traceIdStr).AsSpan())
+            : ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+
+        spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+
+        if (IsSampledValue(traceFlagsStr)
+            || traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))
+        {
+            traceOptions |= ActivityTraceFlags.Recorded;
+        }
+
+        return true;
+    }
+
+    private static bool IsSampledValue(ReadOnlySpan<char> value)
+        => value.Equals(SampledValue.AsSpan(), StringComparison.Ordinal)
+            || value.Equals(LegacySampledValue.AsSpan(), StringComparison.Ordinal);
+
+    private static string ReadNextPart(string header, ref int position)
+    {
+        var separatorIndex = header.IndexOf(XB3CombinedDelimiter, position);
+        if (separatorIndex < 0)
+        {
+            var part = header.Substring(position);
+            position = header.Length;
+            return part;
+        }
+
+        var result = header.Substring(position, separatorIndex - position);
+        position = separatorIndex + 1;
+        return result;
     }
 }

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -6,6 +6,9 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Improve efficiency of parsing of baggage, B3 and Jaeger propagation headers.
+  ([#7061](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7061))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -71,14 +71,11 @@ public class JaegerPropagator : TextMapPropagator
 
             var jaegerHeaderParsed = TryExtractTraceContext(jaegerHeader, out var traceId, out var spanId, out var traceOptions);
 
-            if (!jaegerHeaderParsed)
-            {
-                return context;
-            }
-
-            return new PropagationContext(
-                new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
-                context.Baggage);
+            return !jaegerHeaderParsed
+                ? context
+                : new PropagationContext(
+                    new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
+                    context.Baggage);
         }
         catch (Exception ex)
         {
@@ -147,13 +144,20 @@ public class JaegerPropagator : TextMapPropagator
             return false;
         }
 
-        var traceComponents = jaegerHeader.Split(JaegerDelimiters, StringSplitOptions.RemoveEmptyEntries);
-        if (traceComponents.Length != 4)
+#if NET
+        var headerValue = jaegerHeader;
+#else
+        var headerValue = jaegerHeader!;
+#endif
+        if (!TryExtractTraceParts(
+                headerValue,
+                out var traceIdStr,
+                out var spanIdStr,
+                out var traceFlagsStr))
         {
             return false;
         }
 
-        var traceIdStr = traceComponents[0];
         if (traceIdStr.Length < TraceId128BitLength)
         {
             traceIdStr = traceIdStr.PadLeft(TraceId128BitLength, '0');
@@ -161,7 +165,6 @@ public class JaegerPropagator : TextMapPropagator
 
         traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
 
-        var spanIdStr = traceComponents[1];
         if (spanIdStr.Length < SpanIdLength)
         {
             spanIdStr = spanIdStr.PadLeft(SpanIdLength, '0');
@@ -169,12 +172,96 @@ public class JaegerPropagator : TextMapPropagator
 
         spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
 
-        var traceFlagsStr = traceComponents[3];
         if (SampledValue.Equals(traceFlagsStr, StringComparison.Ordinal))
         {
             traceOptions |= ActivityTraceFlags.Recorded;
         }
 
         return true;
+    }
+
+    private static bool TryExtractTraceParts(
+        string jaegerHeader,
+        out string traceId,
+        out string spanId,
+        out string traceFlags)
+    {
+        traceId = string.Empty;
+        spanId = string.Empty;
+        traceFlags = string.Empty;
+
+        var position = 0;
+        var componentCount = 0;
+
+        while (position <= jaegerHeader.Length)
+        {
+            var component = ReadNextComponent(jaegerHeader, ref position);
+            if (component.IsEmpty)
+            {
+                if (position >= jaegerHeader.Length)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            switch (componentCount)
+            {
+                case 0:
+                    traceId = component.ToString();
+                    break;
+                case 1:
+                    spanId = component.ToString();
+                    break;
+                case 2:
+                    break;
+                case 3:
+                    traceFlags = component.ToString();
+                    break;
+                default:
+                    return false;
+            }
+
+            componentCount++;
+
+            if (position >= jaegerHeader.Length)
+            {
+                break;
+            }
+        }
+
+        return componentCount == 4;
+    }
+
+    private static ReadOnlySpan<char> ReadNextComponent(string header, ref int position)
+    {
+        var colonIndex = header.IndexOf(JaegerDelimiter, position, StringComparison.Ordinal);
+        var encodedIndex = header.IndexOf(JaegerDelimiterEncoded, position, StringComparison.Ordinal);
+
+        var nextIndex = -1;
+        var delimiterLength = 0;
+
+        if (colonIndex >= 0 && (encodedIndex < 0 || colonIndex < encodedIndex))
+        {
+            nextIndex = colonIndex;
+            delimiterLength = JaegerDelimiter.Length;
+        }
+        else if (encodedIndex >= 0)
+        {
+            nextIndex = encodedIndex;
+            delimiterLength = JaegerDelimiterEncoded.Length;
+        }
+
+        if (nextIndex < 0)
+        {
+            var result = header.AsSpan(position);
+            position = header.Length;
+            return result;
+        }
+
+        var component = header.AsSpan(position, nextIndex - position);
+        position = nextIndex + delimiterLength;
+        return component;
     }
 }

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -211,14 +211,18 @@ public class JaegerPropagator : TextMapPropagator
                 case 0:
                     traceId = component.ToString();
                     break;
+
                 case 1:
                     spanId = component.ToString();
                     break;
+
                 case 2:
                     break;
+
                 case 3:
                     traceFlags = component.ToString();
                     break;
+
                 default:
                     return false;
             }

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" Aliases="OpenTelemetryProtocol" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj" Aliases="Zipkin" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\OpenTelemetry.Exporter.Prometheus.HttpListener.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Propagators\OpenTelemetry.Extensions.Propagators.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Benchmarks/Context/Propagation/B3PropagatorBenchmarks.cs
+++ b/test/Benchmarks/Context/Propagation/B3PropagatorBenchmarks.cs
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry.Context.Propagation;
+using ApiB3Propagator = OpenTelemetry.Context.Propagation.B3Propagator;
+using ExtensionsB3Propagator = OpenTelemetry.Extensions.Propagators.B3Propagator;
+
+namespace Benchmarks.Context.Propagation;
+
+[MemoryDiagnoser]
+[Obsolete("Intentional coverage for obsolete API.")]
+public class B3PropagatorBenchmarks
+{
+    private const string TraceIdBase16 = "ff000000000000000000000000000041";
+    private const string SpanIdBase16 = "ff00000000000041";
+    private const string B3TraceId = "X-B3-TraceId";
+    private const string B3SpanId = "X-B3-SpanId";
+    private const string B3Sampled = "X-B3-Sampled";
+    private const string B3Combined = "b3";
+    private const string SampledValue = "1";
+
+    private static readonly ActivityTraceId TraceId = ActivityTraceId.CreateFromString(TraceIdBase16.AsSpan());
+    private static readonly ActivitySpanId SpanId = ActivitySpanId.CreateFromString(SpanIdBase16.AsSpan());
+
+    private static readonly ApiB3Propagator ApiMultiHeaderPropagator = new();
+    private static readonly ApiB3Propagator ApiSingleHeaderPropagator = new(true);
+    private static readonly ExtensionsB3Propagator ExtensionsMultiHeaderPropagator = new();
+    private static readonly ExtensionsB3Propagator ExtensionsSingleHeaderPropagator = new(true);
+
+    private static readonly Func<Dictionary<string, string>, string, IEnumerable<string>> Getter =
+        static (carrier, name) => carrier.TryGetValue(name, out var value) ? [value] : [];
+
+    private static readonly Action<Dictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
+
+    [Params(false, true)]
+    public bool SingleHeader { get; set; }
+
+    [Params(false, true)]
+    public bool Sampled { get; set; }
+
+    public Dictionary<string, string> ExtractCarrier { get; private set; } = [];
+
+    public Dictionary<string, string> ApiInjectCarrier { get; private set; } = [];
+
+    public Dictionary<string, string> ExtensionsInjectCarrier { get; private set; } = [];
+
+    public PropagationContext InjectContext { get; private set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.ExtractCarrier = this.CreateExtractCarrier();
+        this.InjectContext = new PropagationContext(
+            new ActivityContext(
+                TraceId,
+                SpanId,
+                this.Sampled ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None),
+            default);
+
+        this.ApiInjectCarrier = [];
+        this.ExtensionsInjectCarrier = [];
+    }
+
+    [Benchmark(Baseline = true)]
+    public PropagationContext ApiExtract() =>
+        this.GetApiPropagator().Extract(default, this.ExtractCarrier, Getter);
+
+    [Benchmark]
+    public PropagationContext ExtensionsExtract() =>
+        this.GetExtensionsPropagator().Extract(default, this.ExtractCarrier, Getter);
+
+    [Benchmark]
+    public void ApiInject()
+    {
+        this.ApiInjectCarrier.Clear();
+        this.GetApiPropagator().Inject(this.InjectContext, this.ApiInjectCarrier, Setter);
+    }
+
+    [Benchmark]
+    public void ExtensionsInject()
+    {
+        this.ExtensionsInjectCarrier.Clear();
+        this.GetExtensionsPropagator().Inject(this.InjectContext, this.ExtensionsInjectCarrier, Setter);
+    }
+
+    private static Dictionary<string, string> CreateMultiHeaderCarrier(bool sampled)
+    {
+        var carrier = new Dictionary<string, string>
+        {
+            [B3TraceId] = TraceIdBase16,
+            [B3SpanId] = SpanIdBase16,
+        };
+
+        if (sampled)
+        {
+            carrier[B3Sampled] = SampledValue;
+        }
+
+        return carrier;
+    }
+
+    private static Dictionary<string, string> CreateSingleHeaderCarrier(bool sampled) =>
+        new()
+        {
+            [B3Combined] = sampled
+                ? $"{TraceIdBase16}-{SpanIdBase16}-{SampledValue}"
+                : $"{TraceIdBase16}-{SpanIdBase16}",
+        };
+
+    private Dictionary<string, string> CreateExtractCarrier() =>
+        this.SingleHeader
+            ? CreateSingleHeaderCarrier(this.Sampled)
+            : CreateMultiHeaderCarrier(this.Sampled);
+
+    private ApiB3Propagator GetApiPropagator() =>
+        this.SingleHeader ? ApiSingleHeaderPropagator : ApiMultiHeaderPropagator;
+
+    private ExtensionsB3Propagator GetExtensionsPropagator() =>
+        this.SingleHeader ? ExtensionsSingleHeaderPropagator : ExtensionsMultiHeaderPropagator;
+}

--- a/test/Benchmarks/Context/Propagation/JaegerPropagatorBenchmarks.cs
+++ b/test/Benchmarks/Context/Propagation/JaegerPropagatorBenchmarks.cs
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Extensions.Propagators;
+
+namespace Benchmarks.Context.Propagation;
+
+[MemoryDiagnoser]
+[Obsolete("Intentional coverage for obsolete API.")]
+public class JaegerPropagatorBenchmarks
+{
+    private const string TraceIdBase16 = "0007651916cd43dd8448eb211c803177";
+    private const string SpanIdBase16 = "0007c989f9791877";
+    private const string ParentSpanId = "0";
+    private const string JaegerHeader = "uber-trace-id";
+    private const string JaegerDelimiter = ":";
+    private const string JaegerDelimiterEncoded = "%3A";
+    private const string SampledValue = "1";
+
+    private static readonly ActivityTraceId TraceId = ActivityTraceId.CreateFromString(TraceIdBase16.AsSpan());
+    private static readonly ActivitySpanId SpanId = ActivitySpanId.CreateFromString(SpanIdBase16.AsSpan());
+    private static readonly JaegerPropagator Propagator = new();
+
+    private static readonly Func<Dictionary<string, string[]>, string, IEnumerable<string>> Getter =
+        static (carrier, name) => carrier.TryGetValue(name, out var values) ? values : [];
+
+    private static readonly Action<Dictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
+
+    [Params(false, true)]
+    public bool Sampled { get; set; }
+
+    [Params(false, true)]
+    public bool UseEncodedDelimiter { get; set; }
+
+    public Dictionary<string, string[]> ExtractCarrier { get; private set; } = [];
+
+    public Dictionary<string, string> InjectCarrier { get; private set; } = [];
+
+    public PropagationContext InjectContext { get; private set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var delimiter = this.UseEncodedDelimiter
+            ? JaegerDelimiterEncoded
+            : JaegerDelimiter;
+        var flags = this.Sampled ? SampledValue : "0";
+        var headerValue = string.Join(delimiter, TraceIdBase16, SpanIdBase16, ParentSpanId, flags);
+
+        this.ExtractCarrier = new Dictionary<string, string[]>
+        {
+            [JaegerHeader] = [headerValue],
+        };
+
+        this.InjectContext = new PropagationContext(
+            new ActivityContext(
+                TraceId,
+                SpanId,
+                this.Sampled ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None),
+            default);
+
+        this.InjectCarrier = [];
+    }
+
+    [Benchmark(Baseline = true)]
+    public PropagationContext Extract() =>
+        Propagator.Extract(default, this.ExtractCarrier, Getter);
+
+    [Benchmark]
+    public void Inject()
+    {
+        this.InjectCarrier.Clear();
+        Propagator.Inject(this.InjectContext, this.InjectCarrier, Setter);
+    }
+}

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/B3PropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/B3PropagatorFuzzTests.cs
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using OpenTelemetry.Context.Propagation;
+
+namespace OpenTelemetry.Api.FuzzTests;
+
+[Obsolete("B3Propagator is obsolete but intentionally fuzz tested.")]
+public class B3PropagatorFuzzTests
+{
+    private const int MaxTests = 200;
+
+    private const string CombinedHeader = "b3";
+    private const string TraceIdHeader = "X-B3-TraceId";
+    private const string SpanIdHeader = "X-B3-SpanId";
+    private const string SampledHeader = "X-B3-Sampled";
+
+    [Property(MaxTest = MaxTests)]
+    public Property MultipleHeaderInjectExtractRoundTripPreservesTraceContext() => Prop.ForAll(Generators.ActivityContextArbitrary(), (activityContext) =>
+    {
+        try
+        {
+            var propagator = new B3Propagator();
+            var carrier = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            propagator.Inject(new PropagationContext(activityContext, default), carrier, FuzzTestHelpers.Setter);
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.Getter);
+
+            return
+                carrier.TryGetValue(TraceIdHeader, out var traceId) &&
+                carrier.TryGetValue(SpanIdHeader, out var spanId) &&
+                traceId.Length == 32 &&
+                spanId.Length == 16 &&
+                (!carrier.TryGetValue(SampledHeader, out var sampled) || sampled == "1") &&
+                HaveEquivalentB3State(activityContext, extracted.ActivityContext);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
+    public Property SingleHeaderInjectExtractRoundTripPreservesTraceContext() => Prop.ForAll(Generators.ActivityContextArbitrary(), (activityContext) =>
+    {
+        try
+        {
+            var propagator = new B3Propagator(singleHeader: true);
+            var carrier = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            propagator.Inject(new PropagationContext(activityContext, default), carrier, FuzzTestHelpers.Setter);
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.Getter);
+
+            return
+                carrier.TryGetValue(CombinedHeader, out var headerValue) &&
+                headerValue.Split('-').Length is 2 or 3 &&
+                HaveEquivalentB3State(activityContext, extracted.ActivityContext);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
+    public Property MultipleHeaderExtractIsDeterministicForArbitraryHeaders() => Prop.ForAll(Generators.B3MultipleHeaderCarrierArbitrary(), (carrier) =>
+    {
+        try
+        {
+            var propagator = new B3Propagator();
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var first = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+            var second = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return
+                FuzzTestHelpers.CarriersEqual(original, carrier) &&
+                HaveEquivalentB3State(first.ActivityContext, second.ActivityContext);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
+    public Property SingleHeaderExtractIsDeterministicForArbitraryHeaders() => Prop.ForAll(Generators.B3SingleHeaderCarrierArbitrary(), (carrier) =>
+    {
+        try
+        {
+            var propagator = new B3Propagator(singleHeader: true);
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var first = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+            var second = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return
+                FuzzTestHelpers.CarriersEqual(original, carrier) &&
+                HaveEquivalentB3State(first.ActivityContext, second.ActivityContext);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    private static bool HaveEquivalentB3State(ActivityContext expected, ActivityContext actual) =>
+        expected.TraceId == actual.TraceId &&
+        expected.SpanId == actual.SpanId &&
+        expected.TraceFlags == actual.TraceFlags;
+}

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/B3PropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/B3PropagatorFuzzTests.cs
@@ -13,6 +13,7 @@ namespace OpenTelemetry.Api.FuzzTests;
 public class B3PropagatorFuzzTests
 {
     private const int MaxTests = 200;
+    private const int DelimiterFloodTests = 25;
 
     private const string CombinedHeader = "b3";
     private const string TraceIdHeader = "X-B3-TraceId";
@@ -103,6 +104,28 @@ public class B3PropagatorFuzzTests
             return
                 FuzzTestHelpers.CarriersEqual(original, carrier) &&
                 HaveEquivalentB3State(first.ActivityContext, second.ActivityContext);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = DelimiterFloodTests)]
+    public Property SingleHeaderDelimiterFloodReturnsDefault() => Prop.ForAll(Generators.DelimiterFloodArbitrary('-'), (headerValue) =>
+    {
+        try
+        {
+            var propagator = new B3Propagator(singleHeader: true);
+            var carrier = new Dictionary<string, string[]>(StringComparer.Ordinal)
+            {
+                [CombinedHeader] = [headerValue],
+            };
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return extracted.Equals(default) && FuzzTestHelpers.CarriersEqual(original, carrier);
         }
         catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
         {

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/BaggagePropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/BaggagePropagatorFuzzTests.cs
@@ -1,0 +1,82 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using OpenTelemetry.Context.Propagation;
+
+namespace OpenTelemetry.Api.FuzzTests;
+
+public class BaggagePropagatorFuzzTests
+{
+    private const string BaggageHeader = "baggage";
+    private const int MaxTests = 200;
+
+    [Property(MaxTest = MaxTests)]
+    public Property InjectExtractRoundTripPreservesSafeBaggage() => Prop.ForAll(Generators.SafeBaggageDictionaryArbitrary(), (baggageItems) =>
+    {
+        try
+        {
+            var propagator = new BaggagePropagator();
+            var carrier = new Dictionary<string, string>(StringComparer.Ordinal);
+            var propagationContext = new PropagationContext(default, Baggage.Create(baggageItems));
+
+            propagator.Inject(propagationContext, carrier, FuzzTestHelpers.Setter);
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.Getter);
+
+            return DictionariesEqual(baggageItems, extracted.Baggage.GetBaggage());
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
+    public Property InjectedHeadersStayWithinConfiguredLimits() => Prop.ForAll(Generators.BaggageDictionaryArbitrary(), (baggageItems) =>
+    {
+        try
+        {
+            var propagator = new BaggagePropagator();
+            var carrier = new Dictionary<string, string>(StringComparer.Ordinal);
+            var propagationContext = new PropagationContext(default, Baggage.Create(baggageItems));
+
+            propagator.Inject(propagationContext, carrier, FuzzTestHelpers.Setter);
+
+            return
+                !carrier.TryGetValue(BaggageHeader, out var headerValue) ||
+                (headerValue.Length <= 8192 && headerValue.Split(',').Length <= 180);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
+    public Property ExtractIsDeterministicForArbitraryHeaders() => Prop.ForAll(Generators.BaggageCarrierArbitrary(), (carrier) =>
+    {
+        try
+        {
+            var propagator = new BaggagePropagator();
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var first = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+            var second = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return
+                FuzzTestHelpers.CarriersEqual(original, carrier) &&
+                DictionariesEqual(first.Baggage.GetBaggage(), second.Baggage.GetBaggage());
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    private static bool DictionariesEqual(IReadOnlyDictionary<string, string> expected, IReadOnlyDictionary<string, string> actual) =>
+        expected.Count == actual.Count &&
+        expected.All(pair => actual.TryGetValue(pair.Key, out var value) && value == pair.Value);
+}

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/BaggagePropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/BaggagePropagatorFuzzTests.cs
@@ -12,6 +12,8 @@ public class BaggagePropagatorFuzzTests
 {
     private const string BaggageHeader = "baggage";
     private const int MaxTests = 200;
+    private const int MaxBaggageLength = 8192;
+    private const int MaxBaggageItems = 180;
 
     [Property(MaxTest = MaxTests)]
     public Property InjectExtractRoundTripPreservesSafeBaggage() => Prop.ForAll(Generators.SafeBaggageDictionaryArbitrary(), (baggageItems) =>
@@ -76,7 +78,49 @@ public class BaggagePropagatorFuzzTests
         }
     });
 
+    [Property(MaxTest = MaxTests)]
+    public Property OversizedExtractionHonorsConfiguredLimits() => Prop.ForAll(Generators.OversizedBaggageValuesArbitrary(), (values) =>
+    {
+        try
+        {
+            var propagator = new BaggagePropagator();
+            var carrier = new Dictionary<string, string[]>(StringComparer.Ordinal)
+            {
+                [BaggageHeader] = [string.Join(",", values.Select((value, index) => $"k{index:D4}={value}"))],
+            };
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return DictionariesEqual(ExpectedBaggageForOversizedHeader(values), extracted.Baggage.GetBaggage());
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
     private static bool DictionariesEqual(IReadOnlyDictionary<string, string> expected, IReadOnlyDictionary<string, string> actual) =>
         expected.Count == actual.Count &&
         expected.All(pair => actual.TryGetValue(pair.Key, out var value) && value == pair.Value);
+
+    private static Dictionary<string, string> ExpectedBaggageForOversizedHeader(string[] values)
+    {
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal);
+        var baggageLength = -1;
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var key = $"k{i:D4}";
+            baggageLength += key.Length + values[i].Length + 2; // key, equals sign, value, and comma.
+
+            if (baggageLength >= MaxBaggageLength || expected.Count >= MaxBaggageItems)
+            {
+                break;
+            }
+
+            expected[key] = values[i];
+        }
+
+        return expected;
+    }
 }

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/BaggagePropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/BaggagePropagatorFuzzTests.cs
@@ -79,6 +79,27 @@ public class BaggagePropagatorFuzzTests
     });
 
     [Property(MaxTest = MaxTests)]
+    public Property ExtractMatchesReplayableGetterForSinglePassEnumerables() => Prop.ForAll(Generators.BaggageCarrierArbitrary(), (carrier) =>
+    {
+        try
+        {
+            var propagator = new BaggagePropagator();
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var replayable = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+            var singlePass = propagator.Extract(default, carrier, FuzzTestHelpers.SinglePassArrayGetter);
+
+            return
+                FuzzTestHelpers.CarriersEqual(original, carrier) &&
+                DictionariesEqual(replayable.Baggage.GetBaggage(), singlePass.Baggage.GetBaggage());
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
     public Property OversizedExtractionHonorsConfiguredLimits() => Prop.ForAll(Generators.OversizedBaggageValuesArbitrary(), (values) =>
     {
         try

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/FuzzTestHelpers.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/FuzzTestHelpers.cs
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Api.FuzzTests;
+
+internal static class FuzzTestHelpers
+{
+    public static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter =
+        static (carrier, name) => carrier.TryGetValue(name, out var value) ? [value] : [];
+
+    public static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> ArrayGetter =
+        static (carrier, name) => carrier.TryGetValue(name, out var value) ? value : [];
+
+    public static readonly Action<IDictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
+
+    public static Dictionary<string, string[]> CloneCarrier(Dictionary<string, string[]> carrier)
+    {
+        var clone = new Dictionary<string, string[]>(carrier.Count, StringComparer.Ordinal);
+
+        foreach (var pair in carrier)
+        {
+            clone[pair.Key] = [.. pair.Value];
+        }
+
+        return clone;
+    }
+
+    public static bool CarriersEqual(Dictionary<string, string[]> left, Dictionary<string, string[]> right) =>
+        left.Count == right.Count &&
+        left.All(pair => right.TryGetValue(pair.Key, out var value) && pair.Value.SequenceEqual(value));
+
+    public static bool IsAllowedException(Exception ex) => ex is ArgumentException;
+}

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/FuzzTestHelpers.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/FuzzTestHelpers.cs
@@ -11,6 +11,9 @@ internal static class FuzzTestHelpers
     public static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> ArrayGetter =
         static (carrier, name) => carrier.TryGetValue(name, out var value) ? value : [];
 
+    public static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> SinglePassArrayGetter =
+        static (carrier, name) => carrier.TryGetValue(name, out var value) ? EnumerateOnce(value) : [];
+
     public static readonly Action<IDictionary<string, string>, string, string> Setter =
         static (carrier, name, value) => carrier[name] = value;
 
@@ -31,4 +34,12 @@ internal static class FuzzTestHelpers
         left.All(pair => right.TryGetValue(pair.Key, out var value) && pair.Value.SequenceEqual(value));
 
     public static bool IsAllowedException(Exception ex) => ex is ArgumentException;
+
+    private static IEnumerable<string> EnumerateOnce(IEnumerable<string> values)
+    {
+        foreach (var value in values)
+        {
+            yield return value;
+        }
+    }
 }

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
@@ -1,0 +1,217 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace OpenTelemetry.Api.FuzzTests;
+
+internal static class Generators
+{
+    private static readonly Gen<char> LowerAlphaNumericChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz0123456789".ToCharArray());
+    private static readonly Gen<char> TraceStateKeyChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz0123456789_-*/".ToCharArray());
+    private static readonly Gen<char> TraceStateValueChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~:/".ToCharArray());
+    private static readonly Gen<char> BaggageChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_./:!$&'()*+;@?=,".ToCharArray());
+    private static readonly Gen<char> HeaderValueChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=,;: ./@".ToCharArray());
+
+    public static Arbitrary<ActivityContext> ActivityContextArbitrary()
+    {
+        var gen =
+            from traceFlags in Gen.Elements(default, ActivityTraceFlags.Recorded)
+            from traceState in Gen.OneOf(
+                Gen.Constant((string?)null),
+                ValidTraceStateArbitrary().Generator.Select(static value => (string?)value))
+            select new ActivityContext(
+                ActivityTraceId.CreateRandom(),
+                ActivitySpanId.CreateRandom(),
+                traceFlags,
+                traceState);
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<Dictionary<string, string>> SafeBaggageDictionaryArbitrary()
+    {
+        var pairGen =
+            from key in CreateString(BaggageChar, 1, 12)
+            from value in CreateString(BaggageChar, 1, 24)
+            select new KeyValuePair<string, string>(key, value);
+
+        var gen = Gen.Sized(size =>
+        {
+            var maxCount = Math.Min(Math.Max(size + 1, 1), 20);
+
+            return
+                from count in Gen.Choose(0, maxCount)
+                from pairs in Gen.ArrayOf(pairGen, count)
+                select ToDictionary(pairs);
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<Dictionary<string, string>> BaggageDictionaryArbitrary()
+    {
+        var pairGen =
+            from key in CreateString(BaggageChar, 0, 12)
+            from value in CreateString(BaggageChar, 0, 32)
+            select new KeyValuePair<string, string>(key, value);
+
+        var gen = Gen.Sized(size =>
+        {
+            var maxCount = Math.Min(Math.Max(size + 1, 1), 256);
+
+            return
+                from count in Gen.Choose(0, maxCount)
+                from pairs in Gen.ArrayOf(pairGen, count)
+                select ToDictionary(pairs);
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<Dictionary<string, string[]>> TraceContextCarrierArbitrary()
+    {
+        var gen =
+            from includeTraceParent in Gen.Elements(true, false)
+            from includeTraceState in Gen.Elements(true, false)
+            from traceParentValues in HeaderValuesArbitrary(4, 96).Generator
+            from traceStateValues in HeaderValuesArbitrary(4, 256).Generator
+            select CreateCarrier(
+                ("traceparent", includeTraceParent, traceParentValues),
+                ("tracestate", includeTraceState, traceStateValues));
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<Dictionary<string, string[]>> BaggageCarrierArbitrary()
+    {
+        var gen =
+            from includeBaggage in Gen.Elements(true, false)
+            from baggageValues in HeaderValuesArbitrary(6, 512).Generator
+            select CreateCarrier(("baggage", includeBaggage, baggageValues));
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<Dictionary<string, string[]>> B3MultipleHeaderCarrierArbitrary()
+    {
+        var gen =
+            from includeTraceId in Gen.Elements(true, false)
+            from includeSpanId in Gen.Elements(true, false)
+            from includeSampled in Gen.Elements(true, false)
+            from includeFlags in Gen.Elements(true, false)
+            from traceIdValues in HeaderValuesArbitrary(4, 64).Generator
+            from spanIdValues in HeaderValuesArbitrary(4, 32).Generator
+            from sampledValues in HeaderValuesArbitrary(4, 8).Generator
+            from flagsValues in HeaderValuesArbitrary(4, 8).Generator
+            select CreateCarrier(
+                ("X-B3-TraceId", includeTraceId, traceIdValues),
+                ("X-B3-SpanId", includeSpanId, spanIdValues),
+                ("X-B3-Sampled", includeSampled, sampledValues),
+                ("X-B3-Flags", includeFlags, flagsValues));
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<Dictionary<string, string[]>> B3SingleHeaderCarrierArbitrary()
+    {
+        var gen =
+            from includeCombined in Gen.Elements(true, false)
+            from combinedValues in HeaderValuesArbitrary(4, 128).Generator
+            select CreateCarrier(("b3", includeCombined, combinedValues));
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<string> ValidTraceStateArbitrary()
+    {
+        var memberGen =
+            from key in ValidTraceStateKey()
+            from value in CreateString(TraceStateValueChar, 1, 24)
+            select (key, value);
+
+        var gen = Gen.Sized(size =>
+        {
+            var maxCount = Math.Min(Math.Max(size + 1, 1), 16);
+
+            return
+                from count in Gen.Choose(1, maxCount)
+                from members in Gen.ArrayOf(memberGen, count)
+                select string.Join(
+                    ",",
+                    members.Select(static (member, index) => $"{member.key}{index}={member.value}"));
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    private static Arbitrary<string[]> HeaderValuesArbitrary(int maxCount, int maxLength)
+    {
+        var valueGen = CreateString(HeaderValueChar, 0, maxLength);
+        var gen = Gen.Sized(size =>
+        {
+            var count = Math.Min(Math.Max(size + 1, 1), maxCount);
+
+            return
+                from actualCount in Gen.Choose(0, count)
+                from values in Gen.ArrayOf(valueGen, actualCount)
+                select values;
+        });
+
+        return gen.ToArbitrary();
+    }
+
+    private static Gen<string> CreateString(Gen<char> charGen, int minLength, int maxLength) =>
+        from length in Gen.Choose(minLength, maxLength)
+        from chars in Gen.ArrayOf(charGen, length)
+        select new string(chars);
+
+    private static Gen<string> ValidTraceStateKey()
+    {
+        var simpleKey =
+            from length in Gen.Choose(1, 12)
+            from first in LowerAlphaNumericChar
+            from rest in Gen.ArrayOf(TraceStateKeyChar, length - 1)
+            select $"{first}{new string(rest)}";
+
+        var vendorKey =
+            from tenantLength in Gen.Choose(1, 8)
+            from vendorLength in Gen.Choose(1, 6)
+            from tenantFirst in LowerAlphaNumericChar
+            from tenantRest in Gen.ArrayOf(TraceStateKeyChar, tenantLength - 1)
+            from vendorFirst in LowerAlphaNumericChar
+            from vendorRest in Gen.ArrayOf(TraceStateKeyChar, vendorLength - 1)
+            select $"{tenantFirst}{new string(tenantRest)}@{vendorFirst}{new string(vendorRest)}";
+
+        return Gen.OneOf(simpleKey, vendorKey);
+    }
+
+    private static Dictionary<string, string> ToDictionary(IEnumerable<KeyValuePair<string, string>> pairs)
+    {
+        var dictionary = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var pair in pairs)
+        {
+            dictionary[pair.Key] = pair.Value;
+        }
+
+        return dictionary;
+    }
+
+    private static Dictionary<string, string[]> CreateCarrier(params (string Key, bool Include, string[] Values)[] entries)
+    {
+        var carrier = new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+        foreach (var (key, include, values) in entries)
+        {
+            if (include)
+            {
+                carrier[key] = [.. values];
+            }
+        }
+
+        return carrier;
+    }
+}

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
@@ -13,6 +13,7 @@ internal static class Generators
     private static readonly Gen<char> TraceStateKeyChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz0123456789_-*/".ToCharArray());
     private static readonly Gen<char> TraceStateValueChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~:/".ToCharArray());
     private static readonly Gen<char> BaggageChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_./:!$&'()*+;@?=,".ToCharArray());
+    private static readonly Gen<char> CompactBaggageValueChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-".ToCharArray());
     private static readonly Gen<char> HeaderValueChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=,;: ./@".ToCharArray());
 
     public static Arbitrary<ActivityContext> ActivityContextArbitrary()
@@ -95,6 +96,22 @@ internal static class Generators
         return gen.ToArbitrary();
     }
 
+    public static Arbitrary<string[]> OversizedBaggageValuesArbitrary()
+    {
+        var valueGen = CreateString(CompactBaggageValueChar, 1, 64);
+        var gen = Gen.Sized(size =>
+        {
+            var maxCount = Math.Min(Math.Max((size * 4) + 181, 181), 512);
+
+            return
+                from count in Gen.Choose(181, maxCount)
+                from values in Gen.ArrayOf(valueGen, count)
+                select values;
+        });
+
+        return gen.ToArbitrary();
+    }
+
     public static Arbitrary<Dictionary<string, string[]>> B3MultipleHeaderCarrierArbitrary()
     {
         var gen =
@@ -121,6 +138,15 @@ internal static class Generators
             from includeCombined in Gen.Elements(true, false)
             from combinedValues in HeaderValuesArbitrary(4, 128).Generator
             select CreateCarrier(("b3", includeCombined, combinedValues));
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<string> DelimiterFloodArbitrary(char delimiter, int minLength = 1024, int maxLength = 50_000)
+    {
+        var gen =
+            from length in Gen.Choose(minLength, maxLength)
+            select new string(delimiter, length);
 
         return gen.ToArbitrary();
     }

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/TraceContextPropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/TraceContextPropagatorFuzzTests.cs
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using OpenTelemetry.Context.Propagation;
+
+namespace OpenTelemetry.Api.FuzzTests;
+
+public class TraceContextPropagatorFuzzTests
+{
+    private const int MaxTests = 200;
+    private const string TraceParent = "traceparent";
+
+    [Property(MaxTest = MaxTests)]
+    public Property InjectExtractRoundTripPreservesValidContexts() => Prop.ForAll(Generators.ActivityContextArbitrary(), (activityContext) =>
+    {
+        try
+        {
+            var carrier = new Dictionary<string, string>(StringComparer.Ordinal);
+            var propagator = new TraceContextPropagator();
+
+            propagator.Inject(new PropagationContext(activityContext, default), carrier, FuzzTestHelpers.Setter);
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.Getter);
+
+            return
+                carrier.TryGetValue(TraceParent, out var traceParent) &&
+                traceParent is not null &&
+                traceParent.Length == 55 &&
+                AreEquivalent(activityContext, extracted.ActivityContext);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
+    public Property ExtractIsDeterministicForArbitraryHeaders() => Prop.ForAll(Generators.TraceContextCarrierArbitrary(), (carrier) =>
+    {
+        try
+        {
+            var propagator = new TraceContextPropagator();
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var first = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+            var second = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return
+                FuzzTestHelpers.CarriersEqual(original, carrier) &&
+                AreEquivalent(first.ActivityContext, second.ActivityContext);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    [Property(MaxTest = MaxTests)]
+    public Property MultipleInjectionCallsAreConsistent() => Prop.ForAll(Generators.ActivityContextArbitrary(), activityContext =>
+    {
+        try
+        {
+            var propagator = new TraceContextPropagator();
+            var firstCarrier = new Dictionary<string, string>(StringComparer.Ordinal);
+            var secondCarrier = new Dictionary<string, string>(StringComparer.Ordinal);
+            var propagationContext = new PropagationContext(activityContext, default);
+
+            propagator.Inject(propagationContext, firstCarrier, FuzzTestHelpers.Setter);
+            propagator.Inject(propagationContext, secondCarrier, FuzzTestHelpers.Setter);
+
+            return
+                firstCarrier.Count == secondCarrier.Count &&
+                firstCarrier.All(pair => secondCarrier.TryGetValue(pair.Key, out var value) && value == pair.Value);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+
+    private static bool AreEquivalent(ActivityContext expected, ActivityContext actual) =>
+        expected.TraceId == actual.TraceId &&
+        expected.SpanId == actual.SpanId &&
+        expected.TraceFlags == actual.TraceFlags &&
+        expected.TraceState == actual.TraceState;
+}

--- a/test/OpenTelemetry.Api.FuzzTests/OpenTelemetry.Api.FuzzTests.csproj
+++ b/test/OpenTelemetry.Api.FuzzTests/OpenTelemetry.Api.FuzzTests.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsCheck.Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
@@ -352,7 +352,6 @@ public class B3PropagatorTests
             this.b3propagator.Fields,
             [B3Propagator.XB3TraceId, B3Propagator.XB3SpanId, B3Propagator.XB3ParentSpanId, B3Propagator.XB3Sampled, B3Propagator.XB3Flags]);
 
-#if NET
     [Fact]
     public void ParseSingleHeaderWithManyDelimitersReturnsDefault()
     {
@@ -366,7 +365,6 @@ public class B3PropagatorTests
 
         Assert.Equal(default, result);
     }
-#endif
 
     private static void ContainsExactly(ISet<string> list, List<string> items)
     {

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
@@ -20,17 +20,9 @@ public class B3PropagatorTests
     private static readonly ActivityTraceId TraceIdEightBytes = ActivityTraceId.CreateFromString(("0000000000000000" + TraceIdBase16EightBytes).AsSpan());
     private static readonly ActivitySpanId SpanId = ActivitySpanId.CreateFromString(SpanIdBase16.AsSpan());
 
-    private static readonly Action<IDictionary<string, string>, string, string> Setter = (d, k, v) => d[k] = v;
+    private static readonly Action<IDictionary<string, string>, string, string> Setter = static (d, k, v) => d[k] = v;
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter =
-        (d, k) =>
-        {
-            if (d.TryGetValue(k, out var v))
-            {
-                return [v];
-            }
-
-            return [];
-        };
+        static (d, k) => d.TryGetValue(k, out var v) ? [v] : [];
 
     private readonly B3Propagator b3propagator = new();
     private readonly B3Propagator b3PropagatorSingleHeader = new(true);
@@ -355,12 +347,26 @@ public class B3PropagatorTests
     }
 
     [Fact]
-    public void Fields_list()
-    {
+    public void Fields_list() =>
         ContainsExactly(
             this.b3propagator.Fields,
             [B3Propagator.XB3TraceId, B3Propagator.XB3SpanId, B3Propagator.XB3ParentSpanId, B3Propagator.XB3Sampled, B3Propagator.XB3Flags]);
+
+#if NET
+    [Fact]
+    public void ParseSingleHeaderWithManyDelimitersReturnsDefault()
+    {
+        var headerValue = new string('-', 50_000);
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3Combined, headerValue },
+        };
+
+        var result = this.b3PropagatorSingleHeader.Extract(default, headers, Getter);
+
+        Assert.Equal(default, result);
     }
+#endif
 
     private static void ContainsExactly(ISet<string> list, List<string> items)
     {

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
@@ -16,10 +16,8 @@ public class BaggagePropagatorTests
     private static readonly Func<IList<KeyValuePair<string, string>>, string, IEnumerable<string>> GetterList =
         static (d, k) => d.Where(i => i.Key == k).Select(i => i.Value);
 
-    private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
-    {
-        carrier[name] = value;
-    };
+    private static readonly Action<IDictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
 
     private readonly BaggagePropagator baggage = new();
 
@@ -488,6 +486,28 @@ public class BaggagePropagatorTests
         Assert.Single(extractedBaggage);
         Assert.Equal("value=more=equals", extractedBaggage["key"]);
     }
+
+#if NET
+    [Fact]
+    public void ValidateOversizedBaggageExtractionHonorsLimits()
+    {
+        var entries = Enumerable.Range(0, 5000).Select(i => $"k{i:D4}=v");
+        var headerValue = string.Join(",", entries);
+        var carrier = new Dictionary<string, string>
+        {
+            { BaggagePropagator.BaggageHeaderName, headerValue },
+        };
+
+        var propagationContext = this.baggage.Extract(default, carrier, Getter);
+        var baggage = propagationContext.Baggage.GetBaggage();
+
+        Assert.NotEqual(default, propagationContext);
+        Assert.Equal(180, baggage.Count);
+        Assert.Equal("v", baggage["k0000"]);
+        Assert.Equal("v", baggage["k0179"]);
+        Assert.False(baggage.ContainsKey("k0180"));
+    }
+#endif
 
     [Fact(Skip = "Fails due to spec mismatch, tracked in https://github.com/open-telemetry/opentelemetry-dotnet/issues/5210")]
     public void ValidateSpecialCharactersInjection()

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
@@ -9,21 +9,10 @@ namespace OpenTelemetry.Context.Propagation.Tests;
 public class BaggagePropagatorTests
 {
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter =
-        (d, k) =>
-        {
-            if (d.TryGetValue(k, out var v))
-            {
-                return [v];
-            }
-
-            return [];
-        };
+        static (d, k) => d.TryGetValue(k, out var v) ? [v] : [];
 
     private static readonly Func<IList<KeyValuePair<string, string>>, string, IEnumerable<string>> GetterList =
-        (d, k) =>
-        {
-            return d.Where(i => i.Key == k).Select(i => i.Value);
-        };
+        static (d, k) => d.Where(i => i.Key == k).Select(i => i.Value);
 
     private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
     {
@@ -85,9 +74,9 @@ public class BaggagePropagatorTests
     {
         var carrier = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>(BaggagePropagator.BaggageHeaderName, "name1=test1"),
-            new KeyValuePair<string, string>(BaggagePropagator.BaggageHeaderName, "name2=test2"),
-            new KeyValuePair<string, string>(BaggagePropagator.BaggageHeaderName, "name2=test2"),
+            new(BaggagePropagator.BaggageHeaderName, "name1=test1"),
+            new(BaggagePropagator.BaggageHeaderName, "name2=test2"),
+            new(BaggagePropagator.BaggageHeaderName, "name2=test2"),
         };
 
         var propagationContext = this.baggage.Extract(default, carrier, GetterList);
@@ -140,7 +129,7 @@ public class BaggagePropagatorTests
         var initialBaggage = $"key+1=value+1,{encodedKey}={encodedValue},{escapedKey}={escapedValue}";
         var carrier = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>(BaggagePropagator.BaggageHeaderName, initialBaggage),
+            new(BaggagePropagator.BaggageHeaderName, initialBaggage),
         };
 
         var propagationContext = this.baggage.Extract(default, carrier, GetterList);
@@ -376,6 +365,31 @@ public class BaggagePropagatorTests
         var baggageHeader = carrier[BaggagePropagator.BaggageHeaderName];
 
         Assert.Equal(8192, baggageHeader.Length);
+    }
+
+    [Fact]
+    public void ValidateInjectionStopsBeforeExceedingMaximumLength()
+    {
+        var longValue = new string('0', 8187);
+
+        var propagationContext = new PropagationContext(
+            default,
+            new Baggage(new Dictionary<string, string>
+            {
+                ["a"] = longValue,
+                ["b"] = "c",
+            }));
+
+        var carrier = new Dictionary<string, string>();
+
+        this.baggage.Inject(propagationContext, carrier, Setter);
+
+        Assert.Single(carrier);
+
+        var baggageHeader = carrier[BaggagePropagator.BaggageHeaderName];
+
+        Assert.Equal($"a={longValue}", baggageHeader);
+        Assert.True(baggageHeader.Length < 8192);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
@@ -8,6 +8,8 @@ namespace OpenTelemetry.Context.Propagation.Tests;
 
 public class BaggagePropagatorTests
 {
+    const int MaxBaggageLength = 8192;
+
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter =
         static (d, k) => d.TryGetValue(k, out var v) ? [v] : [];
 
@@ -345,7 +347,7 @@ public class BaggagePropagatorTests
     }
 
     [Fact]
-    public void ValidateInjectionOf8192Bytes()
+    public void ValidateInjectionOfMaximumLength()
     {
         var longValue = new string('0', 8190);
 
@@ -364,13 +366,17 @@ public class BaggagePropagatorTests
 
         var baggageHeader = carrier[BaggagePropagator.BaggageHeaderName];
 
-        Assert.Equal(8192, baggageHeader.Length);
+        Assert.Equal(MaxBaggageLength, baggageHeader.Length);
     }
 
-    [Fact]
-    public void ValidateInjectionStopsBeforeExceedingMaximumLength()
+    [Theory]
+    [InlineData(8187)]
+    [InlineData(8188)]
+    [InlineData(8189)]
+    [InlineData(8190)]
+    public void ValidateInjectionStopsBeforeExceedingMaximumLength(int length)
     {
-        var longValue = new string('0', 8187);
+        var longValue = new string('0', length);
 
         var propagationContext = new PropagationContext(
             default,
@@ -384,12 +390,35 @@ public class BaggagePropagatorTests
 
         this.baggage.Inject(propagationContext, carrier, Setter);
 
-        Assert.Single(carrier);
+        var item = Assert.Single(carrier);
 
-        var baggageHeader = carrier[BaggagePropagator.BaggageHeaderName];
+        Assert.Equal(BaggagePropagator.BaggageHeaderName, item.Key);
 
+        var baggageHeader = item.Value;
+        Assert.True(baggageHeader.Length <= MaxBaggageLength, $"Baggage length {baggageHeader.Length} exceeds maximum allowed length of {MaxBaggageLength}");
         Assert.Equal($"a={longValue}", baggageHeader);
-        Assert.True(baggageHeader.Length < 8192);
+    }
+
+    [Theory]
+    [InlineData(8191)]
+    [InlineData(16384)]
+    public void ValidateInjectionDoesNotExceedMaximumLength(int length)
+    {
+        var longValue = new string('0', length);
+
+        var propagationContext = new PropagationContext(
+            default,
+            new Baggage(new Dictionary<string, string>
+            {
+                ["a"] = longValue,
+                ["b"] = "c",
+            }));
+
+        var carrier = new Dictionary<string, string>();
+
+        this.baggage.Inject(propagationContext, carrier, Setter);
+
+        Assert.Empty(carrier);
     }
 
     [Fact]
@@ -412,7 +441,7 @@ public class BaggagePropagatorTests
 
         var baggageHeader = carrier[BaggagePropagator.BaggageHeaderName];
 
-        Assert.True(baggageHeader.Length <= 8192);
+        Assert.True(baggageHeader.Length <= MaxBaggageLength);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
@@ -487,7 +487,6 @@ public class BaggagePropagatorTests
         Assert.Equal("value=more=equals", extractedBaggage["key"]);
     }
 
-#if NET
     [Fact]
     public void ValidateOversizedBaggageExtractionHonorsLimits()
     {
@@ -507,7 +506,6 @@ public class BaggagePropagatorTests
         Assert.Equal("v", baggage["k0179"]);
         Assert.False(baggage.ContainsKey("k0180"));
     }
-#endif
 
     [Fact(Skip = "Fails due to spec mismatch, tracked in https://github.com/open-telemetry/opentelemetry-dotnet/issues/5210")]
     public void ValidateSpecialCharactersInjection()

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
@@ -8,7 +8,7 @@ namespace OpenTelemetry.Context.Propagation.Tests;
 
 public class BaggagePropagatorTests
 {
-    const int MaxBaggageLength = 8192;
+    private const int MaxBaggageLength = 8192;
 
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter =
         static (d, k) => d.TryGetValue(k, out var v) ? [v] : [];

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/TracestateUtilsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/TracestateUtilsTests.cs
@@ -100,4 +100,31 @@ public class TracestateUtilsTests
 
         Assert.Equal("k1=v1,k2=v2", TraceStateUtils.GetString(tracestateEntries));
     }
+
+    [Fact]
+    public void GetString_RemovesLargeEntriesFirstWhenTruncating()
+    {
+        var tracestateEntries = new List<KeyValuePair<string, string>>
+        {
+            new("big", new string('a', 196)),
+        };
+
+        tracestateEntries.AddRange(Enumerable.Range(0, 17).Select(i => new KeyValuePair<string, string>($"k{i:00}", new string('a', 15))));
+
+        Assert.Equal(
+            string.Join(",", Enumerable.Range(0, 17).Select(i => $"k{i:00}={new string('a', 15)}")),
+            TraceStateUtils.GetString(tracestateEntries));
+    }
+
+    [Fact]
+    public void GetString_RemovesEntriesFromEndWhenStillTooLong()
+    {
+        var tracestateEntries = Enumerable.Range(0, 32)
+            .Select(i => new KeyValuePair<string, string>($"k{i:00}", new string('a', 20)))
+            .ToList();
+
+        Assert.Equal(
+            string.Join(",", Enumerable.Range(0, 20).Select(i => $"k{i:00}={new string('a', 20)}")),
+            TraceStateUtils.GetString(tracestateEntries));
+    }
 }

--- a/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/B3PropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/B3PropagatorFuzzTests.cs
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using ExtensionsB3Propagator = OpenTelemetry.Extensions.Propagators.B3Propagator;
+
+namespace OpenTelemetry.Extensions.Propagators.FuzzTests;
+
+[Obsolete("B3Propagator is obsolete but intentionally fuzz tested.")]
+public class B3PropagatorFuzzTests
+{
+    private const int MaxTests = 25;
+    private const string CombinedHeader = "b3";
+
+    [Property(MaxTest = MaxTests)]
+    public Property SingleHeaderDelimiterFloodReturnsDefault() => Prop.ForAll(Generators.DelimiterFloodArbitrary('-'), (headerValue) =>
+    {
+        try
+        {
+            var propagator = new ExtensionsB3Propagator(singleHeader: true);
+            var carrier = new Dictionary<string, string[]>(StringComparer.Ordinal)
+            {
+                [CombinedHeader] = [headerValue],
+            };
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return extracted.Equals(default) && FuzzTestHelpers.CarriersEqual(original, carrier);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+}

--- a/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/FuzzTestHelpers.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/FuzzTestHelpers.cs
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Extensions.Propagators.FuzzTests;
+
+internal static class FuzzTestHelpers
+{
+    public static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> ArrayGetter =
+        static (carrier, name) => carrier.TryGetValue(name, out var value) ? value : [];
+
+    public static Dictionary<string, string[]> CloneCarrier(Dictionary<string, string[]> carrier)
+    {
+        var clone = new Dictionary<string, string[]>(carrier.Count, StringComparer.Ordinal);
+
+        foreach (var pair in carrier)
+        {
+            clone[pair.Key] = [.. pair.Value];
+        }
+
+        return clone;
+    }
+
+    public static bool CarriersEqual(Dictionary<string, string[]> left, Dictionary<string, string[]> right) =>
+        left.Count == right.Count &&
+        left.All(pair => right.TryGetValue(pair.Key, out var value) && pair.Value.SequenceEqual(value));
+
+    public static bool IsAllowedException(Exception ex) => ex is ArgumentException;
+}

--- a/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/Generators.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/Generators.cs
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace OpenTelemetry.Extensions.Propagators.FuzzTests;
+
+internal static class Generators
+{
+    public static Arbitrary<string> DelimiterFloodArbitrary(char delimiter, int minLength = 1024, int maxLength = 50_000)
+    {
+        var gen =
+            from length in Gen.Choose(minLength, maxLength)
+            select new string(delimiter, length);
+
+        return gen.ToArbitrary();
+    }
+
+    public static Arbitrary<string> JaegerManyComponentHeaderArbitrary(int minParts = 1024, int maxParts = 50_000)
+    {
+        var gen =
+            from delimiter in Gen.Elements(":", "%3A")
+            from count in Gen.Choose(minParts, maxParts)
+            select string.Join(delimiter, Enumerable.Repeat("part", count));
+
+        return gen.ToArbitrary();
+    }
+}

--- a/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/JaegerPropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.FuzzTests/Context/Propagation/JaegerPropagatorFuzzTests.cs
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using ExtensionsJaegerPropagator = OpenTelemetry.Extensions.Propagators.JaegerPropagator;
+
+namespace OpenTelemetry.Extensions.Propagators.FuzzTests;
+
+[Obsolete("JaegerPropagator is obsolete but intentionally fuzz tested.")]
+public class JaegerPropagatorFuzzTests
+{
+    private const int MaxTests = 25;
+    private const string JaegerHeader = "uber-trace-id";
+
+    [Property(MaxTest = MaxTests)]
+    public Property ManyComponentHeadersReturnDefault() => Prop.ForAll(Generators.JaegerManyComponentHeaderArbitrary(), (headerValue) =>
+    {
+        try
+        {
+            var propagator = new ExtensionsJaegerPropagator();
+            var carrier = new Dictionary<string, string[]>(StringComparer.Ordinal)
+            {
+                [JaegerHeader] = [headerValue],
+            };
+            var original = FuzzTestHelpers.CloneCarrier(carrier);
+
+            var extracted = propagator.Extract(default, carrier, FuzzTestHelpers.ArrayGetter);
+
+            return extracted.Equals(default) && FuzzTestHelpers.CarriersEqual(original, carrier);
+        }
+        catch (Exception ex) when (FuzzTestHelpers.IsAllowedException(ex))
+        {
+            return true;
+        }
+    });
+}

--- a/test/OpenTelemetry.Extensions.Propagators.FuzzTests/OpenTelemetry.Extensions.Propagators.FuzzTests.csproj
+++ b/test/OpenTelemetry.Extensions.Propagators.FuzzTests/OpenTelemetry.Extensions.Propagators.FuzzTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsCheck.Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Propagators\OpenTelemetry.Extensions.Propagators.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
@@ -236,6 +236,19 @@ public class B3PropagatorTests
     }
 
     [Fact]
+    public void ParseLegacySampled_SingleHeader()
+    {
+        var headersSampled = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3Combined, $"{TraceIdBase16}-{SpanIdBase16}-true" },
+        };
+
+        Assert.Equal(
+            new PropagationContext(new ActivityContext(TraceId, SpanId, TraceOptions, isRemote: true), default),
+            this.b3PropagatorSingleHeader.Extract(default, headersSampled, Getter));
+    }
+
+    [Fact]
     public void ParseZeroSampled_SingleHeader()
     {
         var headersNotSampled = new Dictionary<string, string>
@@ -321,6 +334,13 @@ public class B3PropagatorTests
     }
 
     [Fact]
+    public void ParseSingleHeaderWithoutDelimiterReturnsDefault()
+    {
+        var invalidHeaders = new Dictionary<string, string> { { B3Propagator.XB3Combined, TraceIdBase16 } };
+        Assert.Equal(default, this.b3PropagatorSingleHeader.Extract(default, invalidHeaders, Getter));
+    }
+
+    [Fact]
     public void ParseInvalidSpanId_SingleHeader()
     {
         var invalidHeaders = new Dictionary<string, string>
@@ -363,6 +383,34 @@ public class B3PropagatorTests
         var headers = new Dictionary<string, string>
         {
             { B3Propagator.XB3Combined, headerValue },
+        };
+
+        var result = this.b3PropagatorSingleHeader.Extract(default, headers, Getter);
+
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public void ParseSingleHeaderWithFourthPartReturnsContext()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3Combined, $"{TraceIdBase16}-{SpanIdBase16}-1-parent" },
+        };
+
+        var result = this.b3PropagatorSingleHeader.Extract(default, headers, Getter);
+
+        Assert.Equal(
+            new PropagationContext(new ActivityContext(TraceId, SpanId, TraceOptions, isRemote: true), default),
+            result);
+    }
+
+    [Fact]
+    public void ParseSingleHeaderWithTooManyPartsReturnsDefault()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3Combined, $"{TraceIdBase16}-{SpanIdBase16}-1-parent-extra" },
         };
 
         var result = this.b3PropagatorSingleHeader.Extract(default, headers, Getter);

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
@@ -21,17 +21,9 @@ public class B3PropagatorTests
     private static readonly ActivityTraceId TraceIdEightBytes = ActivityTraceId.CreateFromString(("0000000000000000" + TraceIdBase16EightBytes).AsSpan());
     private static readonly ActivitySpanId SpanId = ActivitySpanId.CreateFromString(SpanIdBase16.AsSpan());
 
-    private static readonly Action<IDictionary<string, string>, string, string> Setter = (d, k, v) => d[k] = v;
+    private static readonly Action<IDictionary<string, string>, string, string> Setter = static (d, k, v) => d[k] = v;
     private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter =
-        (d, k) =>
-        {
-            if (d.TryGetValue(k, out var v))
-            {
-                return [v];
-            }
-
-            return [];
-        };
+        static (d, k) => d.TryGetValue(k, out var v) ? [v] : [];
 
     private readonly B3Propagator b3propagator = new();
     private readonly B3Propagator b3PropagatorSingleHeader = new(true);
@@ -363,6 +355,22 @@ public class B3PropagatorTests
             this.b3propagator.Fields,
             [B3Propagator.XB3TraceId, B3Propagator.XB3SpanId, B3Propagator.XB3ParentSpanId, B3Propagator.XB3Sampled, B3Propagator.XB3Flags]);
     }
+
+#if NET
+    [Fact]
+    public void ParseSingleHeaderWithManyDelimitersReturnsDefault()
+    {
+        var headerValue = new string('-', 50_000);
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3Combined, headerValue },
+        };
+
+        var result = this.b3PropagatorSingleHeader.Extract(default, headers, Getter);
+
+        Assert.Equal(default, result);
+    }
+#endif
 
     private static void ContainsExactly(ISet<string> list, List<string> items)
     {

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
@@ -356,7 +356,6 @@ public class B3PropagatorTests
             [B3Propagator.XB3TraceId, B3Propagator.XB3SpanId, B3Propagator.XB3ParentSpanId, B3Propagator.XB3Sampled, B3Propagator.XB3Flags]);
     }
 
-#if NET
     [Fact]
     public void ParseSingleHeaderWithManyDelimitersReturnsDefault()
     {
@@ -370,7 +369,6 @@ public class B3PropagatorTests
 
         Assert.Equal(default, result);
     }
-#endif
 
     private static void ContainsExactly(ISet<string> list, List<string> items)
     {

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace OpenTelemetry.Extensions.Propagators.Tests;
 
+[Obsolete("We still want to test obsolete APIs.")]
 public class JaegerPropagatorTests
 {
     private const string JaegerHeader = "uber-trace-id";
@@ -21,15 +22,11 @@ public class JaegerPropagatorTests
     private const string FlagSampled = "1";
     private const string FlagNotSampled = "0";
 
-    private static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> Getter = (headers, name) =>
-    {
-        return headers.TryGetValue(name, out var value) ? value : [];
-    };
+    private static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> Getter =
+        static (headers, name) => headers.TryGetValue(name, out var value) ? value : [];
 
-    private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
-    {
-        carrier[name] = value;
-    };
+    private static readonly Action<IDictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
 
     [Fact]
     public void ExtractReturnsOriginalContextIfContextIsAlreadyValid()
@@ -44,9 +41,7 @@ public class JaegerPropagatorTests
         var headers = new Dictionary<string, string[]>();
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         var result = new JaegerPropagator().Extract(propagationContext, headers, Getter);
-#pragma warning restore CS0618
 
         // assert
         Assert.Equal(propagationContext, result);
@@ -59,9 +54,7 @@ public class JaegerPropagatorTests
         var propagationContext = default(PropagationContext);
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         var result = new JaegerPropagator().Extract(propagationContext, null, Getter!);
-#pragma warning restore CS0618
 
         // assert
         Assert.Equal(propagationContext, result);
@@ -76,9 +69,7 @@ public class JaegerPropagatorTests
         var headers = new Dictionary<string, string[]>();
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         var result = new JaegerPropagator().Extract(propagationContext, headers, null!);
-#pragma warning restore CS0618
 
         // assert
         Assert.Equal(propagationContext, result);
@@ -108,9 +99,7 @@ public class JaegerPropagatorTests
         var headers = new Dictionary<string, string[]> { { JaegerHeader, [formattedHeader] } };
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         var result = new JaegerPropagator().Extract(propagationContext, headers, Getter);
-#pragma warning restore CS0618
 
         // assert
         Assert.Equal(propagationContext, result);
@@ -149,9 +138,7 @@ public class JaegerPropagatorTests
         var headers = new Dictionary<string, string[]> { { JaegerHeader, [formattedHeader] } };
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         var result = new JaegerPropagator().Extract(propagationContext, headers, Getter);
-#pragma warning restore CS0618
 
         // assert
         Assert.Equal(traceId.PadLeft(TraceId.Length, '0'), result.ActivityContext.TraceId.ToString());
@@ -168,9 +155,7 @@ public class JaegerPropagatorTests
         var headers = new Dictionary<string, string>();
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         new JaegerPropagator().Inject(propagationContext, headers, Setter);
-#pragma warning restore CS0618
 
         // assert
         Assert.Empty(headers);
@@ -187,9 +172,7 @@ public class JaegerPropagatorTests
             default);
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         new JaegerPropagator().Inject(propagationContext, null, Setter!);
-#pragma warning restore CS0618
 
         // assert
     }
@@ -207,9 +190,7 @@ public class JaegerPropagatorTests
         var headers = new Dictionary<string, string>();
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         new JaegerPropagator().Inject(propagationContext, headers, null!);
-#pragma warning restore CS0618
 
         // assert
         Assert.Empty(headers);
@@ -237,12 +218,23 @@ public class JaegerPropagatorTests
         var headers = new Dictionary<string, string>();
 
         // act
-#pragma warning disable CS0618 // Type or member is obsolete
         new JaegerPropagator().Inject(propagationContext, headers, Setter);
-#pragma warning restore CS0618
 
         // assert
         Assert.Single(headers);
         Assert.Equal(expectedValue, headers[JaegerHeader]);
     }
+
+#if NET
+    [Fact]
+    public void ExtractHeaderWithManyDelimitersReturnsDefault()
+    {
+        var formattedHeader = string.Join(JaegerDelimiter, Enumerable.Repeat("part", 50_000));
+        var headers = new Dictionary<string, string[]> { { JaegerHeader, [formattedHeader] } };
+
+        var result = new JaegerPropagator().Extract(default, headers, Getter);
+
+        Assert.Equal(default, result);
+    }
+#endif
 }

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
@@ -225,7 +225,6 @@ public class JaegerPropagatorTests
         Assert.Equal(expectedValue, headers[JaegerHeader]);
     }
 
-#if NET
     [Fact]
     public void ExtractHeaderWithManyDelimitersReturnsDefault()
     {
@@ -236,5 +235,4 @@ public class JaegerPropagatorTests
 
         Assert.Equal(default, result);
     }
-#endif
 }

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
@@ -147,6 +147,22 @@ public class JaegerPropagatorTests
     }
 
     [Fact]
+    public void ExtractReturnsNewContextIfHeaderContainsEmptyComponent()
+    {
+        var formattedHeader = $"{TraceId}{JaegerDelimiter}{JaegerDelimiter}{SpanId}{JaegerDelimiter}{ParentSpanId}{JaegerDelimiter}{FlagSampled}";
+        var headers = new Dictionary<string, string[]>
+        {
+            [JaegerHeader] = [formattedHeader],
+        };
+
+        var result = new JaegerPropagator().Extract(default, headers, Getter);
+
+        Assert.Equal(TraceId, result.ActivityContext.TraceId.ToString());
+        Assert.Equal(SpanId, result.ActivityContext.SpanId.ToString());
+        Assert.Equal(ActivityTraceFlags.Recorded, result.ActivityContext.TraceFlags);
+    }
+
+    [Fact]
     public void InjectDoesNoopIfContextIsInvalid()
     {
         // arrange

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
@@ -13,31 +13,14 @@ public class TraceContextPropagatorTests
     private const string TraceId = "0af7651916cd43dd8448eb211c80319c";
     private const string SpanId = "b9c7c989f97918e1";
 
-    private static readonly string[] Empty = [];
-    private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
-    {
-        if (headers.TryGetValue(name, out var value))
-        {
-            return [value];
-        }
+    private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter =
+        static (headers, name) => headers.TryGetValue(name, out var value) ? [value] : [];
 
-        return Empty;
-    };
+    private static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> ArrayGetter =
+        static (headers, name) => headers.TryGetValue(name, out var value) ? value : [];
 
-    private static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> ArrayGetter = (headers, name) =>
-    {
-        if (headers.TryGetValue(name, out var value))
-        {
-            return value;
-        }
-
-        return [];
-    };
-
-    private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>
-    {
-        carrier[name] = value;
-    };
+    private static readonly Action<IDictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
 
     [Fact]
     public void CanParseExampleFromSpec()
@@ -56,7 +39,7 @@ public class TraceContextPropagatorTests
 
         Assert.True(ctx.ActivityContext.IsRemote);
         Assert.True(ctx.ActivityContext.IsValid());
-        Assert.True((ctx.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0);
+        Assert.NotEqual(0, (int)(ctx.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded));
 
         Assert.Equal($"congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4,rojo=00-{TraceId}-00f067aa0ba902b7-01", ctx.ActivityContext.TraceState);
     }
@@ -74,7 +57,7 @@ public class TraceContextPropagatorTests
 
         Assert.Equal(ActivityTraceId.CreateFromString(TraceId.AsSpan()), ctx.ActivityContext.TraceId);
         Assert.Equal(ActivitySpanId.CreateFromString(SpanId.AsSpan()), ctx.ActivityContext.SpanId);
-        Assert.True((ctx.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) == 0);
+        Assert.Equal(0, (int)(ctx.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded));
 
         Assert.True(ctx.ActivityContext.IsRemote);
         Assert.True(ctx.ActivityContext.IsValid());
@@ -175,6 +158,24 @@ public class TraceContextPropagatorTests
         f.Inject(propagationContext, carrier, Setter);
 
         Assert.Equal(expectedHeaders, carrier);
+    }
+
+    [Fact]
+    public void Inject_TruncatesOversizedTracestate()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var expectedTraceState = string.Join(",", Enumerable.Range(0, 17).Select(i => $"k{i:00}={new string('a', 15)}"));
+        var oversizedTraceState = $"big={new string('a', 196)},{expectedTraceState}";
+
+        var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded, oversizedTraceState);
+        var propagationContext = new PropagationContext(activityContext, default);
+        var carrier = new Dictionary<string, string>();
+        var f = new TraceContextPropagator();
+        f.Inject(propagationContext, carrier, Setter);
+
+        Assert.Equal($"00-{traceId}-{spanId}-01", carrier[TraceParent]);
+        Assert.Equal(expectedTraceState, carrier[TraceState]);
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

Add fuzz tests for the propagator classes.

I thought it would be a good idea to add these after working on #7059 and #7060 due to the amount of string parsing they do.

In the process of adding the new fuzz tests, some bugs were found in the processing that have now been fixed.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
