### PR TITLE
Fix Prometheus exporter to sanitize malformed unit strings

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
@@ -119,6 +119,41 @@ internal sealed class PrometheusMetric
         }
     }
 
+    internal static string SanitizeUnitName(string unit)
+    {
+        if (string.IsNullOrEmpty(unit))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(unit.Length);
+        var lastCharUnderscore = false;
+
+        for (var i = 0; i < unit.Length; i++)
+        {
+            var c = unit[i];
+
+            if (char.IsLetterOrDigit(c))
+            {
+                sb.Append(c);
+                lastCharUnderscore = false;
+            }
+            else if (!lastCharUnderscore && sb.Length > 0)
+            {
+                sb.Append('_');
+                lastCharUnderscore = true;
+            }
+        }
+
+        // Strip trailing underscore
+        if (sb.Length > 0 && sb[sb.Length - 1] == '_')
+        {
+            sb.Length--;
+        }
+
+        return sb.Length == 0 ? string.Empty : sb.ToString();
+    }
+
     internal static string RemoveAnnotations(string unit)
     {
         // UCUM standard says the curly braces shouldn't be nested:
@@ -208,6 +243,7 @@ internal sealed class PrometheusMetric
             updatedUnit = MapUnit(updatedUnit.AsSpan());
         }
 
+        updatedUnit = SanitizeUnitName(updatedUnit);
         return updatedUnit;
     }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
@@ -264,6 +264,42 @@ public sealed class PrometheusMetricTests
     public void Name_EmptyUnit_NoSuffixAdded() => AssertName("metric", string.Empty, PrometheusType.Gauge, false, "metric");
 
     [Fact]
+    public void Name_MalformedUnit_HashRU_Sanitized()
+        => AssertName("metric", "# RU", PrometheusType.Gauge, false, "metric_RU");
+
+    [Fact]
+    public void Name_MalformedUnit_HashOnly_Unitless()
+        => AssertName("metric", "#", PrometheusType.Gauge, false, "metric");
+
+    [Fact]
+    public void Name_MalformedUnit_HashSpaceHash_Unitless()
+        => AssertName("metric", "# #", PrometheusType.Gauge, false, "metric");
+
+    [Fact]
+    public void Name_MalformedUnit_HashUnderscoreRDotUDot_Sanitized()
+        => AssertName("metric", "#_R.U.", PrometheusType.Gauge, false, "metric_R_U");
+
+    [Fact]
+    public void SanitizeUnitName_Valid()
+        => Assert.Equal("bytes", PrometheusMetric.SanitizeUnitName("bytes"));
+
+    [Fact]
+    public void SanitizeUnitName_WithInvalidChars()
+        => Assert.Equal("RU", PrometheusMetric.SanitizeUnitName("# RU"));
+
+    [Fact]
+    public void SanitizeUnitName_OnlyInvalidChars_ReturnsEmpty()
+        => Assert.Equal(string.Empty, PrometheusMetric.SanitizeUnitName("#"));
+
+    [Fact]
+    public void SanitizeUnitName_Empty_ReturnsEmpty()
+        => Assert.Equal(string.Empty, PrometheusMetric.SanitizeUnitName(string.Empty));
+
+    [Fact]
+    public void SanitizeUnitName_DotsCollapsed()
+        => Assert.Equal("R_U", PrometheusMetric.SanitizeUnitName("R.U."));
+
+    [Fact]
     public void Name_NullUnit_NoSuffixAdded()
     {
         var prometheusMetric = new PrometheusMetric("metric", null!, PrometheusType.Gauge, false);
@@ -361,7 +397,7 @@ public sealed class PrometheusMetricTests
 
     [Fact]
     public void Name_MultipleSlashesInUnit_FirstSlashProcessed()
-        => AssertName("metric", "req/s/extra", PrometheusType.Gauge, false, "metric_req_per_s/extra"); // // Multiple slashes
+        => AssertName("metric", "req/s/extra", PrometheusType.Gauge, false, "metric_req_per_s_extra"); // Multiple slashes
 
     [Theory]
     [InlineData(PrometheusType.Counter)]


### PR DESCRIPTION
# Description
Add SanitizeUnitName() to strip invalid characters from metric unit strings before they are used in Prometheus metric names. Units like '# RU' (from Azure Cosmos DB) previously produced invalid metric names containing comment markers and spaces.

The sanitizer replaces non-alphanumeric characters with underscores, collapses consecutive underscores, and strips leading/trailing underscores. Fully invalid units (e.g. '#') result in an empty string so no unit suffix is appended.

Fixes #6187
 
 The Prometheus exporter does not sanitize unit strings after processing in
 `GetUnit()`. When upstream libraries set malformed units (e.g., Azure Cosmos DB
 uses `# RU`), the resulting Prometheus metric name contains invalid characters
 like `#` and spaces, which breaks Prometheus scraping because `#` is interpreted
 as a comment marker.
 
 ## Expected behavior
 
 Malformed unit strings should be sanitized so the final Prometheus metric name
 only contains valid characters (`[a-zA-Z0-9_]`).
 
 - `# RU` → metric suffix becomes `_RU`
 - `#` → treated as unitless (no suffix)
 - `#_R.U.` → metric suffix becomes `_R_U`
 
 ## Actual behavior
 
 The unit string `# RU` is appended as-is, producing metric names like
 `azure_cosmosdb_client_operation_request_charge_# RU_bucket` which Prometheus
 cannot scrape.
 
 ## Steps to reproduce
 
 1. Create a Meter with unit set to `# RU`
 2. Configure OpenTelemetry with the Prometheus exporter
 3. Query the Prometheus metrics endpoint
 4. Observe the metric name contains `#` and spaces
 
 ## Environment
 
 - OpenTelemetry .NET SDK
 - .NET 8.0
 - Package: OpenTelemetry.Exporter.Prometheus.HttpListener
 
 ## Changes
 
 - Added `SanitizeUnitName()` method to `PrometheusMetric.cs` that replaces
   invalid characters with `_`, collapses consecutive underscores, and strips
   leading/trailing underscores
 - Wired it as the final step in `GetUnit()` before returning
 - Added 9 new test cases for malformed unit scenarios
 - Updated 1 existing test expectation for multi-slash units
 
 ## Type of change
 
 - [x] Bug fix (non-breaking change which fixes an issue)
 
 ## How Has This Been Tested?
 
 All 188 tests pass via `dotnet test`.
 
 ## Does This PR Require a Contrib Repo Change?
 
 - [x] No
 
 
## Merge Requirement Checklist:
 
 * [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed 
(license requirements, nullable enabled, static analysis, etc.)
 * [x] Unit tests added/updated
 * [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
 * [ ] Changes in public API reviewed (if applicable)