### PR TITLE
[OTLP] Fix OTLP/gRPC status parsing

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed an issue in OTLP/gRPC retry handling where parsing gRPC status.
+  ([#7064](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7064))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/Grpc/GrpcStatusDeserializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/Grpc/GrpcStatusDeserializer.cs
@@ -125,6 +125,9 @@ internal static class GrpcStatusDeserializer
     private static Duration DecodeDuration(Stream stream)
     {
         var length = DecodeVarint(stream);
+
+        CheckLength(length, stream);
+
         var endPosition = stream.Position + length;
         long seconds = 0;
         int nanos = 0;
@@ -155,6 +158,9 @@ internal static class GrpcStatusDeserializer
     private static Any DecodeAny(Stream stream)
     {
         var length = DecodeVarint(stream);
+
+        CheckLength(length, stream);
+
         var endPosition = stream.Position + length;
 
         string? typeUrl = null;
@@ -227,22 +233,13 @@ internal static class GrpcStatusDeserializer
 
     private static byte[] DecodeBytes(Stream stream)
     {
-        var length = DecodeVarint(stream);
-        if (length < 0 || length > int.MaxValue)
-        {
-            throw new InvalidDataException($"Invalid length: {length}");
-        }
+        var length = (int)DecodeVarint(stream);
 
-        var remainingBytes = stream.Length - stream.Position;
-        if (length > remainingBytes)
-        {
-            throw new EndOfStreamException();
-        }
+        CheckLength(length, stream);
 
-        var lengthInt = (int)length;
-        var buffer = new byte[lengthInt];
-        int read = stream.Read(buffer, 0, lengthInt);
-        if (read != lengthInt)
+        var buffer = new byte[length];
+        int read = stream.Read(buffer, 0, length);
+        if (read != length)
         {
             throw new EndOfStreamException();
         }
@@ -262,6 +259,7 @@ internal static class GrpcStatusDeserializer
                 break;
             case WIRETYPE_LENGTH_DELIMITED:
                 var length = DecodeVarint(stream);
+                CheckLength(length, stream);
                 stream.Position += length;
                 break;
             case WIRETYPE_FIXED32:
@@ -269,6 +267,21 @@ internal static class GrpcStatusDeserializer
                 break;
             default:
                 throw new InvalidDataException($"Unknown wire type: {wireType}");
+        }
+    }
+
+    private static void CheckLength(long length, Stream stream)
+    {
+        if (length < 0 || length > int.MaxValue)
+        {
+            throw new InvalidDataException($"Invalid length: {length}.");
+        }
+
+        long available = stream.Length - stream.Position;
+
+        if (length > available)
+        {
+            throw new EndOfStreamException();
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/Grpc/GrpcStatusDeserializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/Grpc/GrpcStatusDeserializer.cs
@@ -227,10 +227,22 @@ internal static class GrpcStatusDeserializer
 
     private static byte[] DecodeBytes(Stream stream)
     {
-        var length = (int)DecodeVarint(stream);
-        var buffer = new byte[length];
-        int read = stream.Read(buffer, 0, length);
-        if (read != length)
+        var length = DecodeVarint(stream);
+        if (length < 0 || length > int.MaxValue)
+        {
+            throw new InvalidDataException($"Invalid length: {length}");
+        }
+
+        var remainingBytes = stream.Length - stream.Position;
+        if (length > remainingBytes)
+        {
+            throw new EndOfStreamException();
+        }
+
+        var lengthInt = (int)length;
+        var buffer = new byte[lengthInt];
+        int read = stream.Read(buffer, 0, lengthInt);
+        if (read != lengthInt)
         {
             throw new EndOfStreamException();
         }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
@@ -332,4 +332,27 @@ public class GrpcStatusDeserializerTests
         Assert.Throws<EndOfStreamException>(() =>
             GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin));
     }
+
+    [Fact]
+    public void DeserializeStatus_WithLargeLengthDelimitedField_ThrowsEndOfStreamException()
+    {
+        // Arrange
+        // This payload encodes a Status.details Any.value field with an extremely large
+        // length value (0x7FFFFFF0) but without enough bytes in the payload.
+        const string grpcStatusDetailsBin = "GgYS8P///wc=";
+
+        // Act & Assert
+        Assert.Throws<EndOfStreamException>(() =>
+            GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin));
+    }
+
+    [Theory]
+    [InlineData("GgsS////////////AQ==")] // -1
+    [InlineData("GgYSgICAgAg=")] // 0x80000000
+    public void DeserializeStatus_WithInvalidLengthDelimitedField_ThrowsInvalidDataException(string grpcStatusDetailsBin)
+    {
+        // Act & Assert
+        var exception = Assert.Throws<InvalidDataException>(() => GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin));
+        Assert.Contains("Invalid length", exception.Message, StringComparison.Ordinal);
+    }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
@@ -4,6 +4,7 @@
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient.Grpc;
+using Type = System.Type;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.Implementation.ExportClient;
 
@@ -314,7 +315,7 @@ public class GrpcStatusDeserializerTests
     }
 
     [Fact]
-    public void DeserializeStatus_TruncatedStream_ThrowsEndOfStreamException()
+    public void DeserializeStatus_TruncatedStream_ThrowsException()
     {
         // Arrange: Create valid Base64 data and truncate it
         var status = new Google.Rpc.Status
@@ -334,7 +335,7 @@ public class GrpcStatusDeserializerTests
     }
 
     [Fact]
-    public void DeserializeStatus_WithLargeLengthDelimitedField_ThrowsEndOfStreamException()
+    public void DeserializeStatus_WithLargeLengthDelimitedField_ThrowsException()
     {
         // Arrange
         // This payload encodes a Status.details Any.value field with an extremely large
@@ -349,10 +350,66 @@ public class GrpcStatusDeserializerTests
     [Theory]
     [InlineData("GgsS////////////AQ==")] // -1
     [InlineData("GgYSgICAgAg=")] // 0x80000000
-    public void DeserializeStatus_WithInvalidLengthDelimitedField_ThrowsInvalidDataException(string grpcStatusDetailsBin)
+    public void DeserializeStatus_WithInvalidLengthDelimitedField_ThrowsException(string grpcStatusDetailsBin)
     {
         // Act & Assert
         var exception = Assert.Throws<InvalidDataException>(() => GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin));
         Assert.Contains("Invalid length", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue / 2, typeof(EndOfStreamException))]
+    [InlineData(int.MaxValue - 1024, typeof(EndOfStreamException))]
+    [InlineData(int.MaxValue - 1, typeof(EndOfStreamException))]
+    [InlineData(int.MaxValue, typeof(EndOfStreamException))]
+    [InlineData(uint.MaxValue, typeof(InvalidDataException))]
+    public void DeserializeStatus_InvalidDetailValueLength_Throws(long value, Type expected)
+    {
+        var anyValueLength = EncodeVarint(value);
+        var statusBytes = new byte[2 + 1 + anyValueLength.Length];
+
+        statusBytes[0] = 0x1A; // field 3 (details), wire type 2
+        statusBytes[1] = (byte)(1 + anyValueLength.Length); // embedded Any payload length
+        statusBytes[2] = 0x12; // field 2 (value), wire type 2
+        anyValueLength.CopyTo(statusBytes, 3);
+
+        var grpcStatusDetailsBin = Convert.ToBase64String(statusBytes);
+
+        Assert.Throws(expected, () => GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin));
+    }
+
+    [Fact]
+    public void DeserializeStatus_InvalidEmbeddedMessageLength_Throws()
+    {
+        var statusBytes = new byte[1 + EncodeVarint(long.MaxValue).Length];
+
+        statusBytes[0] = 0x1A; // field 3 (details), wire type 2
+        EncodeVarint(long.MaxValue).CopyTo(statusBytes, 1);
+
+        var grpcStatusDetailsBin = Convert.ToBase64String(statusBytes);
+
+        Assert.Throws<InvalidDataException>(() => GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin));
+    }
+
+    private static byte[] EncodeVarint(long value)
+    {
+        var encoded = new List<byte>();
+        var remaining = unchecked((ulong)value);
+
+        do
+        {
+            var current = (byte)(remaining & 0x7F);
+            remaining >>= 7;
+
+            if (remaining != 0)
+            {
+                current |= 0x80;
+            }
+
+            encoded.Add(current);
+        }
+        while (remaining != 0);
+
+        return [.. encoded];
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterRetryTransmissionHandlerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterRetryTransmissionHandlerTests.cs
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient.Grpc;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission.Tests;
+
+public class OtlpExporterRetryTransmissionHandlerTests
+{
+    [Theory]
+    [InlineData(int.MaxValue / 2)]
+    [InlineData(int.MaxValue - 1024)]
+    [InlineData(int.MaxValue - 1)]
+    [InlineData(int.MaxValue)]
+    [InlineData(uint.MaxValue)]
+    public void TrySubmitRequest_FailedRequestWithOverflowingRetryHeader_LogsParsingFailureAndRetries(long value)
+    {
+        var maliciousHeader = CreateMalformedGrpcStatusDetailsHeader(value);
+        var exportClient = new RetryingTestExportClient(maliciousHeader);
+
+        using var transmissionHandler = new OtlpExporterRetryTransmissionHandler(exportClient, timeoutMilliseconds: 1_000);
+
+        bool actual;
+
+#if NET
+        using (new AllocationAssertion())
+#endif
+        {
+            actual = transmissionHandler.TrySubmitRequest([1, 2, 3], 3);
+        }
+
+        Assert.False(actual);
+        Assert.True(exportClient.SendCount >= 2, $"Expected at least 2 send attempts, but got {exportClient.SendCount}.");
+    }
+
+    private static string CreateMalformedGrpcStatusDetailsHeader(long value)
+    {
+        var anyValueLength = EncodeVarint(value);
+        var statusBytes = new byte[2 + 1 + anyValueLength.Length];
+
+        statusBytes[0] = 0x1A; // field 3 (details), wire type 2
+        statusBytes[1] = (byte)(1 + anyValueLength.Length); // embedded Any payload length
+        statusBytes[2] = 0x12; // field 2 (value), wire type 2
+
+        anyValueLength.CopyTo(statusBytes, 3);
+
+        return Convert.ToBase64String(statusBytes);
+    }
+
+    private static byte[] EncodeVarint(long value)
+    {
+        var encoded = new List<byte>();
+        var remaining = unchecked((ulong)value);
+
+        do
+        {
+            var current = (byte)(remaining & 0x7F);
+            remaining >>= 7;
+
+            if (remaining != 0)
+            {
+                current |= 0x80;
+            }
+
+            encoded.Add(current);
+        }
+        while (remaining != 0);
+
+        return [.. encoded];
+    }
+
+    private sealed class RetryingTestExportClient(string maliciousHeader) : IExportClient
+    {
+        public int SendCount { get; private set; }
+
+        public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
+        {
+            this.SendCount++;
+
+            return new ExportClientGrpcResponse(
+                success: false,
+                deadlineUtc: deadlineUtc,
+                exception: null,
+                status: new Status(StatusCode.Unavailable, "retryable"),
+                grpcStatusDetailsHeader: maliciousHeader);
+        }
+
+        public bool Shutdown(int timeoutMilliseconds) => true;
+    }
+
+#if NET
+    private sealed class AllocationAssertion : IDisposable
+    {
+        private readonly long before;
+
+        public AllocationAssertion()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            this.before = GC.GetTotalAllocatedBytes();
+        }
+
+        public void Dispose()
+        {
+            var allocatedBytes = GC.GetTotalAllocatedBytes() - this.before;
+
+            const int Limit = 1_000_000;
+            Assert.False(
+                allocatedBytes > Limit,
+                $"{allocatedBytes} bytes were allocated during the operation which is more than the limit of {Limit}.");
+        }
+    }
+#endif
+}


### PR DESCRIPTION
Fixes issues dected by Codex/security scans

## Changes

Fixed an issue in OTLP/gRPC retry handling where parsing gRPC status for some malformed data.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
