### PR TITLE
[OpenTelemetry.Api] tracestate parsing - do not allow keys starting from digits

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* **Breaking change:** Fixed `tracestate` parsing to reject keys that do not
+  begin with a lowercase letter, including keys beginning with digits, to
+  align with the W3C Trace Context specification.
+  ([#7065](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7065))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
@@ -183,7 +183,7 @@ internal static class TraceStateUtils
 
         if (key.IsEmpty
             || key.Length > KeyMaxSize
-            || ((!(key[i] >= 'a' && key[i] <= 'z')) && (!(key[i] >= '0' && key[i] <= '9'))))
+            || (!(key[i] >= 'a' && key[i] <= 'z')))
         {
             return false;
         }

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
@@ -9,7 +9,7 @@ namespace OpenTelemetry.Api.FuzzTests;
 
 internal static class Generators
 {
-    private static readonly Gen<char> LowerAlphaNumericChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz0123456789".ToCharArray());
+    private static readonly Gen<char> LowerAlphaChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz".ToCharArray());
     private static readonly Gen<char> TraceStateKeyChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz0123456789_-*/".ToCharArray());
     private static readonly Gen<char> TraceStateValueChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~:/".ToCharArray());
     private static readonly Gen<char> BaggageChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_./:!$&'()*+;@?=,".ToCharArray());
@@ -198,16 +198,16 @@ internal static class Generators
     {
         var simpleKey =
             from length in Gen.Choose(1, 12)
-            from first in LowerAlphaNumericChar
+            from first in LowerAlphaChar
             from rest in Gen.ArrayOf(TraceStateKeyChar, length - 1)
             select $"{first}{new string(rest)}";
 
         var vendorKey =
             from tenantLength in Gen.Choose(1, 8)
             from vendorLength in Gen.Choose(1, 6)
-            from tenantFirst in LowerAlphaNumericChar
+            from tenantFirst in LowerAlphaChar
             from tenantRest in Gen.ArrayOf(TraceStateKeyChar, tenantLength - 1)
-            from vendorFirst in LowerAlphaNumericChar
+            from vendorFirst in LowerAlphaChar
             from vendorRest in Gen.ArrayOf(TraceStateKeyChar, vendorLength - 1)
             select $"{tenantFirst}{new string(tenantRest)}@{vendorFirst}{new string(vendorRest)}";
 

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/TracestateUtilsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/TracestateUtilsTests.cs
@@ -34,6 +34,7 @@ public class TracestateUtilsTests
     [InlineData("k\t=v")]
     [InlineData("k=v,k=v")]
     [InlineData("k1=v1,,,k2=v2")]
+    [InlineData("1k=v")]
     [InlineData("k=morethan256......................................................................................................................................................................................................................................................")]
     [InlineData("v=morethan256......................................................................................................................................................................................................................................................")]
     public void InvalidTracestate(string tracestate)
@@ -75,7 +76,6 @@ public class TracestateUtilsTests
     [InlineData(", k= v, ", "k", "v")]
     [InlineData("k=\tv", "k", "v")]
     [InlineData("k=v\t", "k", "v")]
-    [InlineData("1k=v", "1k", "v")]
     public void ValidPair(string pair, string expectedKey, string expectedValue)
     {
         var tracestateEntries = new List<KeyValuePair<string, string>>();


### PR DESCRIPTION
## Changes

[OpenTelemetry.Api] tracestate parsing - do not allow keys starting from digits
Ref: https://opentelemetry.io/docs/specs/otel/trace/tracestate-handling/#key

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
