### PR TITLE
[OpenTelemetry] Self diagnostics - misformats negative date time offsets

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -199,16 +199,17 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
 
             case DateTimeKind.Local:
                 var ts = TimeZoneInfo.Local.GetUtcOffset(datetime);
+                var absoluteTs = ts.Duration();
 
-                bytes[pos++] = (byte)(ts.Hours >= 0 ? '+' : '-');
+                bytes[pos++] = (byte)(ts >= TimeSpan.Zero ? '+' : '-');
 
-                num = Math.Abs(ts.Hours);
+                num = absoluteTs.Hours;
                 bytes[pos++] = (byte)('0' + ((num / 10) % 10));
                 bytes[pos++] = (byte)('0' + (num % 10));
 
                 bytes[pos++] = (byte)':';
 
-                num = ts.Minutes;
+                num = absoluteTs.Minutes;
                 bytes[pos++] = (byte)('0' + ((num / 10) % 10));
                 bytes[pos++] = (byte)('0' + (num % 10));
                 break;


### PR DESCRIPTION
## Changes

Found by Codex security scans.

[OpenTelemetry] Self diagnostics - misformats negative date time offsets

Tested locally by, I do not want to introduce this tests as it requires internally visible method with artificial parameter.
Changelog intentionally skipped.

```
    [Theory]
    [InlineData(-5, -30, "-05:30")]  // Negative offset with non-zero minutes: old code wrote negative digit for minutes
    [InlineData(-0, -30, "-00:30")]  // Negative sub-hour offset: old code used ts.Hours >= 0 which gave '+' sign
    [InlineData(5, 30, "+05:30")]    // Positive offset with non-zero minutes: should remain correct
    [InlineData(-8, 0, "-08:00")]    // Negative whole-hour offset: should remain correct
    [InlineData(0, 0, "+00:00")]     // UTC expressed as local: should be '+'
    public void SelfDiagnosticsEventListener_DateTimeGetBytes_LocalKind_NegativeOffsets(int offsetHours, int offsetMinutes, string expectedSuffix)
    {
        using var configRefresher = new TestSelfDiagnosticsConfigRefresher();
        using var listener = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresher);

        var datetime = DateTime.SpecifyKind(
            new DateTime(2024, 6, 15, 12, 30, 45, 1234567 / 10000),
            DateTimeKind.Local);

        var utcOffset = new TimeSpan(offsetHours, offsetMinutes, 0);
        var buffer = new byte[40];
        var len = SelfDiagnosticsEventListener.DateTimeGetBytes(datetime, buffer, 0, utcOffset);
        var result = Encoding.UTF8.GetString(buffer, 0, len);

        Assert.EndsWith(expectedSuffix, result, StringComparison.Ordinal);
        Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}[+\-]\d{2}:\d{2}$", result);
    }
```


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
