### PR TITLE
[infra] Fix AOT tests execution

### DIFF
--- a/build/scripts/test-aot-compatibility.ps1
+++ b/build/scripts/test-aot-compatibility.ps1
@@ -29,7 +29,7 @@ $app = $IsWindows ? "./OpenTelemetry.AotCompatibility.TestApp.exe" : "./OpenTele
 Push-Location $rootDirectory/artifacts/publish/OpenTelemetry.AotCompatibility.TestApp/release_$targetNetFramework
 
 Write-Host "Executing test App..."
-$app
+& $app
 Write-Host "Finished executing test App"
 
 if ($LastExitCode -ne 0)


### PR DESCRIPTION
## Changes

Before changes:

```log
Actual warning count is: 0
Executing test App...
./OpenTelemetry.AotCompatibility.TestApp.exe
Finished executing test App
```

After changes:

```log
Actual warning count is: 0
Executing test App...
Passed.
Finished executing test App
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
