### PR TITLE
[OpenTelemetry] Metrics - beter handling for double.NaN

### DIFF
--- a/src/OpenTelemetry/Internal/InterlockedHelper.cs
+++ b/src/OpenTelemetry/Internal/InterlockedHelper.cs
@@ -16,7 +16,7 @@ internal static class InterlockedHelper
         var currentValue = Volatile.Read(ref location);
 
         var returnedValue = Interlocked.CompareExchange(ref location, currentValue + value, currentValue);
-        if (returnedValue != currentValue)
+        if (!AreSame(returnedValue, currentValue))
         {
             AddRare(ref location, value, returnedValue);
         }
@@ -35,7 +35,7 @@ internal static class InterlockedHelper
             sw.SpinOnce();
 
             var returnedValue = Interlocked.CompareExchange(ref location, currentValue + value, currentValue);
-            if (returnedValue == currentValue)
+            if (AreSame(returnedValue, currentValue))
             {
                 break;
             }
@@ -43,4 +43,8 @@ internal static class InterlockedHelper
             currentValue = returnedValue;
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreSame(double left, double right)
+        => BitConverter.DoubleToInt64Bits(left) == BitConverter.DoubleToInt64Bits(right);
 }

--- a/test/OpenTelemetry.Tests/Internal/InterlockedHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/InterlockedHelperTests.cs
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
+
+namespace OpenTelemetry.Internal.Tests;
+
+public class InterlockedHelperTests
+{
+    [Fact]
+    public async Task AddWhenCurrentValueIsNaNShouldNotHang()
+    {
+        var value = double.NaN;
+
+        var task = Task.Run(() => InterlockedHelper.Add(ref value, 1d));
+        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(2))) == task;
+
+        Assert.True(completed);
+        Assert.True(double.IsNaN(value));
+    }
+}


### PR DESCRIPTION
Fixes N/A
Design discussion issue N/A

Found by Codex/security scans. Ref: https://github.com/open-telemetry/opentelemetry-dotnet/pull/406

## Changes

[OpenTelemetry] Metrics - beter handling for double.NaN.
Previously, there were possibility to go into infinite loop here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~ Skipped, the code in the same way was here by last 6 years, no issues reported. I think that the change might be artificial, but no-ham here, so it should be safe to make the analyzer happy.
* ~~[ ] Changes in public API reviewed (if applicable)~~
