### PR TITLE
[infra] pin dotnet-coverage to exact version

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -99,7 +99,10 @@ jobs:
         -- RunConfiguration.DisableAppDomain=true
 
     - name: Install coverage tool
-      run: dotnet tool install -g dotnet-coverage
+      env:
+        # renovate: datasource=nuget depName=dotnet-coverage
+        DOTNET_COVERAGE_VERSION: '18.6.2'
+      run: dotnet tool install -g dotnet-coverage --version ${env:DOTNET_COVERAGE_VERSION}
 
     - name: Merging test results
       run: dotnet-coverage merge -f cobertura -o ./TestResults/Cobertura.xml ./TestResults/**/*.coverage

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -99,6 +99,7 @@ jobs:
         -- RunConfiguration.DisableAppDomain=true
 
     - name: Install coverage tool
+      shell: pwsh
       env:
         # renovate: datasource=nuget depName=dotnet-coverage
         DOTNET_COVERAGE_VERSION: '18.6.2'


### PR DESCRIPTION
Fixes Codex/security findings

## Changes

[infra] pin dotnet-coverage to exact version
It should be auto-updated by renovate as other similar tools

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
