### PR TITLE
[OTLP] Fix disk retry storage where metrics and logs used the traces storage directory

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -10,6 +10,11 @@ Notes](../../RELEASENOTES.md).
 * Fixed an issue in OTLP/gRPC retry handling where parsing gRPC status.
   ([#7064](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7064))
 
+* Fixed an issue with OTLP disk retry storage where metrics and logs used the
+  traces storage directory. Disk retry storage is now separated by signal using
+  `traces`, `metrics`, and `logs` directories.
+  ([#7074](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7074))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -197,12 +197,11 @@ internal static class OtlpExporterOptionsExtensions
         return new Uri(string.Concat(uri.AbsoluteUri, separator, path));
     }
 
-    private static string GetSignalStorageDirectoryName(OtlpSignalType otlpSignalType)
-        => otlpSignalType switch
-        {
-            OtlpSignalType.Traces => "traces",
-            OtlpSignalType.Metrics => "metrics",
-            OtlpSignalType.Logs => "logs",
-            _ => throw new NotSupportedException($"OtlpSignalType {otlpSignalType} is not supported."),
-        };
+    private static string GetSignalStorageDirectoryName(OtlpSignalType otlpSignalType) => otlpSignalType switch
+    {
+        OtlpSignalType.Logs => "logs",
+        OtlpSignalType.Metrics => "metrics",
+        OtlpSignalType.Traces => "traces",
+        _ => throw new NotSupportedException($"OtlpSignalType {otlpSignalType} is not supported."),
+    };
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -90,7 +90,7 @@ internal static class OtlpExporterOptionsExtensions
             return new OtlpExporterPersistentStorageTransmissionHandler(
                 exportClient,
                 timeoutMilliseconds,
-                Path.Combine(experimentalOptions.DiskRetryDirectoryPath, "traces"));
+                Path.Combine(experimentalOptions.DiskRetryDirectoryPath, GetSignalStorageDirectoryName(otlpSignalType)));
         }
         else
         {
@@ -196,4 +196,13 @@ internal static class OtlpExporterOptionsExtensions
 
         return new Uri(string.Concat(uri.AbsoluteUri, separator, path));
     }
+
+    private static string GetSignalStorageDirectoryName(OtlpSignalType otlpSignalType)
+        => otlpSignalType switch
+        {
+            OtlpSignalType.Traces => "traces",
+            OtlpSignalType.Metrics => "metrics",
+            OtlpSignalType.Logs => "logs",
+            _ => throw new NotSupportedException($"OtlpSignalType {otlpSignalType} is not supported."),
+        };
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -131,8 +131,8 @@ public class OtlpExporterOptionsExtensionsTests
 
     [Theory]
     [InlineData("Traces", "traces")]
-    [InlineData("Metrics", "metrics")]
     [InlineData("Logs", "logs")]
+    [InlineData("Metrics", "metrics")]
     public void GetTransmissionHandler_DiskRetry_UsesSignalSpecificStorageDirectory(string signalTypeName, string expectedDirectoryName)
     {
         var retryRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -142,9 +142,9 @@ public class OtlpExporterOptionsExtensionsTests
             var exporterOptions = new OtlpExporterOptions();
             var signalType = signalTypeName switch
             {
-                "Traces" => OtlpSignalType.Traces,
-                "Metrics" => OtlpSignalType.Metrics,
                 "Logs" => OtlpSignalType.Logs,
+                "Metrics" => OtlpSignalType.Metrics,
+                "Traces" => OtlpSignalType.Traces,
                 _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
             };
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -140,7 +140,13 @@ public class OtlpExporterOptionsExtensionsTests
         try
         {
             var exporterOptions = new OtlpExporterOptions();
-            var signalType = GetSignalType(signalTypeName);
+            var signalType = signalTypeName switch
+            {
+                "Traces" => OtlpSignalType.Traces,
+                "Metrics" => OtlpSignalType.Metrics,
+                "Logs" => OtlpSignalType.Logs,
+                _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
+            };
 
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(
@@ -169,16 +175,16 @@ public class OtlpExporterOptionsExtensionsTests
     }
 
     [Theory]
-    [InlineData("Profiles")]
-    [InlineData("Foo")]
-    public void GetTransmissionHandler_DiskRetry_UnsupportedSignalType_ThrowsNotSupportedException(string signalTypeName)
+    [InlineData(3)] // Profiles
+    [InlineData(int.MaxValue)] // Invalid/Unknown signal type
+    public void GetTransmissionHandler_DiskRetry_UnsupportedSignalType_ThrowsNotSupportedException(int signalTypeValue)
     {
         var retryRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
         try
         {
             var exporterOptions = new OtlpExporterOptions();
-            var signalType = GetSignalType(signalTypeName);
+            var signalType = (OtlpSignalType)signalTypeValue;
 
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(
@@ -220,16 +226,6 @@ public class OtlpExporterOptionsExtensionsTests
 
         Assert.Equal(expectedTimeoutMilliseconds, transmissionHandler.TimeoutMilliseconds);
     }
-
-    private static OtlpSignalType GetSignalType(string signalTypeName) => signalTypeName switch
-    {
-        "Foo" => (OtlpSignalType)int.MaxValue,
-        "Logs" => OtlpSignalType.Logs,
-        "Metrics" => OtlpSignalType.Metrics,
-        "Profiles" => (OtlpSignalType)3,
-        "Traces" => OtlpSignalType.Traces,
-        _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
-    };
 
     /// <summary>
     /// Validates whether the `Headers` property in `OtlpExporterOptions` is correctly processed and parsed.

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
+using OpenTelemetry.PersistentStorage.FileSystem;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
@@ -126,6 +127,51 @@ public class OtlpExporterOptionsExtensionsTests
 
         var transmissionHandler = exporterOptions.GetExportTransmissionHandler(new ExperimentalOptions(configuration), OtlpSignalType.Traces);
         AssertTransmissionHandler(transmissionHandler, exportClientType, expectedTimeoutMilliseconds, retryStrategy);
+    }
+
+    [Theory]
+    [InlineData("Traces", "traces")]
+    [InlineData("Metrics", "metrics")]
+    [InlineData("Logs", "logs")]
+    public void GetTransmissionHandler_DiskRetry_UsesSignalSpecificStorageDirectory(string signalTypeName, string expectedDirectoryName)
+    {
+        var retryRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        try
+        {
+            var exporterOptions = new OtlpExporterOptions();
+            var signalType = signalTypeName switch
+            {
+                "Traces" => OtlpSignalType.Traces,
+                "Metrics" => OtlpSignalType.Metrics,
+                "Logs" => OtlpSignalType.Logs,
+                _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    [ExperimentalOptions.OtlpRetryEnvVar] = "disk",
+                    [ExperimentalOptions.OtlpDiskRetryDirectoryPathEnvVar] = retryRootPath,
+                })
+                .Build();
+
+            var transmissionHandler = exporterOptions.GetExportTransmissionHandler(new ExperimentalOptions(configuration), signalType);
+            var persistentStorageTransmissionHandler = Assert.IsType<OtlpExporterPersistentStorageTransmissionHandler>(transmissionHandler);
+
+            var fileBlobProviderField = typeof(OtlpExporterPersistentStorageTransmissionHandler).GetField("persistentBlobProvider", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var persistentBlobProvider = Assert.IsType<FileBlobProvider>(fileBlobProviderField?.GetValue(persistentStorageTransmissionHandler));
+
+            Assert.EndsWith(expectedDirectoryName, persistentBlobProvider.DirectoryPath, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(retryRootPath))
+            {
+                Directory.Delete(retryRootPath, recursive: true);
+            }
+        }
     }
 
     private static void AssertTransmissionHandler(OtlpExporterTransmissionHandler transmissionHandler, Type exportClientType, int expectedTimeoutMilliseconds, string? retryStrategy)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -140,13 +140,7 @@ public class OtlpExporterOptionsExtensionsTests
         try
         {
             var exporterOptions = new OtlpExporterOptions();
-            var signalType = signalTypeName switch
-            {
-                "Traces" => OtlpSignalType.Traces,
-                "Metrics" => OtlpSignalType.Metrics,
-                "Logs" => OtlpSignalType.Logs,
-                _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
-            };
+            var signalType = GetSignalType(signalTypeName);
 
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(
@@ -164,6 +158,39 @@ public class OtlpExporterOptionsExtensionsTests
             var persistentBlobProvider = Assert.IsType<FileBlobProvider>(fileBlobProviderField?.GetValue(persistentStorageTransmissionHandler));
 
             Assert.EndsWith(expectedDirectoryName, persistentBlobProvider.DirectoryPath, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(retryRootPath))
+            {
+                Directory.Delete(retryRootPath, recursive: true);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("Profiles")]
+    [InlineData("Foo")]
+    public void GetTransmissionHandler_DiskRetry_UnsupportedSignalType_ThrowsNotSupportedException(string signalTypeName)
+    {
+        var retryRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        try
+        {
+            var exporterOptions = new OtlpExporterOptions();
+            var signalType = GetSignalType(signalTypeName);
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    [ExperimentalOptions.OtlpRetryEnvVar] = "disk",
+                    [ExperimentalOptions.OtlpDiskRetryDirectoryPathEnvVar] = retryRootPath,
+                })
+                .Build();
+
+            Assert.Throws<NotSupportedException>(
+                () => exporterOptions.GetExportTransmissionHandler(new ExperimentalOptions(configuration), signalType));
         }
         finally
         {
@@ -193,6 +220,17 @@ public class OtlpExporterOptionsExtensionsTests
 
         Assert.Equal(expectedTimeoutMilliseconds, transmissionHandler.TimeoutMilliseconds);
     }
+
+    private static OtlpSignalType GetSignalType(string signalTypeName)
+        => signalTypeName switch
+        {
+            "Traces" => OtlpSignalType.Traces,
+            "Metrics" => OtlpSignalType.Metrics,
+            "Logs" => OtlpSignalType.Logs,
+            "Profiles" => (OtlpSignalType)3,
+            "Foo" => (OtlpSignalType)int.MaxValue,
+            _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
+        };
 
     /// <summary>
     /// Validates whether the `Headers` property in `OtlpExporterOptions` is correctly processed and parsed.

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -221,16 +221,15 @@ public class OtlpExporterOptionsExtensionsTests
         Assert.Equal(expectedTimeoutMilliseconds, transmissionHandler.TimeoutMilliseconds);
     }
 
-    private static OtlpSignalType GetSignalType(string signalTypeName)
-        => signalTypeName switch
-        {
-            "Traces" => OtlpSignalType.Traces,
-            "Metrics" => OtlpSignalType.Metrics,
-            "Logs" => OtlpSignalType.Logs,
-            "Profiles" => (OtlpSignalType)3,
-            "Foo" => (OtlpSignalType)int.MaxValue,
-            _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
-        };
+    private static OtlpSignalType GetSignalType(string signalTypeName) => signalTypeName switch
+    {
+        "Foo" => (OtlpSignalType)int.MaxValue,
+        "Logs" => OtlpSignalType.Logs,
+        "Metrics" => OtlpSignalType.Metrics,
+        "Profiles" => (OtlpSignalType)3,
+        "Traces" => OtlpSignalType.Traces,
+        _ => throw new ArgumentOutOfRangeException(nameof(signalTypeName)),
+    };
 
     /// <summary>
     /// Validates whether the `Headers` property in `OtlpExporterOptions` is correctly processed and parsed.


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex/security scans.

## Changes

Fixed an issue with OTLP disk retry storage where metrics and logs used the traces storage directory. Disk retry storage is now separated by signal using `traces`, `metrics`, and `logs` directories.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~[ ] Changes in public API reviewed (if applicable)~
