### PR TITLE
[Exporter.Prometheus] Fix crashes on empty label names

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -11,6 +11,10 @@ Notes](../../RELEASENOTES.md).
   not being sanitized, resulting in malformed metric names.
   ([#6187](https://github.com/open-telemetry/opentelemetry-dotnet/issues/6187))
 
+* Fixed Prometheus metric serialization to handle empty label names without
+  throwing during scrape rendering.
+  ([#7077](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7077))
+
 ## 1.15.2-beta.1
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -139,7 +139,11 @@ internal static partial class PrometheusSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteLabelKey(byte[] buffer, int cursor, string value)
     {
-        Debug.Assert(!string.IsNullOrEmpty(value), $"{nameof(value)} should not be null or empty.");
+        if (string.IsNullOrEmpty(value))
+        {
+            buffer[cursor++] = unchecked((byte)'_');
+            return cursor;
+        }
 
         var ordinal = (ushort)value[0];
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -174,6 +174,45 @@ public sealed class PrometheusSerializerTests
     }
 
     [Fact]
+    public void GaugeEmptyDimensionName()
+    {
+        var buffer = new byte[85000];
+        var metrics = new List<Metric>();
+
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+        meter.CreateObservableGauge(
+            "test_gauge",
+            () => new Measurement<long>(123, new KeyValuePair<string, object?>(string.Empty, "tagValue")));
+
+        provider.ForceFlush();
+
+        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        Assert.Matches(
+            ("^"
+                + "# TYPE test_gauge gauge\n"
+                + $"test_gauge{{otel_scope_name='{Utils.GetCurrentMethodName()}',_='tagValue'}} 123 \\d+\n"
+                + "$").Replace('\'', '"'),
+            Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void WriteLabelKeyNullOrEmptyName(string? labelName)
+    {
+        var buffer = new byte[32];
+
+        var cursor = PrometheusSerializer.WriteLabelKey(buffer, 0, labelName!);
+
+        Assert.Equal("_", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Fact]
     public void GaugeDoubleSubnormal()
     {
         var buffer = new byte[85000];


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex/security scans.

## Changes

Fixed Prometheus metric serialization to handle empty label names without throwing during scrape rendering.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
