### PR TITLE
[OpenTelemetry] Metrics - Raise min CircularBufferBuckets capacity to 2

### DIFF
--- a/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
+++ b/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
@@ -17,7 +17,7 @@ internal sealed class CircularBufferBuckets
 
     public CircularBufferBuckets(int capacity)
     {
-        Guard.ThrowIfOutOfRange(capacity, min: 1);
+        Guard.ThrowIfOutOfRange(capacity, min: 2);
 
         this.Capacity = capacity;
     }

--- a/test/OpenTelemetry.Tests/Metrics/CircularBufferBucketsTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/CircularBufferBucketsTests.cs
@@ -11,6 +11,7 @@ public class CircularBufferBucketsTests
     public void ConstructorThrowsOnInvalidCapacity()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new CircularBufferBuckets(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CircularBufferBuckets(1));
         Assert.Throws<ArgumentOutOfRangeException>(() => new CircularBufferBuckets(-1));
     }
 
@@ -129,53 +130,6 @@ public class CircularBufferBucketsTests
         Assert.Equal(3, buckets[0]);
         Assert.Equal(4, buckets[1]);
         Assert.Equal(5, buckets[2]);
-    }
-
-    [Fact]
-    public void ScaleDownCapacity1()
-    {
-        var buckets = new CircularBufferBuckets(1);
-
-        buckets.ScaleDown(1);
-        buckets.ScaleDown(2);
-        buckets.ScaleDown(3);
-        buckets.ScaleDown(4);
-
-        buckets.TryIncrement(0);
-
-        Assert.Equal(0, buckets.Offset);
-        Assert.Equal(1, buckets.Size);
-        Assert.Equal(1, buckets[0]);
-    }
-
-    [Fact]
-    public void ScaleDownIntMaxValue()
-    {
-        var buckets = new CircularBufferBuckets(1);
-
-        buckets.TryIncrement(int.MaxValue);
-
-        Assert.Equal(int.MaxValue, buckets.Offset);
-
-        buckets.ScaleDown(1);
-
-        Assert.Equal(0x3FFFFFFF, buckets.Offset);
-        Assert.Equal(1, buckets[0x3FFFFFFF]);
-    }
-
-    [Fact]
-    public void ScaleDownIntMinValue()
-    {
-        var buckets = new CircularBufferBuckets(1);
-
-        buckets.TryIncrement(int.MinValue);
-
-        Assert.Equal(int.MinValue, buckets.Offset);
-
-        buckets.ScaleDown(1);
-
-        Assert.Equal(-0x40000000, buckets.Offset);
-        Assert.Equal(1, buckets[-0x40000000]);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex/security scans.

## Changes

`Base2ExponentialBucketHistogram` bucket initialization now rejects invalid `maxBuckets` values smaller than 2, preventing a possible hang during metrics recording.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~Appropriate `CHANGELOG.md` files updated for non-trivial changes~
* [ ] ~Changes in public API reviewed (if applicable)~
