### PR TITLE
[Shims.OpenTracing] Fixes support for byte, short, int, float attributes

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixes support for `byte`, `short`, `int`, and `float` attributes.
+  ([#7080](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7080))
+
 ## 1.15.2-beta.1
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -66,6 +66,15 @@ internal sealed class SpanShim : ISpan
         {
             switch (field.Value)
             {
+                case byte value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case short value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case int value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
                 case long value:
                     spanAttributes.Add(field.Key, value);
                     break;
@@ -76,6 +85,9 @@ internal sealed class SpanShim : ISpan
                     spanAttributes.Add(field.Key, value);
                     break;
                 case bool[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case float value:
                     spanAttributes.Add(field.Key, value);
                     break;
                 case double value:

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -221,7 +221,7 @@ public class SpanShimTests
 
         Assert.Equal(6, tags.Count);
 
-        // float→double widening: 0.1f is not exactly 0.1D due to IEEE 754 representation.
+        // float->double widening: 0.1f is not exactly 0.1D due to IEEE 754 representation.
         // Verify that the stored value matches the widened float, not the double literal.
         double expectedFloatPointOne = 0.1f;
         Assert.Equal(expectedFloatPointOne, Assert.IsType<double>(tags["float-point-one"]));

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -200,6 +200,47 @@ public class SpanShimTests
     }
 
     [Fact]
+    public void LogUsingFieldsPreservesFractionalNumericValues()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        shim.Log(
+        [
+            new("float-point-one", 0.1f),
+            new("double-point-one", 0.1D),
+            new("float-point-three", 0.3f),
+            new("double-point-three", 0.3D),
+            new("float-exact", 1.5f),
+            new("double-exact", 1.5D),
+        ]);
+
+        Assert.NotNull(shim.Span.Activity);
+        var evt = Assert.Single(shim.Span.Activity.Events);
+        var tags = evt.Tags.ToDictionary(pair => pair.Key, pair => pair.Value);
+
+        Assert.Equal(6, tags.Count);
+
+        // float→double widening: 0.1f is not exactly 0.1D due to IEEE 754 representation.
+        // Verify that the stored value matches the widened float, not the double literal.
+        double expectedFloatPointOne = 0.1f;
+        Assert.Equal(expectedFloatPointOne, Assert.IsType<double>(tags["float-point-one"]));
+        Assert.NotEqual(0.1D, (double)tags["float-point-one"]!);
+
+        Assert.Equal(0.1D, Assert.IsType<double>(tags["double-point-one"]));
+
+        double expectedFloatPointThree = 0.3f;
+        Assert.Equal(expectedFloatPointThree, Assert.IsType<double>(tags["float-point-three"]));
+        Assert.NotEqual(0.3D, (double)tags["float-point-three"]!);
+
+        Assert.Equal(0.3D, Assert.IsType<double>(tags["double-point-three"]));
+
+        // 1.5 is exactly representable in both float and double.
+        Assert.Equal(1.5D, Assert.IsType<double>(tags["float-exact"]));
+        Assert.Equal(1.5D, Assert.IsType<double>(tags["double-exact"]));
+    }
+
+    [Fact]
     public void SetTagStringValue()
     {
         var tracer = TracerProvider.Default.GetTracer(TracerName);

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -170,6 +170,36 @@ public class SpanShimTests
     }
 
     [Fact]
+    public void LogUsingFieldsPreservesAllSupportedScalarNumericTypes()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        shim.Log(
+        [
+            new("byte-value", (byte)1),
+            new("short-value", (short)2),
+            new("int-value", 3),
+            new("long-value", 4L),
+            new("float-value", 5f),
+            new("double-value", 6D),
+        ]);
+
+        Assert.NotNull(shim.Span.Activity);
+        var evt = Assert.Single(shim.Span.Activity.Events);
+        var tags = evt.Tags.ToDictionary(pair => pair.Key, pair => pair.Value);
+
+        Assert.Equal(6, tags.Count);
+
+        Assert.Equal(1L, Assert.IsType<long>(tags["byte-value"]));
+        Assert.Equal(2L, Assert.IsType<long>(tags["short-value"]));
+        Assert.Equal(3L, Assert.IsType<long>(tags["int-value"]));
+        Assert.Equal(4L, Assert.IsType<long>(tags["long-value"]));
+        Assert.Equal(5D, Assert.IsType<double>(tags["float-value"]));
+        Assert.Equal(6D, Assert.IsType<double>(tags["double-value"]));
+    }
+
+    [Fact]
     public void SetTagStringValue()
     {
         var tracer = TracerProvider.Default.GetTracer(TracerName);


### PR DESCRIPTION
Fixes Codex/security findings. It is not considered as a security fix. Just detected during such scans.

## Changes

[Shims.OpenTracing] Fixes support for byte, short, int, float attributes
Technically, package is deprecated, but the fix seems be easy enough to avoid occurrence in the similar scans in the future.


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
