### PR TITLE
[OpenTelemetry] Logs - Return None for unset or out-of-range LogLevel mapping

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,6 +9,10 @@ Notes](../../RELEASENOTES.md).
 * Fix resource leak in batch and periodic exporting task workers for Blazor/WASM.
   ([#7069](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7069))
 
+* Fixed `LogRecord.LogLevel` to preserve `LogLevel.None` and handle
+  unspecified or out-of-range severities without returning invalid enum values.
+  ([#7092](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7092))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -189,16 +189,18 @@ public sealed class LogRecord
     {
         get
         {
-            if (this.Data.Severity.HasValue)
+            if (!this.Data.Severity.HasValue)
             {
-                var severity = (uint)this.Data.Severity.Value;
-                if (severity is >= 1 and <= 24)
-                {
-                    return (LogLevel)((severity - 1) / 4);
-                }
+                return LogLevel.None;
             }
 
-            return LogLevel.Trace;
+            var severity = (uint)this.Data.Severity.Value;
+            if (severity is >= 1 and <= 24)
+            {
+                return (LogLevel)((severity - 1) / 4);
+            }
+
+            return LogLevel.None;
         }
 
         set => OpenTelemetryLogger.SetLogRecordSeverityFields(ref this.Data, value);

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -194,7 +194,7 @@ public sealed class LogRecord
                 return LogLevel.None;
             }
 
-            var severity = (uint)this.Data.Severity.Value;
+            var severity = (uint)this.Data.Severity.GetValueOrDefault();
             if (severity is >= 1 and <= 24)
             {
                 return (LogLevel)((severity - 1) / 4);

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTests.cs
@@ -922,8 +922,8 @@ public sealed class LogRecordTests
     }
 
     [Theory]
-    [InlineData((int)LogRecordSeverity.Unspecified, LogLevel.Trace)]
-    [InlineData(int.MaxValue, LogLevel.Trace)]
+    [InlineData((int)LogRecordSeverity.Unspecified, LogLevel.None)]
+    [InlineData(int.MaxValue, LogLevel.None)]
     [InlineData((int)LogRecordSeverity.Trace, LogLevel.Trace, (int)LogRecordSeverity.Trace)]
     [InlineData((int)LogRecordSeverity.Trace2, LogLevel.Trace, (int)LogRecordSeverity.Trace)]
     [InlineData((int)LogRecordSeverity.Trace3, LogLevel.Trace, (int)LogRecordSeverity.Trace)]
@@ -966,6 +966,19 @@ public sealed class LogRecordTests
             Assert.Equal((LogRecordSeverity)transformedLogSeverity.Value, logRecord.Severity);
             Assert.Equal(logLevel.ToString(), logRecord.SeverityText);
         }
+    }
+
+    [Fact]
+    public void LogLevelNoneRoundTripsWhenSeverityUnset()
+    {
+        var logRecord = new LogRecord
+        {
+            LogLevel = LogLevel.None,
+        };
+
+        Assert.Null(logRecord.Severity);
+        Assert.Null(logRecord.SeverityText);
+        Assert.Equal(LogLevel.None, logRecord.LogLevel);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes # N/A
Design discussion issue # N/A

Found by Codex/security scans.

## Changes

Fixed `LogRecord.LogLevel` to preserve `LogLevel.None` and handle unspecified or out-of-range severities without returning invalid enum values.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~
