### PR TITLE
[OTLP] Use shared helper to read string

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
@@ -99,9 +99,9 @@ internal abstract class OtlpExportClient : IExportClient
         // Note: SendAsync must be used with HTTP/2 because synchronous send is
         // not supported.
         this.RequireHttp2 || !SynchronousSendSupportedByCurrentPlatform
-            ? this.HttpClient.SendAsync(request, cancellationToken).GetAwaiter().GetResult()
-            : this.HttpClient.Send(request, cancellationToken);
+            ? this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).GetAwaiter().GetResult()
+            : this.HttpClient.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 #else
-        this.HttpClient.SendAsync(request, cancellationToken).GetAwaiter().GetResult();
+        this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).GetAwaiter().GetResult();
 #endif
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
@@ -94,14 +94,18 @@ internal abstract class OtlpExportClient : IExportClient
         return request;
     }
 
-    protected HttpResponseMessage SendHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken) =>
+    protected HttpResponseMessage SendHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // HTTP/2 (gRPC) requires reading the entire response content to ensure that the response trailers are received
+        var completionOption = this.RequireHttp2 ? HttpCompletionOption.ResponseContentRead : HttpCompletionOption.ResponseHeadersRead;
 #if NET
         // Note: SendAsync must be used with HTTP/2 because synchronous send is
         // not supported.
-        this.RequireHttp2 || !SynchronousSendSupportedByCurrentPlatform
-            ? this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).GetAwaiter().GetResult()
-            : this.HttpClient.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        return this.RequireHttp2 || !SynchronousSendSupportedByCurrentPlatform
+            ? this.HttpClient.SendAsync(request, completionOption, cancellationToken).GetAwaiter().GetResult()
+            : this.HttpClient.Send(request, completionOption, cancellationToken);
 #else
-        this.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).GetAwaiter().GetResult();
+        return this.HttpClient.SendAsync(request, completionOption, cancellationToken).GetAwaiter().GetResult();
 #endif
+    }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
@@ -4,11 +4,7 @@
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
-#if NET
-using System.Buffers;
-#endif
 using System.Net.Http.Headers;
-using System.Text;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
@@ -69,107 +65,8 @@ internal abstract class OtlpExportClient : IExportClient
         return true;
     }
 
-    protected internal static string? TryGetResponseBody(HttpResponseMessage? httpResponse, CancellationToken cancellationToken)
-    {
-        if (httpResponse?.Content == null || cancellationToken.IsCancellationRequested)
-        {
-            return null;
-        }
-
-        try
-        {
-#if NET
-            var stream = httpResponse.Content.ReadAsStream(cancellationToken);
-#else
-            var stream = httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
-#endif
-
-            // See https://github.com/open-telemetry/opentelemetry-proto/pull/781
-            const int MessageSizeLimit = 4 * 1024 * 1024; // 4MiB
-
-            var length = GetBufferLength(stream, MessageSizeLimit);
-
-#if NET
-            var buffer = ArrayPool<byte>.Shared.Rent(length);
-#else
-            var buffer = new byte[length];
-#endif
-
-            string result;
-
-            try
-            {
-                var count = 0;
-
-                // Read raw bytes so the size limit applies to bytes rather than characters
-                while (count < length && !cancellationToken.IsCancellationRequested)
-                {
-                    var read = stream.Read(buffer, count, length - count);
-
-                    if (read is 0)
-                    {
-                        break;
-                    }
-
-                    count += read;
-                }
-
-                // Decode using the charset from the response content headers, if available
-                var encoding = GetEncoding(httpResponse.Content.Headers.ContentType?.CharSet);
-                result = encoding.GetString(buffer, 0, count);
-
-                if (result.Length is MessageSizeLimit)
-                {
-                    result += "[TRUNCATED]";
-                }
-            }
-            finally
-            {
-#if NET
-                ArrayPool<byte>.Shared.Return(buffer);
-#endif
-            }
-
-            return result;
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-
-        static int GetBufferLength(Stream stream, int limit)
-        {
-            try
-            {
-                // Avoid allocating an overly large buffer if the stream is smaller than the size limit
-                return stream.Length < limit ? (int)stream.Length : limit;
-            }
-            catch (Exception)
-            {
-                // Not all Stream types support Length, so default to the maximum
-                return limit;
-            }
-        }
-
-        static Encoding GetEncoding(string? name)
-        {
-            Encoding encoding = Encoding.UTF8;
-
-            if (!string.IsNullOrWhiteSpace(name))
-            {
-                try
-                {
-                    encoding = Encoding.GetEncoding(name);
-                }
-                catch (Exception)
-                {
-                    // Invalid encoding name
-                }
-            }
-
-            return encoding;
-        }
-    }
+    protected internal static string? TryGetResponseBody(HttpResponseMessage? httpResponse, CancellationToken cancellationToken) =>
+        HttpClientHelpers.TryGetResponseBodyAsString(httpResponse, cancellationToken);
 
     protected HttpRequestMessage CreateHttpRequest(byte[] buffer, int contentLength)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
@@ -56,6 +56,8 @@ internal abstract class OtlpExportClient : IExportClient
 
     internal virtual bool RequireHttp2 => false;
 
+    internal virtual HttpCompletionOption CompletionOption => HttpCompletionOption.ResponseHeadersRead;
+
     public abstract ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default);
 
     /// <inheritdoc/>
@@ -94,18 +96,14 @@ internal abstract class OtlpExportClient : IExportClient
         return request;
     }
 
-    protected HttpResponseMessage SendHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        // HTTP/2 (gRPC) requires reading the entire response content to ensure that the response trailers are received
-        var completionOption = this.RequireHttp2 ? HttpCompletionOption.ResponseContentRead : HttpCompletionOption.ResponseHeadersRead;
+    protected HttpResponseMessage SendHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken) =>
 #if NET
         // Note: SendAsync must be used with HTTP/2 because synchronous send is
         // not supported.
-        return this.RequireHttp2 || !SynchronousSendSupportedByCurrentPlatform
-            ? this.HttpClient.SendAsync(request, completionOption, cancellationToken).GetAwaiter().GetResult()
-            : this.HttpClient.Send(request, completionOption, cancellationToken);
+        this.RequireHttp2 || !SynchronousSendSupportedByCurrentPlatform
+            ? this.HttpClient.SendAsync(request, this.CompletionOption, cancellationToken).GetAwaiter().GetResult()
+            : this.HttpClient.Send(request, this.CompletionOption, cancellationToken);
 #else
-        return this.HttpClient.SendAsync(request, completionOption, cancellationToken).GetAwaiter().GetResult();
+        this.HttpClient.SendAsync(request, this.CompletionOption, cancellationToken).GetAwaiter().GetResult();
 #endif
-    }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
@@ -34,6 +34,9 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
 
     internal override bool RequireHttp2 => true;
 
+    // We need the entire response content to ensure that the response trailers are received
+    internal override HttpCompletionOption CompletionOption => HttpCompletionOption.ResponseContentRead;
+
     /// <inheritdoc/>
     public override ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\HttpClientHelpers.cs" Link="Includes\HttpClientHelpers.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PeriodicExportingMetricReaderHelper.cs" Link="Includes\PeriodicExportingMetricReaderHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\TagWriter\ArrayTagWriter.cs" Link="Includes\TagWriter\ArrayTagWriter.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\TagWriter\TagWriter.cs" Link="Includes\TagWriter\TagWriter.cs" />

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -81,8 +81,8 @@ public class ZipkinExporter : BaseExporter<Activity>
 #pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 #if NET
             using var response = this.synchronousSendSupportedByCurrentPlatform
-            ? this.httpClient.Send(request, CancellationToken.None)
-            : this.httpClient.SendAsync(request, CancellationToken.None).GetAwaiter().GetResult();
+            ? this.httpClient.Send(request, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None)
+            : this.httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None).GetAwaiter().GetResult();
 #else
             using var response = this.httpClient.SendAsync(request, CancellationToken.None).GetAwaiter().GetResult();
 #endif

--- a/src/Shared/HttpClientHelpers.cs
+++ b/src/Shared/HttpClientHelpers.cs
@@ -73,19 +73,24 @@ internal static class HttpClientHelpers
                     totalRead += bytesRead;
                 }
 
-                // We've read exactly limit bytes. Check if there's more data.
-                var probe = new byte[1];
+                bool extra = false;
+
+                if (totalRead == limit)
+                {
+                    // We've read exactly limit bytes. Check if there's more data.
+                    var probe = new byte[1];
 
 #if NETFRAMEWORK || NETSTANDARD
-                var extra = stream.Read(probe, 0, 1);
+                    extra = stream.Read(probe, 0, 1) > 0;
 #else
-                var extra = stream.Read(probe);
+                    extra = stream.Read(probe) > 0;
 #endif
 
-                if (extra > 0 && !allowTruncation)
-                {
-                    // + 1: we read exactly MaxMessageSize bytes and confirmed at least one more byte exists.
-                    throw new InvalidOperationException($"Response body exceeded the size limit of {limit} bytes.");
+                    if (extra && !allowTruncation)
+                    {
+                        // + 1: we read exactly MaxMessageSize bytes and confirmed at least one more byte exists.
+                        throw new InvalidOperationException($"Response body exceeded the size limit of {limit} bytes.");
+                    }
                 }
 
                 if (!allowTruncation)
@@ -97,7 +102,7 @@ internal static class HttpClientHelpers
                 var encoding = GetEncoding(httpResponse.Content.Headers.ContentType?.CharSet);
                 var result = encoding.GetString(buffer, 0, totalRead);
 
-                if (extra > 0)
+                if (extra)
                 {
                     result += "[TRUNCATED]";
                 }

--- a/src/Shared/HttpClientHelpers.cs
+++ b/src/Shared/HttpClientHelpers.cs
@@ -107,7 +107,7 @@ internal static class HttpClientHelpers
             finally
             {
 #if NET
-                ArrayPool<byte>.Shared.Return(buffer);
+                ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
 #endif
             }
         }

--- a/src/Shared/HttpClientHelpers.cs
+++ b/src/Shared/HttpClientHelpers.cs
@@ -30,6 +30,12 @@ internal static class HttpClientHelpers
             return null;
         }
 
+        // Check Content-Length before reading if the header is present.
+        if (!allowTruncation && httpResponse.Content.Headers.ContentLength > limit)
+        {
+            throw new InvalidOperationException($"Response body exceeded the size limit of {limit} bytes.");
+        }
+
         if (cancellationToken.IsCancellationRequested)
         {
             if (allowTruncation)
@@ -43,9 +49,9 @@ internal static class HttpClientHelpers
         try
         {
 #if NET
-            var stream = httpResponse.Content.ReadAsStream(cancellationToken);
+            using var stream = httpResponse.Content.ReadAsStream(cancellationToken);
 #else
-            var stream = httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+            using var stream = httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
 #endif
 
             var length = GetBufferLength(stream, limit);
@@ -61,7 +67,7 @@ internal static class HttpClientHelpers
                 var totalRead = 0;
 
                 // Read raw bytes so the size limit applies to bytes rather than characters
-                while (totalRead < limit && !cancellationToken.IsCancellationRequested)
+                while (totalRead < length && !cancellationToken.IsCancellationRequested)
                 {
                     var bytesRead = stream.Read(buffer, totalRead, length - totalRead);
 
@@ -75,9 +81,9 @@ internal static class HttpClientHelpers
 
                 bool extra = false;
 
-                if (totalRead == limit)
+                if (totalRead == length)
                 {
-                    // We've read exactly limit bytes. Check if there's more data.
+                    // We've read exactly length bytes. Check if there's more data.
                     var probe = new byte[1];
 
 #if NETFRAMEWORK || NETSTANDARD

--- a/src/Shared/HttpClientHelpers.cs
+++ b/src/Shared/HttpClientHelpers.cs
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Buffers;
+#endif
+using System.Text;
+
+namespace System.Net.Http;
+
+internal static class HttpClientHelpers
+{
+    // See https://github.com/open-telemetry/opentelemetry-proto/pull/781
+    private const int DefaultMessageSizeLimit = 4 * 1024 * 1024; // 4MiB
+
+    internal static string? TryGetResponseBodyAsString(HttpResponseMessage? httpResponse, CancellationToken cancellationToken)
+        => GetResponseBodyAsString(allowTruncation: true, DefaultMessageSizeLimit, httpResponse, cancellationToken);
+
+    internal static string? GetResponseBodyAsString(HttpResponseMessage? httpResponse, CancellationToken cancellationToken)
+        => GetResponseBodyAsString(allowTruncation: false, DefaultMessageSizeLimit, httpResponse, cancellationToken);
+
+    private static string? GetResponseBodyAsString(
+        bool allowTruncation,
+        int limit,
+        HttpResponseMessage? httpResponse,
+        CancellationToken cancellationToken)
+    {
+        if (httpResponse?.Content is null)
+        {
+            return null;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            if (allowTruncation)
+            {
+                return null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        try
+        {
+#if NET
+            var stream = httpResponse.Content.ReadAsStream(cancellationToken);
+#else
+            var stream = httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+#endif
+
+            var length = GetBufferLength(stream, limit);
+
+#if NET
+            var buffer = ArrayPool<byte>.Shared.Rent(length);
+#else
+            var buffer = new byte[length];
+#endif
+
+            try
+            {
+                var totalRead = 0;
+
+                // Read raw bytes so the size limit applies to bytes rather than characters
+                while (totalRead < limit && !cancellationToken.IsCancellationRequested)
+                {
+                    var bytesRead = stream.Read(buffer, totalRead, length - totalRead);
+
+                    if (bytesRead is 0)
+                    {
+                        break;
+                    }
+
+                    totalRead += bytesRead;
+                }
+
+                // We've read exactly limit bytes. Check if there's more data.
+                var probe = new byte[1];
+
+#if NETFRAMEWORK || NETSTANDARD
+                var extra = stream.Read(probe, 0, 1);
+#else
+                var extra = stream.Read(probe);
+#endif
+
+                if (extra > 0 && !allowTruncation)
+                {
+                    // + 1: we read exactly MaxMessageSize bytes and confirmed at least one more byte exists.
+                    throw new InvalidOperationException($"Response body exceeded the size limit of {limit} bytes.");
+                }
+
+                if (!allowTruncation)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                // Decode using the charset from the response content headers, if available
+                var encoding = GetEncoding(httpResponse.Content.Headers.ContentType?.CharSet);
+                var result = encoding.GetString(buffer, 0, totalRead);
+
+                if (extra > 0)
+                {
+                    result += "[TRUNCATED]";
+                }
+
+                return result;
+            }
+            finally
+            {
+#if NET
+                ArrayPool<byte>.Shared.Return(buffer);
+#endif
+            }
+        }
+        catch (Exception) when (allowTruncation)
+        {
+            return null;
+        }
+    }
+
+    private static int GetBufferLength(Stream stream, int limit)
+    {
+        try
+        {
+            // Avoid allocating an overly large buffer if the stream is smaller than the size limit
+            return stream.Length < limit ? (int)stream.Length : limit;
+        }
+        catch (Exception)
+        {
+            // Not all Stream types support Length, so default to the maximum
+            return limit;
+        }
+    }
+
+    private static Encoding GetEncoding(string? name)
+    {
+        Encoding encoding = Encoding.UTF8;
+
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            try
+            {
+                encoding = Encoding.GetEncoding(name);
+            }
+            catch (Exception)
+            {
+                // Invalid encoding name
+            }
+        }
+
+        return encoding;
+    }
+}

--- a/src/Shared/HttpClientHelpers.cs
+++ b/src/Shared/HttpClientHelpers.cs
@@ -54,7 +54,7 @@ internal static class HttpClientHelpers
             using var stream = httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
 #endif
 
-            var length = GetBufferLength(stream, limit);
+            var length = GetBufferLength(stream, limit, httpResponse.Content.Headers.ContentLength);
 
 #if NET
             var buffer = ArrayPool<byte>.Shared.Rent(length);
@@ -128,8 +128,13 @@ internal static class HttpClientHelpers
         }
     }
 
-    private static int GetBufferLength(Stream stream, int limit)
+    private static int GetBufferLength(Stream stream, int limit, long? contentLength)
     {
+        if (contentLength is { } value && value <= limit)
+        {
+            return (int)value;
+        }
+
         try
         {
             // Avoid allocating an overly large buffer if the stream is smaller than the size limit

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterRetryTransmissionHandlerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterRetryTransmissionHandlerTests.cs
@@ -107,7 +107,7 @@ public class OtlpExporterRetryTransmissionHandlerTests
         {
             var allocatedBytes = GC.GetTotalAllocatedBytes() - this.before;
 
-            const int Limit = 1_000_000;
+            const int Limit = 2_000_000;
             Assert.False(
                 allocatedBytes > Limit,
                 $"{allocatedBytes} bytes were allocated during the operation which is more than the limit of {Limit}.");


### PR DESCRIPTION
## Changes

Move code to read a string from an `HttpResponseMessage` into a shared helper for future re-use.

Taken from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4117 ~~will leave in draft until that's merged in case there's code feedback to address~~.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
