### PR TITLE
[Infra] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -144,11 +144,7 @@ public class JaegerPropagator : TextMapPropagator
             return false;
         }
 
-#if NET
         var headerValue = jaegerHeader;
-#else
-        var headerValue = jaegerHeader!;
-#endif
         if (!TryExtractTraceParts(
                 headerValue,
                 out var traceIdStr,

--- a/src/OpenTelemetry/Internal/BatchExportThreadWorker.cs
+++ b/src/OpenTelemetry/Internal/BatchExportThreadWorker.cs
@@ -38,7 +38,7 @@ internal sealed class BatchExportThreadWorker<T> : BatchExportWorker<T>
         {
             IsBackground = true,
 #pragma warning disable CA1062 // Validate arguments of public methods - needed for netstandard2.1
-            Name = $"OpenTelemetry-{nameof(BatchExportProcessor<T>)}-{exporter.GetType().Name}",
+            Name = $"OpenTelemetry-{nameof(BatchExportProcessor<>)}-{exporter.GetType().Name}",
 #pragma warning restore CA1062 // Validate arguments of public methods - needed for netstandard2.1
         };
     }

--- a/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderThreadWorker.cs
+++ b/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderThreadWorker.cs
@@ -134,6 +134,8 @@ internal sealed class PeriodicExportingMetricReaderThreadWorker : PeriodicExport
                     OpenTelemetrySdkEventSource.Log.MetricReaderEvent("PeriodicExportingMetricReader calling MetricReader.Collect because the export interval has elapsed.");
                     this.MetricReader.Collect(this.ExportTimeoutMilliseconds);
                     break;
+                default:
+                    break;
             }
         }
     }

--- a/test/Benchmarks/Context/Propagation/BaggagePropagatorBenchmarks.cs
+++ b/test/Benchmarks/Context/Propagation/BaggagePropagatorBenchmarks.cs
@@ -35,11 +35,13 @@ public class BaggagePropagatorBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        IEnumerable<(string Key, string Value)> Items() =>
-            Enumerable.Range(0, this.ItemCount).Select(i =>
+        IEnumerable<(string Key, string Value)> Items()
+        {
+            return Enumerable.Range(0, this.ItemCount).Select(i =>
                 this.UseSpecialChars
                     ? ($"key {i}", $"value {i} !@#$%^&*()")
                     : ($"key{i}", $"value{i}"));
+        }
 
         var baggageHeader = string.Join(",", Items().Select(p =>
             $"{Uri.EscapeDataString(p.Key)}={Uri.EscapeDataString(p.Value)}"));

--- a/test/OpenTelemetry.Tests/Internal/InterlockedHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/InterlockedHelperTests.cs
@@ -10,12 +10,19 @@ public class InterlockedHelperTests
     [Fact]
     public async Task AddWhenCurrentValueIsNaNShouldNotHang()
     {
+        var timeout = TimeSpan.FromSeconds(2);
         var value = double.NaN;
 
         var task = Task.Run(() => InterlockedHelper.Add(ref value, 1d));
-        var completed = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(2))) == task;
 
+#if NET
+        await task.WaitAsync(timeout);
+#else
+        using var cts = new CancellationTokenSource(timeout);
+        var completed = await Task.WhenAny(task, Task.Delay(timeout, cts.Token)) == task;
         Assert.True(completed);
+#endif
+
         Assert.True(double.IsNaN(value));
     }
 }

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
@@ -166,7 +166,7 @@ public sealed class BatchLogRecordExportProcessorTests
 
         var scopeProvider = new LoggerExternalScopeProvider();
 
-        List<LogRecord> exportedItems = new();
+        List<LogRecord> exportedItems = [];
 
         var processor = new BatchLogRecordExportProcessor(
 #pragma warning disable CA2000 // Dispose objects before losing scope


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 3 SDK in #6899.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
