### PR TITLE
[Exporter.OTLP] Update PersistentStorage to 1.1.0

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -56,7 +56,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
             return false;
         }
 
-        return this.persistentBlobProvider.TryCreateBlob(request.AsSpan(0, contentLength).ToArray(), out _);
+        return this.persistentBlobProvider.TryCreateBlob(request.AsSpan(0, contentLength), out _);
     }
 
     protected override void OnShutdown(int timeoutMilliseconds)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/FileBlob.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/FileBlob.cs
@@ -58,6 +58,11 @@ public class FileBlob : PersistentBlob
     {
         Guard.ThrowIfNull(buffer);
 
+        return this.OnTryWriteSpan(buffer.AsSpan(), leasePeriodMilliseconds);
+    }
+
+    protected override bool OnTryWriteSpan(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds)
+    {
         var path = this.FullPath + ".tmp";
 
         try
@@ -78,7 +83,7 @@ public class FileBlob : PersistentBlob
             return false;
         }
 
-        this.directorySizeTracker?.FileAdded(buffer.LongLength);
+        this.directorySizeTracker?.FileAdded(buffer.Length);
         return true;
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/FileBlobProvider.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/FileBlobProvider.cs
@@ -114,12 +114,26 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
 
     protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob)
     {
-        blob = this.CreateFileBlob(buffer, leasePeriodMilliseconds);
+        blob = this.CreateFileBlob(new ReadOnlySpan<byte>(buffer), leasePeriodMilliseconds);
 
         return blob != null;
     }
 
     protected override bool OnTryCreateBlob(byte[] buffer, [NotNullWhen(true)] out PersistentBlob? blob)
+    {
+        blob = this.CreateFileBlob(new ReadOnlySpan<byte>(buffer));
+
+        return blob != null;
+    }
+
+    protected override bool OnTryCreateBlob(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob)
+    {
+        blob = this.CreateFileBlob(buffer, leasePeriodMilliseconds);
+
+        return blob != null;
+    }
+
+    protected override bool OnTryCreateBlob(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out PersistentBlob? blob)
     {
         blob = this.CreateFileBlob(buffer);
 
@@ -185,7 +199,7 @@ public class FileBlobProvider : PersistentBlobProvider, IDisposable
         return true;
     }
 
-    private FileBlob? CreateFileBlob(byte[] buffer, int leasePeriodMilliseconds = 0)
+    private FileBlob? CreateFileBlob(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds = 0)
     {
         if (!this.CheckStorageSize())
         {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentBlob.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentBlob.cs
@@ -49,11 +49,37 @@ public abstract class PersistentBlob
     /// <returns>
     /// True if the write operation succeeded or else false.
     /// </returns>
+    [Obsolete("Use TryWrite(ReadOnlySpan<byte>, int) instead. This overload will be removed in a future major version.")]
     public bool TryWrite(byte[] buffer, int leasePeriodMilliseconds = 0)
     {
         try
         {
             return this.OnTryWrite(buffer, leasePeriodMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            PersistentStorageAbstractionsEventSource.Log.PersistentStorageAbstractionsException(nameof(PersistentBlob), "Failed to write the blob", ex);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to write the given content to the blob.
+    /// </summary>
+    /// <param name="buffer">
+    /// The content to be written.
+    /// </param>
+    /// <param name="leasePeriodMilliseconds">
+    /// The number of milliseconds to lease after the write operation finished.
+    /// </param>
+    /// <returns>
+    /// True if the write operation succeeded or else false.
+    /// </returns>
+    public bool TryWrite(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds = 0)
+    {
+        try
+        {
+            return this.OnTryWriteSpan(buffer, leasePeriodMilliseconds);
         }
         catch (Exception ex)
         {
@@ -106,6 +132,9 @@ public abstract class PersistentBlob
     protected abstract bool OnTryRead([NotNullWhen(true)] out byte[]? buffer);
 
     protected abstract bool OnTryWrite(byte[] buffer, int leasePeriodMilliseconds = 0);
+
+    protected virtual bool OnTryWriteSpan(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds)
+        => this.OnTryWrite(buffer.ToArray(), leasePeriodMilliseconds);
 
     protected abstract bool OnTryLease(int leasePeriodMilliseconds);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentBlobProvider.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentBlobProvider.cs
@@ -29,7 +29,37 @@ public abstract class PersistentBlobProvider
     /// <returns>
     /// True if the blob was created or else false.
     /// </returns>
+    [Obsolete("Use TryCreateBlob(ReadOnlySpan<byte>, int, out PersistentBlob?) instead. This overload will be removed in a future major version.")]
     public bool TryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob)
+    {
+        try
+        {
+            return this.OnTryCreateBlob(buffer, leasePeriodMilliseconds, out blob);
+        }
+        catch (Exception ex)
+        {
+            PersistentStorageAbstractionsEventSource.Log.PersistentStorageAbstractionsException(nameof(PersistentBlobProvider), "Failed to create and lease the blob", ex);
+            blob = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to create a new blob with the provided data and lease it.
+    /// </summary>
+    /// <param name="buffer">
+    /// The content to be written.
+    /// </param>
+    /// <param name="leasePeriodMilliseconds">
+    /// The number of milliseconds to lease after the blob is created.
+    /// </param>
+    /// <param name="blob">
+    /// Blob if it is created.
+    /// </param>
+    /// <returns>
+    /// True if the blob was created or else false.
+    /// </returns>
+    public bool TryCreateBlob(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob)
     {
         try
         {
@@ -55,7 +85,34 @@ public abstract class PersistentBlobProvider
     /// <returns>
     /// True if the blob was created or else false.
     /// </returns>
+    [Obsolete("Use TryCreateBlob(ReadOnlySpan<byte>, out PersistentBlob?) instead. This overload will be removed in a future major version.")]
     public bool TryCreateBlob(byte[] buffer, [NotNullWhen(true)] out PersistentBlob? blob)
+    {
+        try
+        {
+            return this.OnTryCreateBlob(buffer, out blob);
+        }
+        catch (Exception ex)
+        {
+            PersistentStorageAbstractionsEventSource.Log.PersistentStorageAbstractionsException(nameof(PersistentBlobProvider), "Failed to create the blob", ex);
+            blob = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to create a new blob with the provided data.
+    /// </summary>
+    /// <param name="buffer">
+    /// The content to be written.
+    /// </param>
+    /// <param name="blob">
+    /// Blob if it is created.
+    /// </param>
+    /// <returns>
+    /// True if the blob was created or else false.
+    /// </returns>
+    public bool TryCreateBlob(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out PersistentBlob? blob)
     {
         try
         {
@@ -116,6 +173,12 @@ public abstract class PersistentBlobProvider
     protected abstract bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob);
 
     protected abstract bool OnTryCreateBlob(byte[] buffer, [NotNullWhen(true)] out PersistentBlob? blob);
+
+    protected virtual bool OnTryCreateBlob(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob)
+        => this.OnTryCreateBlob(buffer.ToArray(), leasePeriodMilliseconds, out blob);
+
+    protected virtual bool OnTryCreateBlob(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out PersistentBlob? blob)
+        => this.OnTryCreateBlob(buffer.ToArray(), out blob);
 
     protected abstract bool OnTryGetBlob([NotNullWhen(true)] out PersistentBlob? blob);
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
@@ -117,6 +117,16 @@ internal static class PersistentStorageHelper
     internal static void WriteAllBytes(string path, byte[] buffer)
         => File.WriteAllBytes(path, buffer);
 
+    internal static void WriteAllBytes(string path, ReadOnlySpan<byte> buffer)
+    {
+#if NET
+        using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        stream.Write(buffer);
+#else
+        File.WriteAllBytes(path, buffer.ToArray());
+#endif
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void RemoveFile(string fileName, out long fileSize)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/README.md
@@ -1,9 +1,9 @@
 # Persistent Storage APIs for OTLP Exporter
 
 The files in this folder have been copied over from
-[OpenTelemetry.PersistentStorage.Abstractions](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/1be4157075ad09e13aa54b8e5845d2310bd82673/src/OpenTelemetry.PersistentStorage.Abstractions)
+[OpenTelemetry.PersistentStorage.Abstractions](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/PersistentStorage-1.1.0/src/OpenTelemetry.PersistentStorage.Abstractions)
 and
-[OpenTelemetry.PersistentStorage.FileSystem](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/1be4157075ad09e13aa54b8e5845d2310bd82673/src/OpenTelemetry.PersistentStorage.FileSystem).
+[OpenTelemetry.PersistentStorage.FileSystem](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/PersistentStorage-1.1.0/src/OpenTelemetry.PersistentStorage.FileSystem).
 Any code changes in this folder MUST go through changes in the original location
 i.e. in the contrib repo. Here is the sequence of steps to be followed when
 making changes:

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
@@ -620,18 +620,19 @@ public sealed class MockCollectorIntegrationTests
 
         public IEnumerable<PersistentBlob> TryGetBlobs() => this.mockStorage.AsEnumerable();
 
-        protected override IEnumerable<PersistentBlob> OnGetBlobs()
-        {
-            return this.mockStorage.AsEnumerable();
-        }
+        protected override IEnumerable<PersistentBlob> OnGetBlobs() => this.mockStorage.AsEnumerable();
 
-        protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out PersistentBlob blob)
+        protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, [NotNullWhen(true)] out PersistentBlob? blob) => this.OnTryCreateBlob(buffer.AsSpan(), out blob);
+
+        protected override bool OnTryCreateBlob(byte[] buffer, [NotNullWhen(true)] out PersistentBlob? blob) => this.OnTryCreateBlob(buffer.AsSpan(), out blob);
+
+        protected override bool OnTryCreateBlob(ReadOnlySpan<byte> buffer, int leasePeriodMilliseconds, out PersistentBlob blob)
         {
             blob = new MockFileBlob(this.mockStorage);
             return blob.TryWrite(buffer);
         }
 
-        protected override bool OnTryCreateBlob(byte[] buffer, out PersistentBlob blob)
+        protected override bool OnTryCreateBlob(ReadOnlySpan<byte> buffer, out PersistentBlob blob)
         {
             blob = new MockFileBlob(this.mockStorage);
             return blob.TryWrite(buffer);


### PR DESCRIPTION
Follow up to #7228 and https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4128
## Changes

[Exporter.OTLP] Update PersistentStorage to 1.1.0

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
