### PR TITLE
[API] Fix LogRecordAttributeList after Clear() call

### DIFF
--- a/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
@@ -50,10 +50,12 @@ internal
     {
         readonly get
         {
-            if (this.OverflowAttributes is not null)
+            if (this.Count > OverflowMaxCount)
             {
-                Debug.Assert(index < this.OverflowAttributes.Count, "Invalid index accessed.");
-                return this.OverflowAttributes[index];
+                var overflowAttributes = this.OverflowAttributes;
+                Debug.Assert(overflowAttributes is not null, "Overflow attributes creation failure.");
+                Debug.Assert(index < overflowAttributes!.Count, "Invalid index accessed.");
+                return overflowAttributes[index];
             }
 
             return (uint)index >= (uint)this.Count
@@ -74,10 +76,12 @@ internal
 
         set
         {
-            if (this.OverflowAttributes is not null)
+            if (this.Count > OverflowMaxCount)
             {
-                Debug.Assert(index < this.OverflowAttributes.Count, "Invalid index accessed.");
-                this.OverflowAttributes[index] = value;
+                var overflowAttributes = this.OverflowAttributes;
+                Debug.Assert(overflowAttributes is not null, "Overflow attributes creation failure.");
+                Debug.Assert(index < overflowAttributes!.Count, "Invalid index accessed.");
+                overflowAttributes[index] = value;
                 return;
             }
 
@@ -128,8 +132,11 @@ internal
         Guard.ThrowIfNull(attributes);
 
         LogRecordAttributeList logRecordAttributes = default;
-        logRecordAttributes.OverflowAttributes = [.. attributes];
-        logRecordAttributes.Count = logRecordAttributes.OverflowAttributes.Count;
+        foreach (var attribute in attributes)
+        {
+            logRecordAttributes.Add(attribute);
+        }
+
         return logRecordAttributes;
     }
 
@@ -221,11 +228,13 @@ internal
             return Empty;
         }
 
-        var overflowAttributes = this.OverflowAttributes;
-        if (overflowAttributes != null)
+        if (readonlyCount > OverflowMaxCount)
         {
+            var overflowAttributes = this.OverflowAttributes;
+            Debug.Assert(overflowAttributes is not null, "Overflow attributes creation failure.");
+
             // An allocation has already occurred, just use the list.
-            return overflowAttributes;
+            return overflowAttributes!;
         }
 
         Debug.Assert(readonlyCount <= 8, "Invalid size detected.");
@@ -285,6 +294,7 @@ internal
         Debug.Assert(this.Count - 1 == OverflowMaxCount, "count did not match OverflowMaxCount");
 
         var attributes = this.OverflowAttributes ??= new(OverflowAdditionalCapacity);
+        Debug.Assert(attributes.Count == 0, "Overflow attributes should be empty before transfer.");
 
         attributes.Add(this.attribute1);
         attributes.Add(this.attribute2);

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
@@ -86,6 +86,61 @@ public sealed class LogRecordAttributeListTests
         }
     }
 
+    [Fact]
+    public void ClearAfterOverflowThenReuseWithInlineCountTest()
+    {
+        LogRecordAttributeList attributes = default;
+
+        for (var i = 0; i <= LogRecordAttributeList.OverflowMaxCount; i++)
+        {
+            attributes.Add($"key{i}", i);
+        }
+
+        Assert.NotNull(attributes.OverflowAttributes);
+
+        attributes.Clear();
+        attributes.Add("key0", 0);
+
+        var item = attributes[0];
+        Assert.Equal("key0", item.Key);
+        Assert.Equal(0, (int)item.Value!);
+
+        Assert.Collection(
+            attributes,
+            exportedItem =>
+            {
+                Assert.Equal("key0", exportedItem.Key);
+                Assert.Equal(0, (int)exportedItem.Value!);
+            });
+    }
+
+    [Fact]
+    public void CreateFromEnumerableSmallCountThenAddToOverflowTest()
+    {
+        var sourceAttributes = new List<KeyValuePair<string, object?>>
+        {
+            new("key0", 0),
+            new("key1", 1),
+            new("key2", 2),
+        };
+
+        var attributes = LogRecordAttributeList.CreateFromEnumerable(sourceAttributes);
+
+        for (var i = 3; i <= LogRecordAttributeList.OverflowMaxCount; i++)
+        {
+            attributes.Add($"key{i}", i);
+        }
+
+        Assert.Equal(LogRecordAttributeList.OverflowMaxCount + 1, attributes.Count);
+
+        for (var i = 0; i < attributes.Count; i++)
+        {
+            var item = attributes[i];
+            Assert.Equal($"key{i}", item.Key);
+            Assert.Equal(i, (int)item.Value!);
+        }
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(1)]


### PR DESCRIPTION
Found by Codex analysis
Issue introduced in #4422

## Changes

* Fixed `LogRecordAttributeList` attribute reuse behavior to prevent stale
  overflow state after `Clear()` from causing incorrect attribute reads.Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
