### PR TITLE
[OpenTelemetry] Edge cases for parsing OTEL_TRACES_SAMPLER_ARG

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -13,6 +13,11 @@ Notes](../../RELEASENOTES.md).
   unspecified or out-of-range severities without returning invalid enum values.
   ([#7092](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7092))
 
+* Fixed `OTEL_TRACES_SAMPLER_ARG` handling to treat out-of-range, `NaN`, and
+  infinite values as invalid and fall back to the default ratio when using
+  `traceidratio` and `parentbased_traceidratio` samplers.
+  ([#7103](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7103))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -444,7 +444,11 @@ internal sealed class TracerProviderSdk : TracerProvider
     private static double ReadTraceIdRatio(IConfiguration configuration)
     {
         if (configuration.TryGetStringValue(TracesSamplerArgConfigKey, out var configValue) &&
-                double.TryParse(configValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var traceIdRatio))
+                double.TryParse(configValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var traceIdRatio) &&
+                !double.IsNaN(traceIdRatio) &&
+                !double.IsInfinity(traceIdRatio) &&
+                traceIdRatio >= 0.0 &&
+                traceIdRatio <= 1.0)
         {
             return traceIdRatio;
         }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
@@ -1063,10 +1063,14 @@ public sealed class TracerProviderSdkTests : IDisposable
     [InlineData("always_OFF", null, "AlwaysOffSampler")]
     [InlineData("traceidratio", "0.5", "TraceIdRatioBasedSampler{0.500000}")]
     [InlineData("traceidratio", "not_a_double", "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("traceidratio", "2.0", "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("traceidratio", "-0.1", "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("traceidratio", "NaN", "TraceIdRatioBasedSampler{1.000000}")]
     [InlineData("parentbased_always_on", null, "ParentBased{AlwaysOnSampler}")]
     [InlineData("parentbased_always_off", null, "ParentBased{AlwaysOffSampler}")]
     [InlineData("parentbased_traceidratio", "0.111", "ParentBased{TraceIdRatioBasedSampler{0.111000}}")]
     [InlineData("parentbased_traceidratio", "not_a_double", "ParentBased{TraceIdRatioBasedSampler{1.000000}}")]
+    [InlineData("parentbased_traceidratio", "Infinity", "ParentBased{TraceIdRatioBasedSampler{1.000000}}")]
     [InlineData("ParentBased_TraceIdRatio", "0.000001", "ParentBased{TraceIdRatioBasedSampler{0.000001}}")]
     public void TestSamplerSetFromConfiguration(string? configValue, string? argValue, string samplerDescription)
     {


### PR DESCRIPTION
Fixes Codex analysis finding

## Changes

* Fixed `OTEL_TRACES_SAMPLER_ARG` handling to treat out-of-range, `NaN`, and
infinite values as invalid and fall back to the default ratio when using
`traceidratio` and `parentbased_traceidratio` samplers.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
