### PR TITLE
[OTLP] Only load custom CA certificate once

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
@@ -127,9 +127,7 @@ internal static class OtlpSecureHttpClientFactory
     public static HttpClient CreateMtlsHttpClient(
         OtlpMtlsOptions mtlsOptions,
         Action<HttpClient>? configureClient = null)
-    {
-        return CreateSecureHttpClient(mtlsOptions, configureClient);
-    }
+        => CreateSecureHttpClient(mtlsOptions, configureClient);
 
     /// <summary>
     /// HttpClientHandler that applies TLS configuration based on loaded certificates.
@@ -138,6 +136,7 @@ internal static class OtlpSecureHttpClientFactory
     {
         private readonly byte[]? caCertificateData;
         private readonly X509Certificate2? clientCertificate;
+        private X509Certificate2? certificateAuthorityCertificate;
 
         internal TlsHttpClientHandler(
             byte[]? caCertificateData,
@@ -146,7 +145,18 @@ internal static class OtlpSecureHttpClientFactory
             this.caCertificateData = caCertificateData;
             this.clientCertificate = clientCertificate;
 
-            this.ConfigureTls();
+            this.CheckCertificateRevocationList = true;
+
+            if (this.clientCertificate != null)
+            {
+                this.ClientCertificates.Add(this.clientCertificate);
+                this.ClientCertificateOptions = ClientCertificateOption.Manual;
+            }
+
+            if (this.caCertificateData != null)
+            {
+                this.ServerCertificateCustomValidationCallback = this.ValidateServerCertificate;
+            }
         }
 
         protected override void Dispose(bool disposing)
@@ -156,58 +166,35 @@ internal static class OtlpSecureHttpClientFactory
             if (disposing)
             {
                 this.clientCertificate?.Dispose();
+                this.certificateAuthorityCertificate?.Dispose();
             }
         }
 
-        private void ConfigureTls()
-        {
-            this.CheckCertificateRevocationList = true;
-
-            this.ConfigureClientCertificate();
-            this.ConfigureCaCertificateValidation();
-        }
-
-        private void ConfigureClientCertificate()
-        {
-            if (this.clientCertificate == null)
-            {
-                return;
-            }
-
-            this.ClientCertificates.Add(this.clientCertificate);
-            this.ClientCertificateOptions = ClientCertificateOption.Manual;
-        }
-
-        private void ConfigureCaCertificateValidation()
-        {
-            if (this.caCertificateData == null)
-            {
-                return;
-            }
-
-            var caCertData = this.caCertificateData;
-            this.ServerCertificateCustomValidationCallback = (
-                httpRequestMessage,
-                cert,
-                chain,
-                sslPolicyErrors) =>
-            {
-                if (cert == null || chain == null)
-                {
-                    return false;
-                }
-
+        private X509Certificate2 EnsureCertificateAuthorityCertificate() =>
 #if NET9_0_OR_GREATER
-                using var caCert = X509CertificateLoader.LoadCertificate(caCertData);
+            this.certificateAuthorityCertificate ??= X509CertificateLoader.LoadCertificate(this.caCertificateData!);
 #else
-                using var caCert = new X509Certificate2(caCertData);
+            this.certificateAuthorityCertificate ??= new X509Certificate2(this.caCertificateData!);
 #endif
-                return OtlpCertificateManager.ValidateServerCertificate(
-                    cert,
-                    chain,
-                    sslPolicyErrors,
-                    caCert);
-            };
+
+        private bool ValidateServerCertificate(
+            HttpRequestMessage httpRequestMessage,
+            X509Certificate2? certificate,
+            X509Chain? chain,
+            System.Net.Security.SslPolicyErrors errors)
+        {
+            if (certificate == null || chain == null)
+            {
+                return false;
+            }
+
+            var caCertificate = this.EnsureCertificateAuthorityCertificate();
+
+            return OtlpCertificateManager.ValidateServerCertificate(
+                certificate,
+                chain,
+                errors,
+                caCertificate);
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
@@ -161,21 +161,39 @@ internal static class OtlpSecureHttpClientFactory
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
             {
                 this.clientCertificate?.Dispose();
                 this.certificateAuthorityCertificate?.Dispose();
             }
+
+            base.Dispose(disposing);
         }
 
-        private X509Certificate2 EnsureCertificateAuthorityCertificate() =>
+        private X509Certificate2 EnsureCertificateAuthorityCertificate()
+        {
+            if (this.certificateAuthorityCertificate == null)
+            {
 #if NET9_0_OR_GREATER
-            this.certificateAuthorityCertificate ??= X509CertificateLoader.LoadCertificate(this.caCertificateData!);
+                var certificate = X509CertificateLoader.LoadCertificate(this.caCertificateData!);
 #else
-            this.certificateAuthorityCertificate ??= new X509Certificate2(this.caCertificateData!);
+                var certificate = new X509Certificate2(this.caCertificateData!);
 #endif
+
+                var existingCertificate = Interlocked.CompareExchange(
+                    ref this.certificateAuthorityCertificate,
+                    certificate,
+                    null);
+
+                if (existingCertificate != null)
+                {
+                    certificate.Dispose();
+                    return existingCertificate;
+                }
+            }
+
+            return this.certificateAuthorityCertificate;
+        }
 
         private bool ValidateServerCertificate(
             HttpRequestMessage httpRequestMessage,


### PR DESCRIPTION
## Changes

Only load the custom CA certificate for OTLP once, not per validation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
