### PR TITLE
Fix timezone-dependent test failures in PersistentStorageHelper

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
@@ -183,7 +183,7 @@ internal static class PersistentStorageHelper
         if (!DateTime.TryParseExact(timestamp, "yyyy-MM-ddTHHmmss.fffffffZ", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dateTime))
         {
             // In case of failure, return DateTime.MinValue so that the lease file can be removed as expired
-            dateTime = DateTime.MinValue;
+            return DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
         }
 
         return dateTime.ToUniversalTime();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs
@@ -157,7 +157,7 @@ public class PersistentStorageHelperTests
         var result = PersistentStorageHelper.GetDateTimeFromBlobName(filePath);
 
         Assert.Equal(DateTimeKind.Utc, result.Kind);
-        Assert.Equal(DateTime.MinValue.ToUniversalTime(), result);
+        Assert.Equal(DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc), result);
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class PersistentStorageHelperTests
         var result = PersistentStorageHelper.GetDateTimeFromLeaseName(filePath);
 
         Assert.Equal(DateTimeKind.Utc, result.Kind);
-        Assert.Equal(DateTime.MinValue.ToUniversalTime(), result);
+        Assert.Equal(DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc), result);
     }
 
     [Theory]


### PR DESCRIPTION
## Changes
Few of the tests in PersistentStorageHelperTests were failing because they expected UTC minimum time but got a time with local timezone offset applied.

Example test failure - 
`[xUnit.net 00:00:56.56]     OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.PersistentStorage.PersistentStorageHelperTests.GetDateTimeFromLeaseName_InvalidFormat_ReturnsDateTimeMinValue(filePath: "invalid-format.lock") [FAIL]
[xUnit.net 00:00:56.56]       Assert.Equal() Failure: Values differ
[xUnit.net 00:00:56.56]       Expected: 0001-01-01T00:00:00.0000000
[xUnit.net 00:00:56.56]       Actual:   0001-01-01T05:00:00.0000000Z`

How to verify: run the tests: 
dotnet test test\OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests and they should pass consistently across time zones.
