### PR TITLE
[Prometheus.HttpListener] Dispose CancellationTokenSource

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -83,16 +83,37 @@ internal sealed class PrometheusHttpListener : IDisposable
     /// </summary>
     public void Stop()
     {
+        CancellationTokenSource? tokenSource;
+        Task? workerThread;
+
         lock (this.syncObject)
         {
-            if (this.tokenSource == null)
+            tokenSource = this.tokenSource;
+            workerThread = this.workerThread;
+
+            if (tokenSource == null)
             {
                 return;
             }
+        }
 
-            this.tokenSource.Cancel();
-            this.workerThread!.Wait();
-            this.tokenSource = null;
+        try
+        {
+            tokenSource.Cancel();
+            workerThread?.Wait();
+        }
+        finally
+        {
+            lock (this.syncObject)
+            {
+                if (ReferenceEquals(this.tokenSource, tokenSource))
+                {
+                    this.tokenSource = null;
+                    this.workerThread = null;
+                }
+            }
+
+            tokenSource.Dispose();
         }
     }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -95,6 +95,9 @@ internal sealed class PrometheusHttpListener : IDisposable
             {
                 return;
             }
+
+            this.tokenSource = null;
+            this.workerThread = null;
         }
 
         try
@@ -104,15 +107,6 @@ internal sealed class PrometheusHttpListener : IDisposable
         }
         finally
         {
-            lock (this.syncObject)
-            {
-                if (ReferenceEquals(this.tokenSource, tokenSource))
-                {
-                    this.tokenSource = null;
-                    this.workerThread = null;
-                }
-            }
-
             tokenSource.Dispose();
         }
     }
@@ -132,23 +126,20 @@ internal sealed class PrometheusHttpListener : IDisposable
     {
         var acceptHeader = request.Headers["Accept"];
 
-        if (string.IsNullOrEmpty(acceptHeader))
-        {
-            return false;
-        }
-
-        return PrometheusHeadersParser.AcceptsOpenMetrics(acceptHeader);
+        return !string.IsNullOrEmpty(acceptHeader) && PrometheusHeadersParser.AcceptsOpenMetrics(acceptHeader);
     }
 
     private void WorkerProc()
     {
+        var cancellationToken = this.tokenSource!.Token;
+
         try
         {
             using var scope = SuppressInstrumentationScope.Begin();
-            while (!this.tokenSource!.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 var ctxTask = this.httpListener.GetContextAsync();
-                ctxTask.Wait(this.tokenSource.Token);
+                ctxTask.Wait(cancellationToken);
                 var ctx = ctxTask.Result;
 
                 Task.Run(() => this.ProcessRequestAsync(ctx));


### PR DESCRIPTION
## Changes

Ensure that the `CancellationTokenSource` is disposed of in `PrometheusHttpListener` when stopping.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
