### PR TITLE
[OTLP] Apply span length limit override

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -33,6 +33,9 @@ Notes](../../RELEASENOTES.md).
   `traces`, `metrics`, and `logs` directories.
   ([#7074](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7074))
 
+* Fix `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` not being applied.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.2
 
 Released 2026-Apr-08

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -34,7 +34,7 @@ Notes](../../RELEASENOTES.md).
   ([#7074](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7074))
 
 * Fix `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` not being applied.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7115](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7115))
 
 ## 1.15.2
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -385,7 +385,7 @@ internal static class ProtobufOtlpTraceSerializer
     internal static int WriteEventAttributes(ref byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ActivityEvent evnt)
     {
         var maxAttributeCount = sdkLimitOptions.SpanEventAttributeCountLimit ?? int.MaxValue;
-        var maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
+        var maxAttributeValueLength = sdkLimitOptions.SpanAttributeValueLengthLimit ?? int.MaxValue;
 
         var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
@@ -468,7 +468,7 @@ internal static class ProtobufOtlpTraceSerializer
     internal static int WriteLinkAttributes(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ActivityLink link)
     {
         var maxAttributeCount = sdkLimitOptions.SpanLinkAttributeCountLimit ?? int.MaxValue;
-        var maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
+        var maxAttributeValueLength = sdkLimitOptions.SpanAttributeValueLengthLimit ?? int.MaxValue;
         var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = buffer,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -286,7 +286,7 @@ internal static class ProtobufOtlpTraceSerializer
         StatusCode? statusCode = null;
         string? statusMessage = null;
         var maxAttributeCount = sdkLimitOptions.SpanAttributeCountLimit ?? int.MaxValue;
-        var maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
+        var maxAttributeValueLength = sdkLimitOptions.SpanAttributeValueLengthLimit ?? int.MaxValue;
         var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = buffer,

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -484,16 +484,42 @@ public sealed class OtlpTraceExporterTests : IDisposable
         };
 
         using var activitySource = new ActivitySource(nameof(this.SpanAttributeValueLengthLimitOverridesAttributeValueLengthLimit));
-        using var activity = activitySource.StartActivity("root", ActivityKind.Server);
+        var links = new[]
+        {
+            new ActivityLink(
+                new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                new ActivityTagsCollection
+                {
+                    { "TruncatedLinkTag", "12345" },
+                }),
+        };
+
+        using var activity = activitySource.StartActivity("root", ActivityKind.Server, default(ActivityContext), tags: null, links);
 
         Assert.NotNull(activity);
         activity.SetTag("TruncatedTag", "12345");
+        activity.AddEvent(
+            new ActivityEvent(
+                "test-event",
+                tags: new ActivityTagsCollection
+                {
+                    { "TruncatedEventTag", "12345" },
+                }));
 
         var otlpSpan = ToOtlpSpan(sdkOptions, activity);
 
         Assert.NotNull(otlpSpan);
+
         var attribute = Assert.Single(otlpSpan.Attributes);
         Assert.Equal("1234", attribute.Value.StringValue);
+
+        var otlpEvent = Assert.Single(otlpSpan.Events);
+        var eventAttribute = Assert.Single(otlpEvent.Attributes);
+        Assert.Equal("1234", eventAttribute.Value.StringValue);
+
+        var otlpLink = Assert.Single(otlpSpan.Links);
+        var linkAttribute = Assert.Single(otlpLink.Attributes);
+        Assert.Equal("1234", linkAttribute.Value.StringValue);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -475,6 +475,28 @@ public sealed class OtlpTraceExporterTests : IDisposable
     }
 
     [Fact]
+    public void SpanAttributeValueLengthLimitOverridesAttributeValueLengthLimit()
+    {
+        var sdkOptions = new SdkLimitOptions()
+        {
+            AttributeValueLengthLimit = null,
+            SpanAttributeValueLengthLimit = 4,
+        };
+
+        using var activitySource = new ActivitySource(nameof(this.SpanAttributeValueLengthLimitOverridesAttributeValueLengthLimit));
+        using var activity = activitySource.StartActivity("root", ActivityKind.Server);
+
+        Assert.NotNull(activity);
+        activity.SetTag("TruncatedTag", "12345");
+
+        var otlpSpan = ToOtlpSpan(sdkOptions, activity);
+
+        Assert.NotNull(otlpSpan);
+        var attribute = Assert.Single(otlpSpan.Attributes);
+        Assert.Equal("1234", attribute.Value.StringValue);
+    }
+
+    [Fact]
     public void ToOtlpSpanTest()
     {
         using var activitySource = new ActivitySource(nameof(this.ToOtlpSpanTest));


### PR DESCRIPTION
## Changes

If the span attribute length limit is overridden by `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, ensure it is applied.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
