### PR TITLE
[OpenTelemetry] Guard against null values

### DIFF
--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Internal;
@@ -66,7 +65,7 @@ internal sealed class CircularBuffer<T>
     /// </returns>
     public bool Add(T value)
     {
-        Debug.Assert(value != null, "value was null");
+        Guard.ThrowIfNull(value);
 
         while (true)
         {
@@ -100,12 +99,12 @@ internal sealed class CircularBuffer<T>
     /// </returns>
     public bool TryAdd(T value, int maxSpinCount)
     {
+        Guard.ThrowIfNull(value);
+
         if (maxSpinCount <= 0)
         {
             return this.Add(value);
         }
-
-        Debug.Assert(value != null, "value was null");
 
         var spinCountDown = maxSpinCount;
 

--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -99,12 +99,12 @@ internal sealed class CircularBuffer<T>
     /// </returns>
     public bool TryAdd(T value, int maxSpinCount)
     {
-        Guard.ThrowIfNull(value);
-
         if (maxSpinCount <= 0)
         {
             return this.Add(value);
         }
+
+        Guard.ThrowIfNull(value);
 
         var spinCountDown = maxSpinCount;
 

--- a/test/OpenTelemetry.Tests/Internal/CircularBufferTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/CircularBufferTests.cs
@@ -9,9 +9,7 @@ public class CircularBufferTests
 {
     [Fact]
     public void CheckInvalidArgument()
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new CircularBuffer<string>(0));
-    }
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new CircularBuffer<string>(0));
 
     [Fact]
     public void CheckCapacity()
@@ -31,6 +29,22 @@ public class CircularBufferTests
         Assert.True(result);
         Assert.Equal(1, circularBuffer.AddedCount);
         Assert.Equal(1, circularBuffer.Count);
+    }
+
+    [Fact]
+    public void Add_NullValue_Throws()
+    {
+        var circularBuffer = new CircularBuffer<string>(1);
+
+        Assert.Throws<ArgumentNullException>(() => circularBuffer.Add(null!));
+    }
+
+    [Fact]
+    public void TryAdd_NullValue_Throws()
+    {
+        var circularBuffer = new CircularBuffer<string>(1);
+
+        Assert.Throws<ArgumentNullException>(() => circularBuffer.TryAdd(null!, maxSpinCount: 1));
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

Guard against null values being added to `CircularBuffer`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
