### PR TITLE
[OpenTelemetry] Ensure collect uses timeout

### DIFF
--- a/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
@@ -152,7 +152,6 @@ public abstract partial class MetricReader : IDisposable
         {
             lock (this.onCollectLock)
             {
-                this.collectionTcs = null;
                 result = this.OnCollect(timeoutMilliseconds);
             }
         }
@@ -160,8 +159,18 @@ public abstract partial class MetricReader : IDisposable
         {
             OpenTelemetrySdkEventSource.Log.MetricReaderException(nameof(this.Collect), ex);
         }
+        finally
+        {
+            tcs.TrySetResult(result);
 
-        tcs.TrySetResult(result);
+            lock (this.newTaskLock)
+            {
+                if (ReferenceEquals(this.collectionTcs, tcs))
+                {
+                    this.collectionTcs = null;
+                }
+            }
+        }
 
         if (result)
         {

--- a/test/OpenTelemetry.Tests/Metrics/MetricReaderTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricReaderTests.cs
@@ -115,13 +115,21 @@ public class MetricReaderTests
 
         var secondCollectTask = Task.Run(() => metricReader.Collect(50));
 
-        Assert.False(await secondCollectTask);
-        Assert.False(firstCollectTask.IsCompleted);
-        Assert.Equal(1, metricReader.CollectCallCount);
+        var firstCollectResult = false;
 
-        metricReader.AllowCollectionToFinish.Set();
+        try
+        {
+            Assert.False(await secondCollectTask);
+            Assert.False(firstCollectTask.IsCompleted);
+            Assert.Equal(1, metricReader.CollectCallCount);
+        }
+        finally
+        {
+            metricReader.AllowCollectionToFinish.Set();
+            firstCollectResult = await firstCollectTask;
+        }
 
-        Assert.True(await firstCollectTask);
+        Assert.True(firstCollectResult);
     }
 
     private sealed class BlockingMetricReader : MetricReader
@@ -136,9 +144,8 @@ public class MetricReaderTests
         {
             this.CollectCallCount++;
             this.CollectionStarted.Set();
-            this.AllowCollectionToFinish.Wait();
 
-            return true;
+            return this.AllowCollectionToFinish.Wait(TimeSpan.FromSeconds(5));
         }
 
         protected override void Dispose(bool disposing)

--- a/test/OpenTelemetry.Tests/Metrics/MetricReaderTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricReaderTests.cs
@@ -103,4 +103,53 @@ public class MetricReaderTests
         var metric = Assert.Single(metrics);
         Assert.Equal(expectedTemporality, metric.Temporality);
     }
+
+    [Fact]
+    public async Task Collect_WhenConcurrentCallTimesOut_ReturnsFalseWithoutStartingAnotherCollection()
+    {
+        using var metricReader = new BlockingMetricReader();
+
+        var firstCollectTask = Task.Run(() => metricReader.Collect(Timeout.Infinite));
+
+        Assert.True(metricReader.CollectionStarted.Wait(TimeSpan.FromSeconds(5)));
+
+        var secondCollectTask = Task.Run(() => metricReader.Collect(50));
+
+        Assert.False(await secondCollectTask);
+        Assert.False(firstCollectTask.IsCompleted);
+        Assert.Equal(1, metricReader.CollectCallCount);
+
+        metricReader.AllowCollectionToFinish.Set();
+
+        Assert.True(await firstCollectTask);
+    }
+
+    private sealed class BlockingMetricReader : MetricReader
+    {
+        public ManualResetEventSlim CollectionStarted { get; } = new();
+
+        public ManualResetEventSlim AllowCollectionToFinish { get; } = new();
+
+        public int CollectCallCount { get; private set; }
+
+        protected override bool OnCollect(int timeoutMilliseconds)
+        {
+            this.CollectCallCount++;
+            this.CollectionStarted.Set();
+            this.AllowCollectionToFinish.Wait();
+
+            return true;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.CollectionStarted.Dispose();
+                this.AllowCollectionToFinish.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
 }


### PR DESCRIPTION
## Changes

Ensure that the timeout is always honoured when concurrent metric collections happen.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
