### PR TITLE
[Infra] Fix netfx benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,44 @@ jobs:
         env:
           FRAMEWORK_VERSION: ${{ matrix.version }}
 
+  validate-benchmarks:
+    needs: detect-changes
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'packaged-code') ||
+      contains(needs.detect-changes.outputs.changes, 'build') ||
+      contains(needs.detect-changes.outputs.changes, 'shared')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-24.04, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+        show-progress: false
+    - name: Setup .NET
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+    - name: Run benchmarks
+      shell: pwsh
+      run: |
+        $runtimes = @("net10.0")
+        if ($IsWindows) {
+          $runtimes += "net462"
+        }
+        dotnet run `
+          --configuration Release `
+          --framework net10.0 `
+          --project ./test/Benchmarks `
+          -- `
+          --filter "*SamplerBenchmarks*" `
+          --job Short `
+          --memory `
+          --runtimes $runtimes
+
   validate-packages:
     needs: detect-changes
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
   validate-benchmarks:
     needs: detect-changes
     if: |
-      contains(needs.detect-changes.outputs.changes, 'packaged-code') ||
+      contains(needs.detect-changes.outputs.changes, 'code') ||
       contains(needs.detect-changes.outputs.changes, 'build') ||
       contains(needs.detect-changes.outputs.changes, 'shared')
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
       build-test-unstable-core,
       otlp-integration-test,
       w3c-trace-context-integration-test,
+      validate-benchmarks,
       validate-packages,
       generate-docs,
       verify-aot-compat,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -110,7 +110,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.10.0" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" Condition="$(OS) != 'Windows_NT'" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />

--- a/build/Common.props
+++ b/build/Common.props
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Condition="$(OS) != 'Windows_NT'" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="'$(SkipAnalysis)'!='true'" />
   </ItemGroup>
 

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -13,9 +13,6 @@ using Zipkin::OpenTelemetry.Exporter;
 
 namespace Benchmarks.Exporter;
 
-#if !NETFRAMEWORK
-[ThreadingDiagnoser]
-#endif
 public class ZipkinExporterBenchmarks
 {
     private readonly byte[] buffer = new byte[4096];

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -3,12 +3,5 @@
 
 using BenchmarkDotNet.Running;
 
-namespace OpenTelemetry.Benchmarks;
-
-internal static class Program
-{
-    public static void Main(string[] args)
-    {
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-    }
-}
+var summary = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+return summary.SelectMany((p) => p.Reports).Any((p) => !p.Success) ? 1 : 0;


### PR DESCRIPTION
## Changes

I discovered while getting some benchmark numbers for `net462` that the benchmarks didn't compile due to an auto-generated `.csproj` that didn't like the presence of `Microsoft.NETFramework.ReferenceAssemblies`. I've made that conditional to see if that makes things happy on a Windows machine.

I've also added a CI job that runs a small benchmark on Windows and Linux for `net10.0` (plus `net462` for Windows) to validate that the project minimally works and doesn't get broken over time.

The intention is not to use it to actually get numbers. There's hundreds of benchmarks, so I've arbitrarily picked a small one and run it as a Short job to keep it relatively quick to run.

Changes:

- Fix benchmarks not working when `net4xx` runtimes are specified.
- Add a basic CI job to validate the benchmarks are in working order.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
