### PR TITLE
[Repo] OpenSSF Security Insights v2

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,126 +1,144 @@
 header:
-  schema-version: '1.0.0'
-  expiration-date: '2027-02-14T00:00:00.000Z'
-  last-updated: '2026-02-14'
-  last-reviewed: '2026-02-14'
-  project-url: https://github.com/open-telemetry/opentelemetry-dotnet
-  changelog: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/RELEASENOTES.md
-  license: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/LICENSE.TXT
-
-project-lifecycle:
-  status: active
-  bug-fixes-only: false
-  core-maintainers:
-    - https://github.com/alanwest
-    - https://github.com/cijothomas
-    - https://github.com/CodeBlanch
-    - https://github.com/Kielek
-    - https://github.com/martincostello
-    - https://github.com/rajkumar-rangaraj
-
-contribution-policy:
-  accepts-pull-requests: true
-  accepts-automated-pull-requests: true
-  contributing-policy: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md
-  code-of-conduct: https://github.com/open-telemetry/.github/blob/main/CODE_OF_CONDUCT.md
-  automated-tools-list:
-    - automated-tool: renovatebot
-      action: allowed
-      comment: Automated dependency updates are accepted.
-
-documentation:
-  - https://opentelemetry.io/docs/languages/dotnet/
-
-distribution-points:
-  - pkg:nuget/OpenTelemetry
-  - pkg:nuget/OpenTelemetry.Api
-  - pkg:nuget/OpenTelemetry.Api.ProviderBuilderExtensions
-  - pkg:nuget/OpenTelemetry.Exporter.Console
-  - pkg:nuget/OpenTelemetry.Exporter.InMemory
-  - pkg:nuget/OpenTelemetry.Exporter.OpenTelemetryProtocol
-  - pkg:nuget/OpenTelemetry.Exporter.Prometheus.AspNetCore
-  - pkg:nuget/OpenTelemetry.Exporter.Prometheus.HttpListener
-  - pkg:nuget/OpenTelemetry.Exporter.Zipkin
-  - pkg:nuget/OpenTelemetry.Extensions.Hosting
-  - pkg:nuget/OpenTelemetry.Extensions.Propagators
-  - pkg:nuget/OpenTelemetry.Shims.OpenTracing
-
-security-artifacts:
-  threat-model:
-    threat-model-created: false
-    comment: |
-      No formal threat model created yet.
-  self-assessment:
-    self-assessment-created: false
-    comment: |
-      No formal self-assessment yet.
-
-security-contacts:
-  - type: website
-    value: https://github.com/open-telemetry/opentelemetry-dotnet/security
-    primary: true
-  - type: email
-    value: security@opentelemetry.io
-    primary: false
-  - type: email
-    value: cncf-opentelemetry-security@lists.cncf.io
-    primary: false
-
-security-testing:
-  - tool-type: sca
-    tool-name: Renovate
-    tool-version: latest
-    tool-url: https://docs.renovatebot.com/
-    tool-rulesets:
-      - built-in
-    integration:
-      ad-hoc: false
-      ci: true
-      before-release: true
-    comment: |
-      Automated dependency updates.
-  - tool-type: fuzzing
-    tool-name: FsCheck
-    tool-version: latest
-    tool-url: https://fscheck.github.io/FsCheck/
-    tool-rulesets:
-      - default
-    integration:
-      ad-hoc: false
-      ci: true
-      before-release: false
-    comment: |
-      FsCheck is used for fuzz testing as part of CI.
-  - tool-type: sast
-    tool-name: CodeQL
-    tool-version: latest
-    tool-url: https://github.com/github/codeql
-    tool-rulesets:
-      - default
-    integration:
-      ad-hoc: false
-      ci: true
-      before-release: true
-    comment: |
-      CodeQL static analysis is run in CI for all commits and pull requests to detect security vulnerabilities.
-
-vulnerability-reporting:
-  accepts-vulnerability-reports: true
-  email-contact: security@opentelemetry.io
-  security-policy: https://opentelemetry.io/docs/security/security-response/
-  bug-bounty-available: false
+  last-reviewed: '2026-04-23'
+  last-updated: '2026-04-23'
+  schema-version: 2.0.0
+  url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/SECURITY-INSIGHTS.yml
   comment: |
-    Report security vulnerabilities via https://github.com/open-telemetry/opentelemetry-dotnet/security.
+    This file contains the minimum information for https://github.com/open-telemetry/opentelemetry-dotnet.
 
-dependencies:
-  third-party-packages: true
-  dependencies-lists:
-    - https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/Directory.Packages.props
-  dependencies-lifecycle:
-    policy-url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
+project:
+  name: OpenTelemetry .NET
+  homepage: https://opentelemetry.io/docs/languages/dotnet/
+  administrators:
+    - name: Alan West
+      affiliation: New Relic
+      social: https://github.com/alanwest
+      primary: true
+    - name: Martin Costello
+      affiliation: Grafana Labs
+      social: https://github.com/martincostello
+    - name: Piotr Kie\u0142kowicz
+      affiliation: Splunk
+      social: https://github.com/Kielek
+    - name: Rajkumar Rangaraj
+      affiliation: Microsoft
+      social: https://github.com/rajkumar-rangaraj
+  documentation:
+    code-of-conduct: https://github.com/open-telemetry/.github/blob/main/CODE_OF_CONDUCT.md
+    detailed-guide: https://opentelemetry.io/docs/languages/dotnet/
+    quickstart-guide: https://opentelemetry.io/docs/languages/dotnet/getting-started/
+    release-process: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/build/RELEASING.md
+    signature-verification: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/README.md#digital-signing
+  repositories:
+    - name: opentelemetry-dotnet
+      url: https://github.com/open-telemetry/opentelemetry-dotnet
+      comment: |
+        The OpenTelemetry .NET Client repository.
+  vulnerability-reporting:
+    bug-bounty-available: false
+    reports-accepted: true
+    policy: https://opentelemetry.io/docs/security/security-response/
+    contact:
+      name: The OpenTelemetry security team
+      email: security@opentelemetry.io
+      primary: true
     comment: |
-      Dependencies are kept up to date by Renovate.
-  env-dependencies-policy:
-    policy-url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
-    comment: |
-      Dependencies are kept up to date by Renovate.
+      Report security vulnerabilities via https://github.com/open-telemetry/opentelemetry-dotnet/security.
+
+repository:
+  url: https://github.com/open-telemetry/opentelemetry-dotnet
+  status: active
+  accepts-automated-change-request: true
+  accepts-change-request: true
+  bug-fixes-only: false
+  no-third-party-packages: false
+  core-team:
+    - name: Alan West
+      affiliation: New Relic
+      social: https://github.com/alanwest
+      primary: true
+    - name: Cijo Thomas
+      affiliation: Microsoft
+      social: https://github.com/cijothomas
+    - name: Martin Costello
+      affiliation: Grafana Labs
+      social: https://github.com/martincostello
+    - name: Mikel Blanchard
+      affiliation: Microsoft
+      social: https://github.com/CodeBlanch
+    - name: Piotr Kie\u0142kowicz
+      affiliation: Splunk
+      social: https://github.com/Kielek
+    - name: Rajkumar Rangaraj
+      affiliation: Microsoft
+      social: https://github.com/rajkumar-rangaraj
+  documentation:
+    contributing-guide: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md
+    dependency-management-policy: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
+    security-policy: https://opentelemetry.io/docs/security/security-response/
+  license:
+    expression: Apache-2.0
+    url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/LICENSE.TXT
+  release:
+    automated-pipeline: true
+    changelog: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/RELEASENOTES.md
+    distribution-points:
+      - uri: https://www.nuget.org/packages/OpenTelemetry
+        comment: OpenTelemetry NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Api
+        comment: OpenTelemetry.Api NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Api.ProviderBuilderExtensions
+        comment: OpenTelemetry.Api.ProviderBuilderExtensions NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Exporter.Console
+        comment: OpenTelemetry.Exporter.Console NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Exporter.InMemory
+        comment: OpenTelemetry.Exporter.InMemory NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol
+        comment: OpenTelemetry.Exporter.OpenTelemetryProtocol NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore
+        comment: OpenTelemetry.Exporter.Prometheus.AspNetCore NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.HttpListener
+        comment: OpenTelemetry.Exporter.Prometheus.HttpListener NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Exporter.Zipkin
+        comment: OpenTelemetry.Exporter.Zipkin NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting
+        comment: OpenTelemetry.Extensions.Hosting NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Extensions.Propagators
+        comment: OpenTelemetry.Extensions.Propagators NuGet package distributed from NuGet.org.
+      - uri: https://www.nuget.org/packages/OpenTelemetry.Shims.OpenTracing
+        comment: OpenTelemetry.Shims.OpenTracing NuGet package distributed from NuGet.org.
+    attestations:
+
+  security:
+    assessments:
+      self:
+        evidence: https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO
+        date: '2026-04-23'
+    tools:
+      - name: CodeQL
+        comment: |
+          Static code analysis.
+        integration:
+          adhoc: true
+          ci: true
+          release: true
+        rulesets: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/workflows/codeql-analysis.yml
+        type: sca
+      - name: FsCheck
+        comment: |
+          FsCheck is used for fuzz testing as part of CI.
+        integration:
+          adhoc: true
+          ci: true
+          release: true
+        rulesets: default
+        type: fuzzing
+      - name: Renovate
+        comment: |
+          Automated dependency updates.
+        integration:
+          adhoc: true
+          ci: true
+          release: true
+        rulesets: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
+        type: sca

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -17,7 +17,7 @@ project:
     - name: Martin Costello
       affiliation: Grafana Labs
       social: https://github.com/martincostello
-    - name: Piotr Kie\u0142kowicz
+    - name: "Piotr Kie\u0142kowicz"
       affiliation: Splunk
       social: https://github.com/Kielek
     - name: Rajkumar Rangaraj
@@ -66,7 +66,7 @@ repository:
     - name: Mikel Blanchard
       affiliation: Microsoft
       social: https://github.com/CodeBlanch
-    - name: Piotr Kie\u0142kowicz
+    - name: "Piotr Kie\u0142kowicz"
       affiliation: Splunk
       social: https://github.com/Kielek
     - name: Rajkumar Rangaraj
@@ -112,7 +112,7 @@ repository:
   security:
     assessments:
       self:
-        evidence: https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO
+        evidence: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7143
         date: '2026-04-23'
     tools:
       - name: CodeQL
@@ -123,7 +123,7 @@ repository:
           ci: true
           release: true
         rulesets: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/workflows/codeql-analysis.yml
-        type: sca
+        type: sast
       - name: FsCheck
         comment: |
           FsCheck is used for fuzz testing as part of CI.


### PR DESCRIPTION
https://github.com/cncf/clomonitor/pull/1900.

## Changes

Migrate back to OpenSSF Security Insights v2.

I don't think there's any way to test this other than to merge it and see if it works.

If it doesn't, we can fix-forward or revert.

If it does, I'll do a similar PR to opentelemetry-dotnet-contrib.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
