### PR TITLE
[Repo] Update security-insights.yml

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -39,22 +39,6 @@ project:
         Active primary OpenTelemetry .NET repository. It contains the API,
         SDK, core exporters, and extensions released as NuGet packages from
         this repository.
-    - name: opentelemetry-dotnet-contrib
-      url: https://github.com/open-telemetry/opentelemetry-dotnet-contrib
-      comment: |
-        Active related OpenTelemetry .NET subproject repository. It contains
-        additional instrumentation libraries, exporters, resource detectors,
-        extensions, and standalone utilities that do not fit the scope of the
-        core or automatic instrumentation repositories. It releases
-        independently and is not compiled into packages produced from the
-        opentelemetry-dotnet repository.
-    - name: opentelemetry-dotnet-instrumentation
-      url: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation
-      comment: |
-        Active related OpenTelemetry .NET subproject repository. It contains
-        automatic instrumentation for .NET applications without requiring
-        source code changes. It releases independently and is not compiled into
-        packages produced from the opentelemetry-dotnet repository.
   vulnerability-reporting:
     bug-bounty-available: false
     reports-accepted: true

--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,8 +1,8 @@
 header:
-  last-reviewed: '2026-04-23'
-  last-updated: '2026-04-23'
+  last-reviewed: '2026-04-24'
+  last-updated: '2026-04-24'
   schema-version: 2.0.0
-  url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/SECURITY-INSIGHTS.yml
+  url: https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet/main/.github/security-insights.yml
   comment: |
     This file contains the minimum information for https://github.com/open-telemetry/opentelemetry-dotnet.
 
@@ -36,7 +36,25 @@ project:
     - name: opentelemetry-dotnet
       url: https://github.com/open-telemetry/opentelemetry-dotnet
       comment: |
-        The OpenTelemetry .NET Client repository.
+        Active primary OpenTelemetry .NET repository. It contains the API,
+        SDK, core exporters, and extensions released as NuGet packages from
+        this repository.
+    - name: opentelemetry-dotnet-contrib
+      url: https://github.com/open-telemetry/opentelemetry-dotnet-contrib
+      comment: |
+        Active related OpenTelemetry .NET subproject repository. It contains
+        additional instrumentation libraries, exporters, resource detectors,
+        extensions, and standalone utilities that do not fit the scope of the
+        core or automatic instrumentation repositories. It releases
+        independently and is not compiled into packages produced from the
+        opentelemetry-dotnet repository.
+    - name: opentelemetry-dotnet-instrumentation
+      url: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation
+      comment: |
+        Active related OpenTelemetry .NET subproject repository. It contains
+        automatic instrumentation for .NET applications without requiring
+        source code changes. It releases independently and is not compiled into
+        packages produced from the opentelemetry-dotnet repository.
   vulnerability-reporting:
     bug-bounty-available: false
     reports-accepted: true
@@ -115,7 +133,7 @@ repository:
         comment: OpenTelemetry.Extensions.Propagators NuGet package distributed from NuGet.org.
       - uri: https://www.nuget.org/packages/OpenTelemetry.Shims.OpenTracing
         comment: OpenTelemetry.Shims.OpenTracing NuGet package distributed from NuGet.org.
-    attestations:
+    attestations: []
 
   security:
     assessments:
@@ -131,8 +149,9 @@ repository:
           adhoc: true
           ci: true
           release: true
-        rulesets: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/workflows/codeql-analysis.yml
-        type: sast
+        rulesets:
+          - https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/workflows/codeql-analysis.yml
+        type: SAST
       - name: FsCheck
         comment: |
           FsCheck is used for fuzz testing as part of CI.
@@ -140,7 +159,8 @@ repository:
           adhoc: true
           ci: true
           release: true
-        rulesets: default
+        rulesets:
+          - default
         type: fuzzing
       - name: Renovate
         comment: |
@@ -149,5 +169,6 @@ repository:
           adhoc: true
           ci: true
           release: true
-        rulesets: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
-        type: sca
+        rulesets:
+          - https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
+        type: SCA


### PR DESCRIPTION
## Changes

Update security-insgiths.yml

pvtr-github-repo-scanner seems to be more strict than clomonitor

Trying to fix  OSPS-QA-04.01 on https://insights.linuxfoundation.org/project/opentelemetry/repository/open-telemetry_opentelemetry-dotnet/security?timeRange=past365days&start=2025-04-24&end=2026-04-24&auth=success

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
