### PR TITLE
[OpenTelemetry.Api] RuntimeContext spec compliance

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,9 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Align `RuntimeContext` with the spec. Introduces a small behavior change -
-  Multiple calls to `RegisterSlot` no longer throw. `SetValue` and `GetValue`
-  now deprecated.
+* Align the behavior of `RuntimeContext` with the OpenTelemetry specification.
+  Multiple calls to `RegisterSlot` no longer throw an exception. The `SetValue`
+  and `GetValue` methods are now deprecated.
   ([#7160](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7160))
 
 ## 1.15.3

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Align `RuntimeContext` with the spec. Introduces a small behavior change -
+  Multiple calls to `RegisterSlot` no longer throw. `SetValue` and `GetValue`
+  now deprecated.
+  ([#7160](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7160))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
@@ -29,6 +29,9 @@ public class RemotingRuntimeContextSlot<T> : RuntimeContextSlot<T>, IRuntimeCont
     // marshalling.
     private static readonly FieldInfo WrapperField = typeof(BitArray).GetField("_syncRoot", BindingFlags.Instance | BindingFlags.NonPublic);
 
+    // Use a unique key per instance so two slots with the same name don't stomp each other's values.
+    private readonly string callContextKey = $"__otel_{Guid.NewGuid():N}";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RemotingRuntimeContextSlot{T}"/> class.
     /// </summary>
@@ -59,7 +62,7 @@ public class RemotingRuntimeContextSlot<T> : RuntimeContextSlot<T>, IRuntimeCont
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override T? Get()
     {
-        if (CallContext.LogicalGetData(this.Name) is not BitArray wrapper)
+        if (CallContext.LogicalGetData(this.callContextKey) is not BitArray wrapper)
         {
             return default;
         }
@@ -80,7 +83,7 @@ public class RemotingRuntimeContextSlot<T> : RuntimeContextSlot<T>, IRuntimeCont
     {
         var wrapper = new BitArray(0);
         WrapperField.SetValue(wrapper, value);
-        CallContext.LogicalSetData(this.Name, wrapper);
+        CallContext.LogicalSetData(this.callContextKey, wrapper);
     }
 }
 #endif

--- a/src/OpenTelemetry.Api/Context/RuntimeContext.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContext.cs
@@ -57,38 +57,30 @@ public static class RuntimeContext
     {
         Guard.ThrowIfNullOrEmpty(slotName);
 
-        RuntimeContextSlot<T>? slot = null;
+        RuntimeContextSlot<T> slot;
 
-        lock (Slots)
+        if (ContextSlotType == typeof(AsyncLocalRuntimeContextSlot<>))
         {
-            if (Slots.ContainsKey(slotName))
-            {
-                throw new InvalidOperationException($"Context slot already registered: '{slotName}'");
-            }
-
-            if (ContextSlotType == typeof(AsyncLocalRuntimeContextSlot<>))
-            {
-                slot = new AsyncLocalRuntimeContextSlot<T>(slotName);
-            }
-            else if (ContextSlotType == typeof(ThreadLocalRuntimeContextSlot<>))
-            {
-                slot = new ThreadLocalRuntimeContextSlot<T>(slotName);
-            }
+            slot = new AsyncLocalRuntimeContextSlot<T>(slotName);
+        }
+        else if (ContextSlotType == typeof(ThreadLocalRuntimeContextSlot<>))
+        {
+            slot = new ThreadLocalRuntimeContextSlot<T>(slotName);
+        }
 
 #if NETFRAMEWORK
-            else if (ContextSlotType == typeof(RemotingRuntimeContextSlot<>))
-            {
-                slot = new RemotingRuntimeContextSlot<T>(slotName);
-            }
-#endif
-            else
-            {
-                throw new NotSupportedException($"ContextSlotType '{ContextSlotType}' is not supported");
-            }
-
-            Slots[slotName] = slot;
-            return slot;
+        else if (ContextSlotType == typeof(RemotingRuntimeContextSlot<>))
+        {
+            slot = new RemotingRuntimeContextSlot<T>(slotName);
         }
+#endif
+        else
+        {
+            throw new NotSupportedException($"ContextSlotType '{ContextSlotType}' is not supported");
+        }
+
+        Slots[slotName] = slot;
+        return slot;
     }
 
     /// <summary>
@@ -97,6 +89,7 @@ public static class RuntimeContext
     /// <param name="slotName">The name of the context slot.</param>
     /// <typeparam name="T">The type of the underlying value.</typeparam>
     /// <returns>The slot previously registered.</returns>
+    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
     public static RuntimeContextSlot<T> GetSlot<T>(string slotName)
     {
         Guard.ThrowIfNullOrEmpty(slotName);
@@ -136,6 +129,7 @@ public static class RuntimeContext
     /// <param name="slotName">The name of the context slot.</param>
     /// <param name="value">The value to be set.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
+    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void SetValue<T>(string slotName, T value)
     {
@@ -148,6 +142,7 @@ public static class RuntimeContext
     /// <param name="slotName">The name of the context slot.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>The value retrieved from the context slot.</returns>
+    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T? GetValue<T>(string slotName)
     {
@@ -159,6 +154,7 @@ public static class RuntimeContext
     /// </summary>
     /// <param name="slotName">The name of the context slot.</param>
     /// <param name="value">The value to be set.</param>
+    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
     public static void SetValue(string slotName, object? value)
     {
         Guard.ThrowIfNullOrEmpty(slotName);
@@ -173,6 +169,7 @@ public static class RuntimeContext
     /// </summary>
     /// <param name="slotName">The name of the context slot.</param>
     /// <returns>The value retrieved from the context slot.</returns>
+    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
     public static object? GetValue(string slotName)
     {
         Guard.ThrowIfNullOrEmpty(slotName);

--- a/src/OpenTelemetry.Api/Context/RuntimeContext.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContext.cs
@@ -12,6 +12,8 @@ namespace OpenTelemetry.Context;
 /// </summary>
 public static class RuntimeContext
 {
+    private const string ObsoletionMessage = "Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly.";
+
     private static readonly ConcurrentDictionary<string, object> Slots = new();
 
     private static Type contextSlotType = typeof(AsyncLocalRuntimeContextSlot<>);
@@ -89,7 +91,7 @@ public static class RuntimeContext
     /// <param name="slotName">The name of the context slot.</param>
     /// <typeparam name="T">The type of the underlying value.</typeparam>
     /// <returns>The slot previously registered.</returns>
-    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
+    [Obsolete(ObsoletionMessage)]
     public static RuntimeContextSlot<T> GetSlot<T>(string slotName)
     {
         Guard.ThrowIfNullOrEmpty(slotName);
@@ -129,7 +131,7 @@ public static class RuntimeContext
     /// <param name="slotName">The name of the context slot.</param>
     /// <param name="value">The value to be set.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
-    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
+    [Obsolete(ObsoletionMessage)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void SetValue<T>(string slotName, T value)
     {
@@ -142,7 +144,7 @@ public static class RuntimeContext
     /// <param name="slotName">The name of the context slot.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>The value retrieved from the context slot.</returns>
-    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
+    [Obsolete(ObsoletionMessage)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T? GetValue<T>(string slotName)
     {
@@ -154,7 +156,7 @@ public static class RuntimeContext
     /// </summary>
     /// <param name="slotName">The name of the context slot.</param>
     /// <param name="value">The value to be set.</param>
-    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
+    [Obsolete(ObsoletionMessage)]
     public static void SetValue(string slotName, object? value)
     {
         Guard.ThrowIfNullOrEmpty(slotName);
@@ -169,7 +171,7 @@ public static class RuntimeContext
     /// </summary>
     /// <param name="slotName">The name of the context slot.</param>
     /// <returns>The value retrieved from the context slot.</returns>
-    [Obsolete("Use the RuntimeContextSlot<T> returned by RegisterSlot to get and set values directly. Lookup by name does not uniquely identify a slot per the OpenTelemetry specification.")]
+    [Obsolete(ObsoletionMessage)]
     public static object? GetValue(string slotName)
     {
         Guard.ThrowIfNullOrEmpty(slotName);

--- a/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma warning disable CS0618 // string-based lookup APIs are intentionally tested here despite being obsolete
-
 using Xunit;
 
 namespace OpenTelemetry.Context.Tests;
@@ -38,6 +36,7 @@ public sealed class RuntimeContextTests : IDisposable
         Assert.Equal(2, slot2.Get());
     }
 
+#pragma warning disable CS0618 // string-based lookup APIs are intentionally tested here despite being obsolete
     [Fact]
     public void GetSlotAfterSameNameRegistrations_ReturnsLastRegistered()
     {
@@ -67,6 +66,7 @@ public sealed class RuntimeContextTests : IDisposable
         RuntimeContext.RegisterSlot<bool>("testslot");
         Assert.Throws<InvalidCastException>(() => RuntimeContext.GetSlot<int>("testslot"));
     }
+#pragma warning restore CS0618 // string-based lookup APIs are intentionally tested here despite being obsolete
 
     [Fact]
     public void RegisterAndGetSlot()

--- a/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma warning disable CS0618 // string-based lookup APIs are intentionally tested here despite being obsolete
+
 using Xunit;
 
 namespace OpenTelemetry.Context.Tests;
@@ -13,22 +15,41 @@ public sealed class RuntimeContextTests : IDisposable
     }
 
     [Fact]
-    public static void RegisterSlotWithInvalidNameThrows()
+    public void RegisterSlotWithInvalidNameThrows()
     {
         Assert.Throws<ArgumentException>(() => RuntimeContext.RegisterSlot<bool>(string.Empty));
         Assert.Throws<ArgumentException>(() => RuntimeContext.RegisterSlot<bool>(null!));
     }
 
     [Fact]
-    public static void RegisterSlotWithSameName()
+    public void RegisterSlotWithSameName_ReturnsDifferentIndependentSlots()
     {
-        var slot = RuntimeContext.RegisterSlot<bool>("testslot");
-        Assert.NotNull(slot);
-        Assert.Throws<InvalidOperationException>(() => RuntimeContext.RegisterSlot<bool>("testslot"));
+        var slot1 = RuntimeContext.RegisterSlot<int>("testslot");
+        var slot2 = RuntimeContext.RegisterSlot<int>("testslot");
+
+        Assert.NotNull(slot1);
+        Assert.NotNull(slot2);
+        Assert.NotSame(slot1, slot2);
+
+        slot1.Set(1);
+        slot2.Set(2);
+
+        Assert.Equal(1, slot1.Get());
+        Assert.Equal(2, slot2.Get());
     }
 
     [Fact]
-    public static void GetSlotWithInvalidNameThrows()
+    public void GetSlotAfterSameNameRegistrations_ReturnsLastRegistered()
+    {
+        var slot1 = RuntimeContext.RegisterSlot<int>("testslot");
+        var slot2 = RuntimeContext.RegisterSlot<int>("testslot");
+
+        var retrieved = RuntimeContext.GetSlot<int>("testslot");
+        Assert.Same(slot2, retrieved);
+    }
+
+    [Fact]
+    public void GetSlotWithInvalidNameThrows()
     {
         Assert.Throws<ArgumentException>(() => RuntimeContext.GetSlot<bool>(string.Empty));
         Assert.Throws<ArgumentException>(() => RuntimeContext.GetSlot<bool>(null!));
@@ -50,12 +71,10 @@ public sealed class RuntimeContextTests : IDisposable
     [Fact]
     public void RegisterAndGetSlot()
     {
-        var expectedSlot = RuntimeContext.RegisterSlot<int>("testslot");
-        Assert.NotNull(expectedSlot);
-        expectedSlot.Set(100);
-        var actualSlot = RuntimeContext.GetSlot<int>("testslot");
-        Assert.Same(expectedSlot, actualSlot);
-        Assert.Equal(100, expectedSlot.Get());
+        var slot = RuntimeContext.RegisterSlot<int>("testslot");
+        Assert.NotNull(slot);
+        slot.Set(100);
+        Assert.Equal(100, slot.Get());
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1810

## Changes

- Aligns `RuntimeContext` with the spec
- Behaviour change - Multiple calls to `RegisterSlot` no longer throw
- `SetValue` and `GetValue` now deprecated
- Last entry wins behavior for backing dictionary required for `SetValue` and `GetValue` methods

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)