### PR TITLE
[OpenTelemetry] Re-use samplers

### DIFF
--- a/src/OpenTelemetry/Trace/Sampler/AlwaysOffSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/AlwaysOffSampler.cs
@@ -8,7 +8,7 @@ namespace OpenTelemetry.Trace;
 /// </summary>
 public sealed class AlwaysOffSampler : Sampler
 {
-    internal static readonly AlwaysOffSampler Instance = new();
+    internal static AlwaysOffSampler Instance => field ??= new();
 
     /// <inheritdoc />
     public override SamplingResult ShouldSample(in SamplingParameters samplingParameters) => new(SamplingDecision.Drop);

--- a/src/OpenTelemetry/Trace/Sampler/AlwaysOffSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/AlwaysOffSampler.cs
@@ -8,9 +8,8 @@ namespace OpenTelemetry.Trace;
 /// </summary>
 public sealed class AlwaysOffSampler : Sampler
 {
+    internal static readonly AlwaysOffSampler Instance = new();
+
     /// <inheritdoc />
-    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
-    {
-        return new SamplingResult(SamplingDecision.Drop);
-    }
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters) => new(SamplingDecision.Drop);
 }

--- a/src/OpenTelemetry/Trace/Sampler/AlwaysOnSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/AlwaysOnSampler.cs
@@ -8,9 +8,8 @@ namespace OpenTelemetry.Trace;
 /// </summary>
 public sealed class AlwaysOnSampler : Sampler
 {
+    internal static readonly AlwaysOnSampler Instance = new();
+
     /// <inheritdoc />
-    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
-    {
-        return new SamplingResult(SamplingDecision.RecordAndSample);
-    }
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters) => new(SamplingDecision.RecordAndSample);
 }

--- a/src/OpenTelemetry/Trace/Sampler/AlwaysOnSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/AlwaysOnSampler.cs
@@ -8,7 +8,7 @@ namespace OpenTelemetry.Trace;
 /// </summary>
 public sealed class AlwaysOnSampler : Sampler
 {
-    internal static readonly AlwaysOnSampler Instance = new();
+    internal static AlwaysOnSampler Instance => field ??= new();
 
     /// <inheritdoc />
     public override SamplingResult ShouldSample(in SamplingParameters samplingParameters) => new(SamplingDecision.RecordAndSample);

--- a/src/OpenTelemetry/Trace/Sampler/ParentBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/ParentBasedSampler.cs
@@ -37,10 +37,10 @@ public sealed class ParentBasedSampler : Sampler
         this.Description = $"ParentBased{{{rootSampler.Description}}}";
 #pragma warning restore CA1062 // Validate arguments of public methods - needed for netstandard2.1
 
-        this.remoteParentSampled = new AlwaysOnSampler();
-        this.remoteParentNotSampled = new AlwaysOffSampler();
-        this.localParentSampled = new AlwaysOnSampler();
-        this.localParentNotSampled = new AlwaysOffSampler();
+        this.remoteParentSampled = AlwaysOnSampler.Instance;
+        this.remoteParentNotSampled = AlwaysOffSampler.Instance;
+        this.localParentSampled = AlwaysOnSampler.Instance;
+        this.localParentNotSampled = AlwaysOffSampler.Instance;
     }
 
     /// <summary>
@@ -76,10 +76,10 @@ public sealed class ParentBasedSampler : Sampler
         Sampler? localParentNotSampled = null)
         : this(rootSampler)
     {
-        this.remoteParentSampled = remoteParentSampled ?? new AlwaysOnSampler();
-        this.remoteParentNotSampled = remoteParentNotSampled ?? new AlwaysOffSampler();
-        this.localParentSampled = localParentSampled ?? new AlwaysOnSampler();
-        this.localParentNotSampled = localParentNotSampled ?? new AlwaysOffSampler();
+        this.remoteParentSampled = remoteParentSampled ?? AlwaysOnSampler.Instance;
+        this.remoteParentNotSampled = remoteParentNotSampled ?? AlwaysOffSampler.Instance;
+        this.localParentSampled = localParentSampled ?? AlwaysOnSampler.Instance;
+        this.localParentNotSampled = localParentNotSampled ?? AlwaysOffSampler.Instance;
     }
 
     /// <inheritdoc />
@@ -93,26 +93,16 @@ public sealed class ParentBasedSampler : Sampler
         }
 
         // Is parent sampled?
-        if ((parentContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
+        if (parentContext.TraceFlags.HasFlag(ActivityTraceFlags.Recorded))
         {
-            if (parentContext.IsRemote)
-            {
-                return this.remoteParentSampled.ShouldSample(samplingParameters);
-            }
-            else
-            {
-                return this.localParentSampled.ShouldSample(samplingParameters);
-            }
+            return parentContext.IsRemote
+                ? this.remoteParentSampled.ShouldSample(samplingParameters)
+                : this.localParentSampled.ShouldSample(samplingParameters);
         }
 
         // If parent is not sampled => delegate to the "not sampled" inner samplers.
-        if (parentContext.IsRemote)
-        {
-            return this.remoteParentNotSampled.ShouldSample(samplingParameters);
-        }
-        else
-        {
-            return this.localParentNotSampled.ShouldSample(samplingParameters);
-        }
+        return parentContext.IsRemote
+            ? this.remoteParentNotSampled.ShouldSample(samplingParameters)
+            : this.localParentNotSampled.ShouldSample(samplingParameters);
     }
 }

--- a/src/OpenTelemetry/Trace/Sampler/ParentBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/ParentBasedSampler.cs
@@ -93,7 +93,7 @@ public sealed class ParentBasedSampler : Sampler
         }
 
         // Is parent sampled?
-        if (parentContext.TraceFlags.HasFlag(ActivityTraceFlags.Recorded))
+        if ((parentContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
         {
             return parentContext.IsRemote
                 ? this.remoteParentSampled.ShouldSample(samplingParameters)

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -402,10 +402,10 @@ internal sealed class TracerProviderSdk : TracerProvider
             switch (configValue)
             {
                 case var _ when string.Equals(configValue, "always_on", StringComparison.OrdinalIgnoreCase):
-                    sampler = new AlwaysOnSampler();
+                    sampler = AlwaysOnSampler.Instance;
                     break;
                 case var _ when string.Equals(configValue, "always_off", StringComparison.OrdinalIgnoreCase):
-                    sampler = new AlwaysOffSampler();
+                    sampler = AlwaysOffSampler.Instance;
                     break;
                 case var _ when string.Equals(configValue, "traceidratio", StringComparison.OrdinalIgnoreCase):
                     {
@@ -415,10 +415,10 @@ internal sealed class TracerProviderSdk : TracerProvider
                     }
 
                 case var _ when string.Equals(configValue, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(new AlwaysOnSampler());
+                    sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
                     break;
                 case var _ when string.Equals(configValue, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(new AlwaysOffSampler());
+                    sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
                     break;
                 case var _ when string.Equals(configValue, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
                     {
@@ -438,7 +438,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             }
         }
 
-        return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
+        return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
     }
 
     private static double ReadTraceIdRatio(IConfiguration configuration)

--- a/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
@@ -60,7 +60,7 @@ public class ParentBasedSamplerTests
     {
         var sampledLink = new ActivityLink[]
         {
-            new ActivityLink(
+            new(
                 new ActivityContext(
                     ActivityTraceId.CreateRandom(),
                     ActivitySpanId.CreateRandom(),
@@ -118,13 +118,10 @@ public class ParentBasedSamplerTests
 
     [Fact]
     public void DisallowNullRootSampler()
-    {
-        Assert.Throws<ArgumentNullException>(() => new ParentBasedSampler(null!));
-    }
+        => Assert.Throws<ArgumentNullException>(() => new ParentBasedSampler(null!));
 
-    private static SamplingParameters MakeTestParameters(bool parentIsRemote, bool parentIsSampled)
-    {
-        return new SamplingParameters(
+    private static SamplingParameters MakeTestParameters(bool parentIsRemote, bool parentIsSampled) =>
+        new(
             parentContext: new ActivityContext(
                 ActivityTraceId.CreateRandom(),
                 ActivitySpanId.CreateRandom(),
@@ -134,5 +131,4 @@ public class ParentBasedSamplerTests
             traceId: default,
             name: "Span",
             kind: ActivityKind.Client);
-    }
 }


### PR DESCRIPTION
## Changes

- Add shared singleton instances of `AlwaysOnSampler` and `AlwaysOffSampler` and use instead of allocating new objects as they carry no state.
- Apply Visual Studio code refactor suggestions.

I noticed when working on something else that `ParentBasedSampler` could potentially create two instances of `AlwaysOnSampler` and/or `AlwaysOffSampler` when they could be shared:

https://github.com/open-telemetry/opentelemetry-dotnet/blob/9b45df91b2a7ccdeb5c60c2a5611944d6c0f7ee8/src/OpenTelemetry/Trace/Sampler/ParentBasedSampler.cs#L40-L43

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
