### PR TITLE
[Infra] Test net10.0 on ARM

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -44,10 +44,6 @@ jobs:
           version: net462
         - os: ubuntu-22.04-arm
           version: net462
-        - os: ubuntu-22.04-arm
-          version: net10.0
-        - os: windows-11-arm
-          version: net10.0
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
## Changes

Add ARM to the CI matrix for `net10.0`.

I noticed we don't test for .NET 10 on ARM, which seems like an oversight.

It might have been a mistake during the .NET 10 adoption and it was excluded (and .NET 8 added instead). If that's the case and we don't want to validate 8-10, I'll just change the exclusion to `net8.0` instead. We'll drop both and add 11 in November, so it's probably neither here-nor-there.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
