### PR TITLE
[Propagators] Improve JaegerPropagator performance

### DIFF
--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -245,15 +245,18 @@ public class JaegerPropagator : TextMapPropagator
     {
 #if NET
         var remaining = header.AsSpan(position);
+        var scanOffset = 0;
         while (true)
         {
-            var delimiterIndex = remaining.IndexOfAny(DelimiterHintChars);
+            var delimiterIndex = remaining.Slice(scanOffset).IndexOfAny(DelimiterHintChars);
             if (delimiterIndex < 0)
             {
                 var result = remaining;
                 position = header.Length;
                 return result;
             }
+
+            delimiterIndex += scanOffset;
 
             if (remaining[delimiterIndex] == ':')
             {
@@ -271,8 +274,7 @@ public class JaegerPropagator : TextMapPropagator
                 return component;
             }
 
-            remaining = remaining.Slice(delimiterIndex + 1);
-            position += delimiterIndex + 1;
+            scanOffset = delimiterIndex + 1;
         }
 #else
         var colonIndex = header.IndexOf(JaegerDelimiter, position, StringComparison.Ordinal);

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
+using System.Buffers;
+#endif
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
@@ -24,6 +27,10 @@ public class JaegerPropagator : TextMapPropagator
 
     private static readonly int TraceId128BitLength = "0af7651916cd43dd8448eb211c80319c".Length;
     private static readonly int SpanIdLength = "00f067aa0ba902b7".Length;
+
+#if NET
+    private static readonly SearchValues<char> DelimiterHintChars = SearchValues.Create(":%");
+#endif
 
     /// <inheritdoc/>
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
@@ -236,6 +243,38 @@ public class JaegerPropagator : TextMapPropagator
 
     private static ReadOnlySpan<char> ReadNextComponent(string header, ref int position)
     {
+#if NET
+        var remaining = header.AsSpan(position);
+        while (true)
+        {
+            var delimiterIndex = remaining.IndexOfAny(DelimiterHintChars);
+            if (delimiterIndex < 0)
+            {
+                var result = remaining;
+                position = header.Length;
+                return result;
+            }
+
+            if (remaining[delimiterIndex] == ':')
+            {
+                var component = remaining.Slice(0, delimiterIndex);
+                position += delimiterIndex + 1;
+                return component;
+            }
+
+            if (remaining.Length - delimiterIndex >= JaegerDelimiterEncoded.Length &&
+                remaining[delimiterIndex + 1] == '3' &&
+                remaining[delimiterIndex + 2] == 'A')
+            {
+                var component = remaining.Slice(0, delimiterIndex);
+                position += delimiterIndex + JaegerDelimiterEncoded.Length;
+                return component;
+            }
+
+            remaining = remaining.Slice(delimiterIndex + 1);
+            position += delimiterIndex + 1;
+        }
+#else
         var colonIndex = header.IndexOf(JaegerDelimiter, position, StringComparison.Ordinal);
         var encodedIndex = header.IndexOf(JaegerDelimiterEncoded, position, StringComparison.Ordinal);
 
@@ -263,5 +302,6 @@ public class JaegerPropagator : TextMapPropagator
         var component = header.AsSpan(position, nextIndex - position);
         position = nextIndex + delimiterLength;
         return component;
+#endif
     }
 }

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
@@ -163,6 +163,20 @@ public class JaegerPropagatorTests
     }
 
     [Fact]
+    public void ExtractReturnsOriginalContextIfHeaderContainsUnexpectedPercentCharacter()
+    {
+        var formattedHeader = $"%{TraceId}{JaegerDelimiter}{SpanId}{JaegerDelimiter}{ParentSpanId}{JaegerDelimiter}{FlagSampled}";
+        var headers = new Dictionary<string, string[]>
+        {
+            [JaegerHeader] = [formattedHeader],
+        };
+
+        var result = new JaegerPropagator().Extract(default, headers, Getter);
+
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
     public void InjectDoesNoopIfContextIsInvalid()
     {
         // arrange


### PR DESCRIPTION
## Changes

Improve the performance of `JaegerPropagator` for .NET 8+ by using `SearchValues<T>`.

## Benchmark Results

### Copilot Summary
 
`JaegerPropagator-perf` improves all common `Extract` benchmarks, while `Inject` is mixed. Allocations are unchanged across every shared suite.
 
 | Suite | Method | `main` | `JaegerPropagator-perf` | Duration delta | Duration ratio | Allocation delta | Allocation ratio |
 |---|---|---:|---:|---:|---:|---:|---:|
 | `Sampled=False, UseEncodedDelimiter=False` | Extract | 212.57 ns | 98.98 ns | **-53.4%** | **0.47x** | 312 B -> 312 B (**0.0%**) | **1.00x** |
 | `Sampled=False, UseEncodedDelimiter=False` | Inject | 54.12 ns | 28.58 ns | **-47.2%** | **0.53x** | 128 B -> 128 B (**0.0%**) | **1.00x** |
 | `Sampled=False, UseEncodedDelimiter=True` | Extract | 200.61 ns | 92.99 ns | **-53.6%** | **0.46x** | 312 B -> 312 B (**0.0%**) | **1.00x** |
 | `Sampled=False, UseEncodedDelimiter=True` | Inject | 27.55 ns | 28.85 ns | **+4.7%** | **1.05x** | 128 B -> 128 B (**0.0%**) | **1.00x** |
 | `Sampled=True, UseEncodedDelimiter=False` | Extract | 119.99 ns | 89.37 ns | **-25.5%** | **0.74x** | 312 B -> 312 B (**0.0%**) | **1.00x** |
 | `Sampled=True, UseEncodedDelimiter=False` | Inject | 26.59 ns | 28.38 ns | **+6.7%** | **1.07x** | 128 B -> 128 B (**0.0%**) | **1.00x** |
 | `Sampled=True, UseEncodedDelimiter=True` | Extract | 120.75 ns | 89.50 ns | **-25.9%** | **0.74x** | 312 B -> 312 B (**0.0%**) | **1.00x** |
 | `Sampled=True, UseEncodedDelimiter=True` | Inject | 27.28 ns | 27.20 ns | **-0.3%** | **1.00x** | 128 B -> 128 B (**0.0%**) | **1.00x** |
 
 **Overall**
 - **Extract:** faster in every shared suite on `JaegerPropagator-perf`, with the biggest wins in non-sampled cases (**~54% lower duration**).
 - **Inject:** one large win (**-47.2%**), two small regressions (**+4.7%** and **+6.7%**), and one effectively unchanged result.
 - **Allocations:** **no change** in any shared benchmark.

### Detailed Results

<details>

<summary>Expand to view</summary>

#### main

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8246/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.203
  [Host]    : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
  .NET 10.0 : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3

Job=.NET 10.0  Runtime=.NET 10.0  Toolchain=net10.0  

```
| Method  | Sampled | UseEncodedDelimiter | Mean      | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|-------- |-------- |-------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| **Extract** | **False**   | **False**               | **212.57 ns** | **4.066 ns** | **3.804 ns** |  **1.00** |    **0.02** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | False   | False               |  54.12 ns | 2.795 ns | 7.975 ns |  0.25 |    0.04 | 0.0102 |     128 B |        0.41 |
|         |         |                     |           |          |          |       |         |        |           |             |
| **Extract** | **False**   | **True**                | **200.61 ns** | **3.607 ns** | **3.542 ns** |  **1.00** |    **0.02** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | False   | True                |  27.55 ns | 0.585 ns | 1.220 ns |  0.14 |    0.01 | 0.0102 |     128 B |        0.41 |
|         |         |                     |           |          |          |       |         |        |           |             |
| **Extract** | **True**    | **False**               | **119.99 ns** | **2.045 ns** | **1.708 ns** |  **1.00** |    **0.02** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | True    | False               |  26.59 ns | 0.560 ns | 1.144 ns |  0.22 |    0.01 | 0.0102 |     128 B |        0.41 |
|         |         |                     |           |          |          |       |         |        |           |             |
| **Extract** | **True**    | **True**                | **120.75 ns** | **2.199 ns** | **2.057 ns** |  **1.00** |    **0.02** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | True    | True                |  27.28 ns | 0.571 ns | 0.984 ns |  0.23 |    0.01 | 0.0102 |     128 B |        0.41 |

#### This PR

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8246/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.203
  [Host]    : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
  .NET 10.0 : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3

Job=.NET 10.0  Runtime=.NET 10.0  Toolchain=net10.0  

```
| Method  | Sampled | UseEncodedDelimiter | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|-------- |-------- |-------------------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| **Extract** | **False**   | **False**               | **98.98 ns** | **2.006 ns** | **2.746 ns** |  **1.00** |    **0.04** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | False   | False               | 28.58 ns | 0.590 ns | 1.245 ns |  0.29 |    0.01 | 0.0102 |     128 B |        0.41 |
|         |         |                     |          |          |          |       |         |        |           |             |
| **Extract** | **False**   | **True**                | **92.99 ns** | **1.827 ns** | **2.438 ns** |  **1.00** |    **0.04** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | False   | True                | 28.85 ns | 0.609 ns | 1.143 ns |  0.31 |    0.01 | 0.0102 |     128 B |        0.41 |
|         |         |                     |          |          |          |       |         |        |           |             |
| **Extract** | **True**    | **False**               | **89.37 ns** | **1.693 ns** | **1.738 ns** |  **1.00** |    **0.03** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | True    | False               | 28.38 ns | 0.564 ns | 1.238 ns |  0.32 |    0.01 | 0.0102 |     128 B |        0.41 |
|         |         |                     |          |          |          |       |         |        |           |             |
| **Extract** | **True**    | **True**                | **89.50 ns** | **1.760 ns** | **1.807 ns** |  **1.00** |    **0.03** | **0.0248** |     **312 B** |        **1.00** |
| Inject  | True    | True                | 27.20 ns | 0.569 ns | 1.353 ns |  0.30 |    0.02 | 0.0102 |     128 B |        0.41 |

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
