### PR TITLE
Bug fix: disposing meter with same name does not dispose the shared metric

### DIFF
--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -74,6 +74,10 @@ public sealed class Metric
 
     internal readonly AggregatorStore AggregatorStore;
 
+    private readonly object instrumentRefLock = new();
+
+    private int instrumentReferenceCount;
+
     internal Metric(
         MetricStreamIdentity instrumentIdentity,
         AggregationTemporality temporality,
@@ -268,4 +272,24 @@ public sealed class Metric
 
     internal int Snapshot()
         => this.AggregatorStore.Snapshot();
+
+    internal void AddInstrumentReference()
+    {
+        lock (this.instrumentRefLock)
+        {
+            Interlocked.Increment(ref this.instrumentReferenceCount);
+        }
+    }
+
+    internal void RemoveInstrumentReference()
+    {
+        lock (this.instrumentRefLock)
+        {
+            var newCount = Interlocked.Decrement(ref this.instrumentReferenceCount);
+            if (newCount == 0)
+            {
+                MetricReader.DeactivateMetric(this);
+            }
+        }
+    }
 }

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -74,9 +74,9 @@ public sealed class Metric
 
     internal readonly AggregatorStore AggregatorStore;
 
-    private readonly object instrumentRefLock = new();
+    private readonly Lock referenceLock = new();
 
-    private int instrumentReferenceCount;
+    private int referenceCount;
 
     internal Metric(
         MetricStreamIdentity instrumentIdentity,
@@ -273,20 +273,20 @@ public sealed class Metric
     internal int Snapshot()
         => this.AggregatorStore.Snapshot();
 
-    internal void AddInstrumentReference()
+    internal void AddReference()
     {
-        lock (this.instrumentRefLock)
+        lock (this.referenceLock)
         {
-            Interlocked.Increment(ref this.instrumentReferenceCount);
+            this.referenceCount++;
         }
     }
 
-    internal void RemoveInstrumentReference()
+    internal void RemoveReference()
     {
-        lock (this.instrumentRefLock)
+        lock (this.referenceLock)
         {
-            var newCount = Interlocked.Decrement(ref this.instrumentReferenceCount);
-            if (newCount == 0)
+            this.referenceCount--;
+            if (this.referenceCount == 0)
             {
                 MetricReader.DeactivateMetric(this);
             }

--- a/src/OpenTelemetry/Metrics/MetricState.cs
+++ b/src/OpenTelemetry/Metrics/MetricState.cs
@@ -24,11 +24,15 @@ internal sealed class MetricState
 
     internal delegate void RecordMeasurementAction<T>(T value, ReadOnlySpan<KeyValuePair<string, object?>> tags);
 
-    public static MetricState BuildForSingleMetric(Metric metric) =>
-        new(
-            completeMeasurement: () => MetricReader.DeactivateMetric(metric),
+    public static MetricState BuildForSingleMetric(Metric metric)
+    {
+        metric.AddInstrumentReference();
+
+        return new(
+            completeMeasurement: () => metric.RemoveInstrumentReference(),
             recordMeasurementLong: metric.UpdateLong,
             recordMeasurementDouble: metric.UpdateDouble);
+    }
 
     public static MetricState BuildForMetricList(
         List<Metric> metrics)
@@ -38,12 +42,17 @@ internal sealed class MetricState
         // Note: Use an array here to elide bounds checks.
         var metricsArray = metrics.ToArray();
 
+        for (var i = 0; i < metricsArray.Length; i++)
+        {
+            metricsArray[i].AddInstrumentReference();
+        }
+
         return new(
             completeMeasurement: () =>
             {
                 for (var i = 0; i < metricsArray.Length; i++)
                 {
-                    MetricReader.DeactivateMetric(metricsArray[i]);
+                    metricsArray[i].RemoveInstrumentReference();
                 }
             },
             recordMeasurementLong: (v, t) =>

--- a/src/OpenTelemetry/Metrics/MetricState.cs
+++ b/src/OpenTelemetry/Metrics/MetricState.cs
@@ -26,10 +26,10 @@ internal sealed class MetricState
 
     public static MetricState BuildForSingleMetric(Metric metric)
     {
-        metric.AddInstrumentReference();
+        metric.AddReference();
 
         return new(
-            completeMeasurement: () => metric.RemoveInstrumentReference(),
+            completeMeasurement: metric.RemoveReference,
             recordMeasurementLong: metric.UpdateLong,
             recordMeasurementDouble: metric.UpdateDouble);
     }
@@ -44,7 +44,7 @@ internal sealed class MetricState
 
         for (var i = 0; i < metricsArray.Length; i++)
         {
-            metricsArray[i].AddInstrumentReference();
+            metricsArray[i].AddReference();
         }
 
         return new(
@@ -52,7 +52,7 @@ internal sealed class MetricState
             {
                 for (var i = 0; i < metricsArray.Length; i++)
                 {
-                    metricsArray[i].RemoveInstrumentReference();
+                    metricsArray[i].RemoveReference();
                 }
             },
             recordMeasurementLong: (v, t) =>

--- a/test/OpenTelemetry.Tests/Metrics/MetricDisposeTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricDisposeTests.cs
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.Metrics;
+using Xunit;
+
+namespace OpenTelemetry.Metrics.Tests;
+
+public class MetricDisposeTests : MetricTestsBase
+{
+    [Fact]
+    public void DisposingOneMeterWithSameNameDoesNotDeactivateSharedMetric()
+    {
+        var exportedItems = new List<Metric>();
+
+        using var m1 = new Meter("shared-meter");
+        using var m2 = new Meter("shared-meter");
+
+        using var container = BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter("shared-meter")
+            .AddInMemoryExporter(exportedItems));
+
+        var counter1 = m1.CreateCounter<long>("my-counter");
+        var counter2 = m2.CreateCounter<long>("my-counter");
+
+        counter1.Add(10, new KeyValuePair<string, object?>("key", "value1"));
+        counter2.Add(20, new KeyValuePair<string, object?>("key", "value2"));
+
+        meterProvider.ForceFlush();
+
+        Assert.Single(exportedItems);
+
+        var sumValue1Before = GetSumForTag(exportedItems, "value1");
+        Assert.Equal(10, sumValue1Before);
+
+        exportedItems.Clear();
+
+        m2.Dispose();
+
+        counter1.Add(5, new KeyValuePair<string, object?>("key", "value1"));
+
+        meterProvider.ForceFlush();
+
+        Assert.Single(exportedItems);
+
+        var sumValue1After = GetSumForTag(exportedItems, "value1");
+        Assert.True(sumValue1After == sumValue1Before + 5, $"Expected sum for 'value1' to increase after m2 disposed. Before={sumValue1Before}, After={sumValue1After}");
+    }
+
+    [Fact]
+    public void DisposingAllMetersWithSameNameDeactivatesSharedMetric()
+    {
+        var exportedItems = new List<Metric>();
+
+        using var m1 = new Meter("shared-meter-all");
+        using var m2 = new Meter("shared-meter-all");
+
+        using var container = BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter("shared-meter-all")
+            .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+            {
+                metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+            }));
+
+        var counter1 = m1.CreateCounter<long>("my-counter");
+        var counter2 = m2.CreateCounter<long>("my-counter");
+
+        counter1.Add(10, new KeyValuePair<string, object?>("key", "value1"));
+        counter2.Add(20, new KeyValuePair<string, object?>("key", "value2"));
+
+        meterProvider.ForceFlush();
+        Assert.Single(exportedItems);
+
+        exportedItems.Clear();
+
+        m1.Dispose();
+        m2.Dispose();
+
+        counter1.Add(5, new KeyValuePair<string, object?>("key", "value1"));
+        counter2.Add(5, new KeyValuePair<string, object?>("key", "value2"));
+
+        meterProvider.ForceFlush();
+
+        Assert.Empty(exportedItems);
+    }
+
+    [Fact]
+    public void DisposingOneMeterWithMultipleReadersDoesNotDeactivateSharedMetric()
+    {
+        var exportedItems1 = new List<Metric>();
+        var exportedItems2 = new List<Metric>();
+
+        using var m1 = new Meter("multi-reader-meter");
+        using var m2 = new Meter("multi-reader-meter");
+
+        using var container = BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter("multi-reader-meter")
+            .AddInMemoryExporter(exportedItems1)
+            .AddInMemoryExporter(exportedItems2));
+
+        var counter1 = m1.CreateCounter<long>("my-counter");
+        var counter2 = m2.CreateCounter<long>("my-counter");
+
+        counter1.Add(10, new KeyValuePair<string, object?>("key", "value1"));
+        counter2.Add(20, new KeyValuePair<string, object?>("key", "value2"));
+
+        meterProvider.ForceFlush();
+
+        Assert.Single(exportedItems1);
+        Assert.Single(exportedItems2);
+
+        var sumValue1Before = GetSumForTag(exportedItems1, "value1");
+        Assert.Equal(10, sumValue1Before);
+
+        exportedItems1.Clear();
+        exportedItems2.Clear();
+
+        m2.Dispose();
+
+        counter1.Add(5, new KeyValuePair<string, object?>("key", "value1"));
+
+        meterProvider.ForceFlush();
+
+        Assert.Single(exportedItems1);
+        Assert.Single(exportedItems2);
+
+        var sumReader1 = GetSumForTag(exportedItems1, "value1");
+        var sumReader2 = GetSumForTag(exportedItems2, "value1");
+
+        Assert.Equal(15, sumReader1);
+        Assert.Equal(15, sumReader2);
+    }
+
+    private static long GetSumForTag(List<Metric> exportedItems, string tagValue)
+    {
+        foreach (ref readonly var mp in exportedItems[0].GetMetricPoints())
+        {
+            foreach (var kv in mp.Tags)
+            {
+                if (kv.Key == "key" && kv.Value?.ToString() == tagValue)
+                {
+                    return mp.GetSumLong();
+                }
+            }
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Fixes #6412

## Changes

Added reference counting to `Metric`. `AddInstrumentReference()` is called when an instrument is attached; `RemoveInstrumentReference()` is called on completion and only triggers `DeactivateMetric(Metric)` when the count reaches zero. Both `BuildForSingleMetric(Metric)` and `BuildForMetricList(List<Metric>)` in `MetricState` are updated accordingly.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
