### PR TITLE
[Shared] Refactor EnvironmentVariableScope

### DIFF
--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -1006,7 +1006,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
     [InlineData("invalid", null)]
     internal void TestDefaultHistogramAggregationUsingEnvVar(string configValue, MetricReaderHistogramAggregation? expectedAggregation)
     {
-        using var scope = new EnvironmentVariableScope(OtlpSpecConfigDefinitions.MetricsDefaultHistogramAggregationEnvVarName, configValue);
+        using var scope = EnvironmentVariableScope.Create(OtlpSpecConfigDefinitions.MetricsDefaultHistogramAggregationEnvVarName, configValue);
 
         var testExecuted = false;
 

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
@@ -329,7 +329,7 @@ public class OpenTelemetryMetricsBuilderExtensionsTests
         // Arrange
         var meterName = "TestMeter";
 
-        using (new EnvironmentVariableScope("OTEL_SDK_DISABLED", "true"))
+        using (EnvironmentVariableScope.Create("OTEL_SDK_DISABLED", "true"))
         {
             var services = new ServiceCollection();
 

--- a/test/OpenTelemetry.Tests/EnvironmentVariableScope.cs
+++ b/test/OpenTelemetry.Tests/EnvironmentVariableScope.cs
@@ -1,17 +1,41 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+namespace OpenTelemetry;
+
 internal sealed class EnvironmentVariableScope : IDisposable
 {
-    private readonly string name;
-    private readonly string? previous;
+    private readonly Dictionary<string, string?> originalEnvironment = [];
+    private bool disposed;
 
-    public EnvironmentVariableScope(string name, string? value)
+    private EnvironmentVariableScope(params ReadOnlySpan<(string Name, string? Value)> environment)
     {
-        this.name = name;
-        this.previous = Environment.GetEnvironmentVariable(name);
-        Environment.SetEnvironmentVariable(name, value);
+        foreach (var (name, value) in environment)
+        {
+            this.originalEnvironment[name] = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
     }
 
-    public void Dispose() => Environment.SetEnvironmentVariable(this.name, this.previous);
+    public static IDisposable Create(string name, string? value)
+        => Create((name, value));
+
+    public static IDisposable Create(params ReadOnlySpan<(string Name, string? Value)> environment)
+        => new EnvironmentVariableScope(environment);
+
+    public static IDisposable Create(IDictionary<string, string?> environment)
+        => new EnvironmentVariableScope([.. environment.Select((p) => (p.Key, p.Value))]);
+
+    public void Dispose()
+    {
+        if (!this.disposed)
+        {
+            foreach (var pair in this.originalEnvironment)
+            {
+                Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+            }
+
+            this.disposed = true;
+        }
+    }
 }

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderBaseTests.cs
@@ -14,7 +14,7 @@ public sealed class LoggerProviderBuilderBaseTests
     [InlineData(null, typeof(LoggerProviderSdk))]
     public void LoggerProviderIsExpectedType(string? value, Type expected)
     {
-        using (new EnvironmentVariableScope("OTEL_SDK_DISABLED", value))
+        using (EnvironmentVariableScope.Create("OTEL_SDK_DISABLED", value))
         {
             var builder = new LoggerProviderBuilderBase();
 

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderBaseTests.cs
@@ -14,7 +14,7 @@ public sealed class MeterProviderBuilderBaseTests
     [InlineData(null, typeof(MeterProviderSdk))]
     public void LoggerProviderIsExpectedType(string? value, Type expected)
     {
-        using (new EnvironmentVariableScope("OTEL_SDK_DISABLED", value))
+        using (EnvironmentVariableScope.Create("OTEL_SDK_DISABLED", value))
         {
             var builder = new MeterProviderBuilderBase();
 

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderBaseTests.cs
@@ -14,7 +14,7 @@ public sealed class TracerProviderBuilderBaseTests
     [InlineData(null, typeof(TracerProviderSdk))]
     public void TracerProviderIsExpectedType(string? value, Type expected)
     {
-        using (new EnvironmentVariableScope("OTEL_SDK_DISABLED", value))
+        using (EnvironmentVariableScope.Create("OTEL_SDK_DISABLED", value))
         {
             var builder = new TestTracerProviderBuilder();
 
@@ -73,13 +73,9 @@ public sealed class TracerProviderBuilderBaseTests
     private sealed class TestTracerProviderBuilder : TracerProviderBuilderBase
     {
         public void AddInstrumentationViaProtectedMethod(Func<object?> factory)
-        {
-            this.AddInstrumentation("MyName", "MyVersion", factory);
-        }
+            => this.AddInstrumentation("MyName", "MyVersion", factory);
 
         public void AddInstrumentationViaProtectedMethod(string? name, string? version, Func<object?>? factory)
-        {
-            this.AddInstrumentation(name!, version!, factory!);
-        }
+            => this.AddInstrumentation(name!, version!, factory!);
     }
 }


### PR DESCRIPTION
## Changes

Copy from [open-telemetry/opentelemetry-dotnet-contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/test/Shared/EnvironmentVariableScope.cs) to support multiple variables without needing to allocator multiple scopes as I've found that need while working on #7168 and #7174.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
