### PR TITLE
[Exporter.Prometheus] Extend test coverage and fix surfaced issues

### DIFF
--- a/OpenTelemetry.slnx
+++ b/OpenTelemetry.slnx
@@ -227,6 +227,7 @@
   <Project Path="test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests.csproj" />
+  <Project Path="test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj" />

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -13,12 +13,12 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed the serialization of `NaN`, `PositiveInfinity`, and `NegativeInfinity`
   values in Prometheus metrics to be compliant with the specification.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7179))
 
 * Fixed loss of precision when serializing `double` and `float` values in
   Prometheus metrics to be compliant with the specification by using 17
   significant digits to represent such values.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7179))
 
 ## 1.15.3-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -11,6 +11,15 @@ Notes](../../RELEASENOTES.md).
   `PrometheusAspNetCoreOptions`.
   ([#7176](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7176))
 
+* Fixed the serialization of `NaN`, `PositiveInfinity`, and `NegativeInfinity`
+  values in Prometheus metrics to be compliant with the specification.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
+* Fixed loss of precision when serializing `double` and `float` values in
+  Prometheus metrics to be compliant with the specification by using 17
+  significant digits to represent such values.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -17,6 +17,15 @@ Notes](../../RELEASENOTES.md).
   `PrometheusHttpListenerOptions`.
   ([#7176](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7176))
 
+* Fixed the serialization of `NaN`, `PositiveInfinity`, and `NegativeInfinity`
+  values in Prometheus metrics to be compliant with the specification.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
+* Fixed loss of precision when serializing `double` and `float` values in
+  Prometheus metrics to be compliant with the specification by using 17
+  significant digits to represent such values.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -19,12 +19,12 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed the serialization of `NaN`, `PositiveInfinity`, and `NegativeInfinity`
   values in Prometheus metrics to be compliant with the specification.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7179))
 
 * Fixed loss of precision when serializing `double` and `float` values in
   Prometheus metrics to be compliant with the specification by using 17
   significant digits to represent such values.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7179))
 
 ## 1.15.3-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -26,10 +26,14 @@ internal static partial class PrometheusSerializer
     {
         if (MathHelper.IsFinite(value))
         {
+            // From https://prometheus.io/docs/specs/om/open_metrics_spec/#considerations-canonical-numbers:
+            // A warning to implementers in C and other languages that share its printf implementation:
+            // The standard precision of %f, %e and %g is only six significant digits. 17 significant
+            // digits are required for full precision, e.g. printf("%.17g", d).
 #if NET
             Span<char> span = stackalloc char[128];
 
-            var result = value.TryFormat(span, out var cchWritten, "G", CultureInfo.InvariantCulture);
+            var result = value.TryFormat(span, out var cchWritten, "G17", CultureInfo.InvariantCulture);
             Debug.Assert(result, $"{nameof(result)} should be true.");
 
             for (var i = 0; i < cchWritten; i++)
@@ -37,7 +41,7 @@ internal static partial class PrometheusSerializer
                 buffer[cursor++] = unchecked((byte)span[i]);
             }
 #else
-            cursor = WriteAsciiStringNoEscape(buffer, cursor, value.ToString(CultureInfo.InvariantCulture));
+            cursor = WriteAsciiStringNoEscape(buffer, cursor, value.ToString("G17", CultureInfo.InvariantCulture));
 #endif
         }
         else if (double.IsPositiveInfinity(value))
@@ -50,8 +54,9 @@ internal static partial class PrometheusSerializer
         }
         else
         {
+            // See https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information
             Debug.Assert(double.IsNaN(value), $"{nameof(value)} should be NaN.");
-            cursor = WriteAsciiStringNoEscape(buffer, cursor, "Nan");
+            cursor = WriteAsciiStringNoEscape(buffer, cursor, "NaN");
         }
 
         return cursor;
@@ -213,7 +218,46 @@ internal static partial class PrometheusSerializer
         {
             // TODO: Attribute values should be written as their JSON representation. Extra logic may need to be added here to correctly convert other .NET types.
             // More detail: https://github.com/open-telemetry/opentelemetry-dotnet/issues/4822#issuecomment-1707328495
-            return labelValue is bool b ? b ? "true" : "false" : labelValue?.ToString() ?? string.Empty;
+            if (labelValue is bool booleanValue)
+            {
+                return booleanValue ? "true" : "false";
+            }
+            else if (labelValue is double doubleValue)
+            {
+                return DoubleToString(doubleValue);
+            }
+            else if (labelValue is float floatValue)
+            {
+                return DoubleToString(floatValue);
+            }
+
+            return labelValue?.ToString() ?? string.Empty;
+
+            static string DoubleToString(double value)
+            {
+                // From https://prometheus.io/docs/specs/om/open_metrics_spec/#considerations-canonical-numbers:
+                // A warning to implementers in C and other languages that share its printf implementation:
+                // The standard precision of %f, %e and %g is only six significant digits. 17 significant
+                // digits are required for full precision, e.g. printf("%.17g", d).
+                if (MathHelper.IsFinite(value))
+                {
+                    return value.ToString("G17", CultureInfo.InvariantCulture);
+                }
+                else if (double.IsPositiveInfinity(value))
+                {
+                    return "+Inf";
+                }
+                else if (double.IsNegativeInfinity(value))
+                {
+                    return "-Inf";
+                }
+                else
+                {
+                    // See https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information
+                    Debug.Assert(double.IsNaN(value), $"{nameof(value)} should be NaN.");
+                    return "NaN";
+                }
+            }
         }
     }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -94,8 +94,10 @@ internal static partial class PrometheusSerializer
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int WriteUnicodeNoEscape(byte[] buffer, int cursor, ushort ordinal)
+    public static int WriteUnicodeNoEscape(byte[] buffer, int cursor, int ordinal)
     {
+        // Strings MUST only consist of valid UTF-8 characters.
+        // See https://prometheus.io/docs/specs/om/open_metrics_spec/#strings.
         if (ordinal <= 0x7F)
         {
             buffer[cursor++] = unchecked((byte)ordinal);
@@ -105,10 +107,16 @@ internal static partial class PrometheusSerializer
             buffer[cursor++] = unchecked((byte)(0b_1100_0000 | (ordinal >> 6)));
             buffer[cursor++] = unchecked((byte)(0b_1000_0000 | (ordinal & 0b_0011_1111)));
         }
+        else if (ordinal <= 0xFFFF)
+        {
+            buffer[cursor++] = unchecked((byte)(0b_1110_0000 | (ordinal >> 12)));
+            buffer[cursor++] = unchecked((byte)(0b_1000_0000 | ((ordinal >> 6) & 0b_0011_1111)));
+            buffer[cursor++] = unchecked((byte)(0b_1000_0000 | (ordinal & 0b_0011_1111)));
+        }
         else
         {
-            // all other <= 0xFFFF which is ushort.MaxValue
-            buffer[cursor++] = unchecked((byte)(0b_1110_0000 | (ordinal >> 12)));
+            buffer[cursor++] = unchecked((byte)(0b_1111_0000 | (ordinal >> 18)));
+            buffer[cursor++] = unchecked((byte)(0b_1000_0000 | ((ordinal >> 12) & 0b_0011_1111)));
             buffer[cursor++] = unchecked((byte)(0b_1000_0000 | ((ordinal >> 6) & 0b_0011_1111)));
             buffer[cursor++] = unchecked((byte)(0b_1000_0000 | (ordinal & 0b_0011_1111)));
         }
@@ -133,7 +141,7 @@ internal static partial class PrometheusSerializer
                     buffer[cursor++] = unchecked((byte)'n');
                     break;
                 default:
-                    cursor = WriteUnicodeNoEscape(buffer, cursor, ordinal);
+                    cursor = WriteUnicodeScalar(buffer, cursor, value, ref i);
                     break;
             }
         }
@@ -193,7 +201,7 @@ internal static partial class PrometheusSerializer
                     buffer[cursor++] = unchecked((byte)'n');
                     break;
                 default:
-                    cursor = WriteUnicodeNoEscape(buffer, cursor, ordinal);
+                    cursor = WriteUnicodeScalar(buffer, cursor, value, ref i);
                     break;
             }
         }
@@ -467,6 +475,27 @@ internal static partial class PrometheusSerializer
         buffer[cursor++] = ASCII_LINEFEED;
 
         return cursor;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int WriteUnicodeScalar(byte[] buffer, int cursor, string value, ref int index)
+    {
+        // Strings MUST only consist of valid UTF-8 characters.
+        // See https://prometheus.io/docs/specs/om/open_metrics_spec/#strings.
+        var current = value[index];
+
+        if (!char.IsSurrogate(current))
+        {
+            return WriteUnicodeNoEscape(buffer, cursor, current);
+        }
+
+        if (char.IsHighSurrogate(current) && index < value.Length - 1 && char.IsLowSurrogate(value[index + 1]))
+        {
+            index++;
+            return WriteUnicodeNoEscape(buffer, cursor, char.ConvertToUtf32(current, value[index]));
+        }
+
+        return WriteUnicodeNoEscape(buffer, cursor, 0xFFFD);
     }
 
     private static string MapPrometheusType(PrometheusType type) => type switch

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/OpenTelemetry.Exporter.Prometheus.HttpListener.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/OpenTelemetry.Exporter.Prometheus.HttpListener.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Benchmarks" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests" PublicKey="$(StrongNamePublicKey)" />
     <InternalsVisibleTo Include="OpenTelemetry.Exporter.Prometheus.HttpListener.Tests" PublicKey="$(StrongNamePublicKey)" />
     <InternalsVisibleTo Include="OpenTelemetry.Exporter.Prometheus.Tests" PublicKey="$(StrongNamePublicKey)" />
   </ItemGroup>

--- a/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
@@ -17,6 +17,8 @@ public class PrometheusSerializerBenchmarks
     private readonly List<Metric> metrics = [];
     private readonly byte[] buffer = new byte[85000];
     private readonly Dictionary<Metric, PrometheusMetric> cache = [];
+    private Metric? histogramMetric;
+    private Metric? typedLabelsMetric;
     private Meter? meter;
     private MeterProvider? meterProvider;
 
@@ -40,7 +42,13 @@ public class PrometheusSerializerBenchmarks
         var histogram = this.meter.CreateHistogram<long>("histogram_name_1", "long", "histogram_name_1_description");
         histogram.Record(100, new("label1", "value1"), new("label2", "value2"));
 
+        var typedLabelsCounter = this.meter.CreateCounter<long>("counter_name_2", "long", "counter_name_2_description");
+        typedLabelsCounter.Add(18, new("bool_label", true), new("long_label", 9223372036854775807L), new("double_label", 1234.5));
+
         this.meterProvider.ForceFlush();
+
+        this.histogramMetric = this.metrics.Single(metric => metric.Name == "histogram_name_1");
+        this.typedLabelsMetric = this.metrics.Single(metric => metric.Name == "counter_name_2");
     }
 
     [GlobalCleanup]
@@ -60,6 +68,24 @@ public class PrometheusSerializerBenchmarks
             {
                 cursor = PrometheusSerializer.WriteMetric(this.buffer, cursor, metric, this.GetPrometheusMetric(metric), openMetricsRequested: false);
             }
+        }
+    }
+
+    [Benchmark]
+    public void WriteHistogramMetric()
+    {
+        for (var i = 0; i < this.NumberOfSerializeCalls; i++)
+        {
+            _ = PrometheusSerializer.WriteMetric(this.buffer, 0, this.histogramMetric!, this.GetPrometheusMetric(this.histogramMetric!), openMetricsRequested: false);
+        }
+    }
+
+    [Benchmark]
+    public void WriteMetricWithTypedLabels()
+    {
+        for (var i = 0; i < this.NumberOfSerializeCalls; i++)
+        {
+            _ = PrometheusSerializer.WriteMetric(this.buffer, 0, this.typedLabelsMetric!, this.GetPrometheusMetric(this.typedLabelsMetric!), openMetricsRequested: false);
         }
     }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsCheck.Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\OpenTelemetry.Exporter.Prometheus.HttpListener.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
+using System.Text;
 using FsCheck;
 using FsCheck.Fluent;
 using FsCheck.Xunit;
@@ -112,50 +113,28 @@ public class PrometheusSerializerFuzzTests
 
     private static byte[] ReferenceWriteEscapedString(string value, bool escapeQuotationMarks)
     {
-        var bytes = new List<byte>(value.Length * 3);
+        var text = new StringBuilder(value.Length);
 
         foreach (var c in value)
         {
-            switch ((ushort)c)
+            switch (c)
             {
                 case '"' when escapeQuotationMarks:
-                    bytes.Add((byte)'\\');
-                    bytes.Add((byte)'"');
+                    text.Append("\\\"");
                     break;
                 case '\\':
-                    bytes.Add((byte)'\\');
-                    bytes.Add((byte)'\\');
+                    text.Append("\\\\");
                     break;
                 case '\n':
-                    bytes.Add((byte)'\\');
-                    bytes.Add((byte)'n');
+                    text.Append("\\n");
                     break;
                 default:
-                    AppendUnicodeNoEscape(bytes, c);
+                    text.Append(c);
                     break;
             }
         }
 
-        return [.. bytes];
-    }
-
-    private static void AppendUnicodeNoEscape(List<byte> bytes, ushort ordinal)
-    {
-        if (ordinal <= 0x7F)
-        {
-            bytes.Add(unchecked((byte)ordinal));
-        }
-        else if (ordinal <= 0x07FF)
-        {
-            bytes.Add(unchecked((byte)(0b_1100_0000 | (ordinal >> 6))));
-            bytes.Add(unchecked((byte)(0b_1000_0000 | (ordinal & 0b_0011_1111))));
-        }
-        else
-        {
-            bytes.Add(unchecked((byte)(0b_1110_0000 | (ordinal >> 12))));
-            bytes.Add(unchecked((byte)(0b_1000_0000 | ((ordinal >> 6) & 0b_0011_1111))));
-            bytes.Add(unchecked((byte)(0b_1000_0000 | (ordinal & 0b_0011_1111))));
-        }
+        return Encoding.UTF8.GetBytes(text.ToString());
     }
 
     private static class Generators

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
@@ -1,0 +1,228 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+
+namespace OpenTelemetry.Exporter.Prometheus.FuzzTests;
+
+public class PrometheusSerializerFuzzTests
+{
+    private const int MaxTests = 200;
+
+    [Property(MaxTest = MaxTests)]
+    public Property WriteAsciiStringNoEscapeMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.AsciiStringArbitrary(),
+        static (value) => Serialize(value, PrometheusSerializer.WriteAsciiStringNoEscape).SequenceEqual(ReferenceWriteAsciiStringNoEscape(value)));
+
+    [Property(MaxTest = MaxTests)]
+    public Property WriteLabelKeyMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.PrometheusStringArbitrary(),
+        static (value) => Serialize(value, PrometheusSerializer.WriteLabelKey).SequenceEqual(ReferenceWriteLabelKey(value)));
+
+    [Property(MaxTest = MaxTests)]
+    public Property WriteLabelValueMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.PrometheusStringArbitrary(),
+        static (value) => Serialize(value, PrometheusSerializer.WriteLabelValue).SequenceEqual(ReferenceWriteLabelValue(value)));
+
+    [Property(MaxTest = MaxTests)]
+    public Property WriteUnicodeStringMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.PrometheusStringArbitrary(),
+        static (value) => Serialize(value, PrometheusSerializer.WriteUnicodeString).SequenceEqual(ReferenceWriteUnicodeString(value)));
+
+    [Property(MaxTest = MaxTests)]
+    public Property WriteLongMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.LongArbitrary(),
+        static (value) => SerializeLong(value).SequenceEqual(ReferenceWriteLong(value)));
+
+    [Property(MaxTest = MaxTests)]
+    public Property WriteDoubleMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.DoubleArbitrary(),
+        static (value) => SerializeDouble(value).SequenceEqual(ReferenceWriteDouble(value)));
+
+    private static byte[] Serialize(string value, Func<byte[], int, string, int> writer)
+    {
+        var buffer = new byte[(value.Length * 8) + 16];
+        var cursor = writer(buffer, 0, value);
+        return buffer.AsSpan(0, cursor).ToArray();
+    }
+
+    private static byte[] SerializeLong(long value)
+    {
+        var buffer = new byte[64];
+        var cursor = PrometheusSerializer.WriteLong(buffer, 0, value);
+        return buffer.AsSpan(0, cursor).ToArray();
+    }
+
+    private static byte[] SerializeDouble(double value)
+    {
+        var buffer = new byte[64];
+        var cursor = PrometheusSerializer.WriteDouble(buffer, 0, value);
+        return buffer.AsSpan(0, cursor).ToArray();
+    }
+
+    private static byte[] ReferenceWriteAsciiStringNoEscape(string value)
+    {
+        var bytes = new byte[value.Length];
+        for (var i = 0; i < value.Length; i++)
+        {
+            bytes[i] = unchecked((byte)value[i]);
+        }
+
+        return bytes;
+    }
+
+    private static byte[] ReferenceWriteLabelKey(string value)
+    {
+        var bytes = new List<byte>(value.Length + 1);
+        if (string.IsNullOrEmpty(value))
+        {
+            bytes.Add((byte)'_');
+            return [.. bytes];
+        }
+
+        if (value[0] is >= '0' and <= '9')
+        {
+            bytes.Add((byte)'_');
+        }
+
+        foreach (var c in value)
+        {
+            bytes.Add(c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') ? (byte)c : (byte)'_');
+        }
+
+        return [.. bytes];
+    }
+
+    private static byte[] ReferenceWriteLabelValue(string value) => ReferenceWriteEscapedString(value, escapeQuotationMarks: true);
+
+    private static byte[] ReferenceWriteUnicodeString(string value) => ReferenceWriteEscapedString(value, escapeQuotationMarks: false);
+
+    private static byte[] ReferenceWriteLong(long value) => System.Text.Encoding.UTF8.GetBytes(value.ToString(CultureInfo.InvariantCulture));
+
+    private static byte[] ReferenceWriteDouble(double value) => value switch
+    {
+        var doubleValue when double.IsPositiveInfinity(doubleValue) => System.Text.Encoding.UTF8.GetBytes("+Inf"),
+        var doubleValue when double.IsNegativeInfinity(doubleValue) => System.Text.Encoding.UTF8.GetBytes("-Inf"),
+        var doubleValue when double.IsNaN(doubleValue) => System.Text.Encoding.UTF8.GetBytes("NaN"),
+        _ => System.Text.Encoding.UTF8.GetBytes(value.ToString("G17", CultureInfo.InvariantCulture)),
+    };
+
+    private static byte[] ReferenceWriteEscapedString(string value, bool escapeQuotationMarks)
+    {
+        var bytes = new List<byte>(value.Length * 3);
+
+        foreach (var c in value)
+        {
+            switch ((ushort)c)
+            {
+                case '"' when escapeQuotationMarks:
+                    bytes.Add((byte)'\\');
+                    bytes.Add((byte)'"');
+                    break;
+                case '\\':
+                    bytes.Add((byte)'\\');
+                    bytes.Add((byte)'\\');
+                    break;
+                case '\n':
+                    bytes.Add((byte)'\\');
+                    bytes.Add((byte)'n');
+                    break;
+                default:
+                    AppendUnicodeNoEscape(bytes, c);
+                    break;
+            }
+        }
+
+        return [.. bytes];
+    }
+
+    private static void AppendUnicodeNoEscape(List<byte> bytes, ushort ordinal)
+    {
+        if (ordinal <= 0x7F)
+        {
+            bytes.Add(unchecked((byte)ordinal));
+        }
+        else if (ordinal <= 0x07FF)
+        {
+            bytes.Add(unchecked((byte)(0b_1100_0000 | (ordinal >> 6))));
+            bytes.Add(unchecked((byte)(0b_1000_0000 | (ordinal & 0b_0011_1111))));
+        }
+        else
+        {
+            bytes.Add(unchecked((byte)(0b_1110_0000 | (ordinal >> 12))));
+            bytes.Add(unchecked((byte)(0b_1000_0000 | ((ordinal >> 6) & 0b_0011_1111))));
+            bytes.Add(unchecked((byte)(0b_1000_0000 | (ordinal & 0b_0011_1111))));
+        }
+    }
+
+    private static class Generators
+    {
+        public static Arbitrary<string> AsciiStringArbitrary()
+        {
+            var asciiChar = Gen.Choose(0, 0x7F).Select(static c => (char)c);
+            return CreateString(asciiChar, maxLength: 256).ToArbitrary();
+        }
+
+        public static Arbitrary<string> PrometheusStringArbitrary()
+        {
+            var charGen = Gen.Choose(0, 0xFFFF).Select(static c => (char)c);
+            return CreateString(charGen, maxLength: 128).ToArbitrary();
+        }
+
+        public static Arbitrary<double> DoubleArbitrary()
+        {
+            var generator =
+                from mantissa in Gen.Choose(-1_000_000, 1_000_000)
+                from exponent in Gen.Choose(-12, 12)
+                select mantissa * Math.Pow(10, exponent);
+
+            var finite = Gen.OneOf(
+                Gen.Elements(-1d, 0d, 1d, double.Epsilon, double.MinValue, double.MaxValue),
+                generator);
+
+            return Gen.OneOf(
+                finite,
+                Gen.Constant(double.PositiveInfinity),
+                Gen.Constant(double.NegativeInfinity),
+                Gen.Constant(double.NaN)).ToArbitrary();
+        }
+
+        public static Arbitrary<long> LongArbitrary()
+        {
+            var generator = from high in Gen.Choose(int.MinValue, int.MaxValue)
+                            from low in Gen.Choose(int.MinValue, int.MaxValue)
+                            select ((long)high << 32) | (uint)low;
+
+            return Gen.OneOf(Gen.Elements(long.MinValue, -1L, 0L, 1L, long.MaxValue), generator).ToArbitrary();
+        }
+
+        public static Arbitrary<object?> LabelValueArbitrary()
+        {
+            var chars = Gen.Choose(0, 0xFFFF).Select(static value => (object?)(char)value);
+            var decimals = Gen.Choose(int.MinValue, int.MaxValue).Select(static value => (object?)(value / 10m));
+            var unsignedLongs =
+                from high in Gen.Choose(0, int.MaxValue)
+                from low in Gen.Choose(int.MinValue, int.MaxValue)
+                select (object?)(((ulong)(uint)high << 32) | (uint)low);
+
+            return Gen.OneOf(
+                Gen.Constant((object?)null),
+                PrometheusStringArbitrary().Generator.Select(static value => (object?)value),
+                Gen.Elements<object?>(true, false),
+                LongArbitrary().Generator.Select(static value => (object?)value),
+                unsignedLongs,
+                DoubleArbitrary().Generator.Select(static value => (object?)value),
+                decimals,
+                chars).ToArbitrary();
+        }
+
+        private static Gen<string> CreateString(Gen<char> charGen, int maxLength) =>
+            Gen.Sized(size =>
+                from length in Gen.Choose(0, Math.Min((size * 2) + 1, maxLength))
+                from chars in Gen.ArrayOf(charGen, length)
+                select new string(chars));
+    }
+}

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
@@ -101,14 +101,14 @@ public class PrometheusSerializerFuzzTests
 
     private static byte[] ReferenceWriteUnicodeString(string value) => ReferenceWriteEscapedString(value, escapeQuotationMarks: false);
 
-    private static byte[] ReferenceWriteLong(long value) => System.Text.Encoding.UTF8.GetBytes(value.ToString(CultureInfo.InvariantCulture));
+    private static byte[] ReferenceWriteLong(long value) => Encoding.UTF8.GetBytes(value.ToString(CultureInfo.InvariantCulture));
 
     private static byte[] ReferenceWriteDouble(double value) => value switch
     {
-        var doubleValue when double.IsPositiveInfinity(doubleValue) => System.Text.Encoding.UTF8.GetBytes("+Inf"),
-        var doubleValue when double.IsNegativeInfinity(doubleValue) => System.Text.Encoding.UTF8.GetBytes("-Inf"),
-        var doubleValue when double.IsNaN(doubleValue) => System.Text.Encoding.UTF8.GetBytes("NaN"),
-        _ => System.Text.Encoding.UTF8.GetBytes(value.ToString("G17", CultureInfo.InvariantCulture)),
+        var doubleValue when double.IsPositiveInfinity(doubleValue) => Encoding.UTF8.GetBytes("+Inf"),
+        var doubleValue when double.IsNegativeInfinity(doubleValue) => Encoding.UTF8.GetBytes("-Inf"),
+        var doubleValue when double.IsNaN(doubleValue) => Encoding.UTF8.GetBytes("NaN"),
+        _ => Encoding.UTF8.GetBytes(value.ToString("G17", CultureInfo.InvariantCulture)),
     };
 
     private static byte[] ReferenceWriteEscapedString(string value, bool escapeQuotationMarks)

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -957,18 +957,4 @@ public sealed class PrometheusSerializerTests
         var cursor = WriteMetric(buffer, 0, metrics[0]);
         return Encoding.UTF8.GetString(buffer, 0, cursor);
     }
-
-    private sealed class CustomFormattable(decimal value) : IFormattable
-    {
-        public string ToString(string? format, IFormatProvider? formatProvider)
-            => value.ToString(format, formatProvider);
-
-        public override string ToString()
-            => value.ToString(CultureInfo.CurrentCulture);
-    }
-
-    private sealed class CustomObject(string value)
-    {
-        public override string ToString() => value;
-    }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -869,15 +869,29 @@ public sealed class PrometheusSerializerTests
     }
 
     [Fact]
-    public void WriteUnicodeStringPreservesUtf16CodeUnitEncoding()
+    public void WriteUnicodeStringEncodesSurrogatePairsAsUtf8ScalarValues()
     {
         const string value = "rocket:\uD83D\uDE80";
         var buffer = new byte[128];
 
         var cursor = PrometheusSerializer.WriteUnicodeString(buffer, 0, value);
         var actual = ToHexString(buffer, cursor);
+        var expected = ToHexString(Encoding.UTF8.GetBytes(value), Encoding.UTF8.GetByteCount(value));
 
-        Assert.Equal("726F636B65743AEDA0BDEDBA80", actual);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void WriteUnicodeStringReplacesInvalidSurrogates()
+    {
+        const string value = "rocket:\uD83D";
+        var buffer = new byte[128];
+
+        var cursor = PrometheusSerializer.WriteUnicodeString(buffer, 0, value);
+        var actual = ToHexString(buffer, cursor);
+        var expected = ToHexString(Encoding.UTF8.GetBytes(value), Encoding.UTF8.GetByteCount(value));
+
+        Assert.Equal(expected, actual);
     }
 
 #if NET

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
+using System.Globalization;
 using System.Text;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
@@ -11,6 +12,55 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests;
 
 public sealed class PrometheusSerializerTests
 {
+    public static TheoryData<object?, string> LabelValueBoundaryCases => new()
+    {
+        { false, "false" },
+        { true, "true" },
+        { null, string.Empty },
+        { string.Empty, string.Empty },
+        { "tagValue", "tagValue" },
+        { "tagValueWith\"Quote", "tagValueWith\\\"Quote" },
+        { "tagValueWith\\Backslash", "tagValueWith\\\\Backslash" },
+        { "tagValueWith\nNewline", "tagValueWith\\nNewline" },
+        { "\"line1\\\nline2\"", "\\\"line1\\\\\\nline2\\\"" },
+        { "caf\u00e9", "caf\u00e9" },
+        { sbyte.MinValue, "-128" },
+        { (sbyte)0, "0" },
+        { sbyte.MaxValue, "127" },
+        { byte.MinValue, "0" },
+        { byte.MaxValue, "255" },
+        { short.MinValue, "-32768" },
+        { (short)0, "0" },
+        { short.MaxValue, "32767" },
+        { ushort.MinValue, "0" },
+        { ushort.MaxValue, "65535" },
+        { int.MinValue, "-2147483648" },
+        { 0, "0" },
+        { int.MaxValue, "2147483647" },
+        { uint.MinValue, "0" },
+        { uint.MaxValue, "4294967295" },
+        { long.MinValue, "-9223372036854775808" },
+        { 0L, "0" },
+        { long.MaxValue, "9223372036854775807" },
+        { ulong.MinValue, "0" },
+        { ulong.MaxValue, "18446744073709551615" },
+        { float.MinValue, "-3.4028234663852886E+38" },
+        { 0f, "0" },
+        { float.NaN, "NaN" },
+        { float.NegativeInfinity, "-Inf" },
+        { float.PositiveInfinity, "+Inf" },
+        { float.MaxValue, "3.4028234663852886E+38" },
+        { double.MinValue, "-1.7976931348623157E+308" },
+        { 0d, "0" },
+        { double.NegativeInfinity, "-Inf" },
+        { double.PositiveInfinity, "+Inf" },
+        { double.NaN, "NaN" },
+        { double.MaxValue, "1.7976931348623157E+308" },
+        { decimal.MinValue, "-79228162514264337593543950335" },
+        { 0m, "0" },
+        { decimal.MaxValue, "79228162514264337593543950335" },
+    };
+
     [Fact]
     public void GaugeZeroDimension()
     {
@@ -236,7 +286,7 @@ public sealed class PrometheusSerializerTests
                 + "# TYPE test_gauge gauge\n"
                 + $"test_gauge{{otel_scope_name='{Utils.GetCurrentMethodName()}',x='1',y='2'}} -Inf\n"
                 + $"test_gauge{{otel_scope_name='{Utils.GetCurrentMethodName()}',x='3',y='4'}} \\+Inf\n"
-                + $"test_gauge{{otel_scope_name='{Utils.GetCurrentMethodName()}',x='5',y='6'}} Nan\n"
+                + $"test_gauge{{otel_scope_name='{Utils.GetCurrentMethodName()}',x='5',y='6'}} NaN\n"
                 + "$").Replace('\'', '"'),
             Encoding.UTF8.GetString(buffer, 0, cursor));
     }
@@ -264,6 +314,35 @@ public sealed class PrometheusSerializerTests
             ("^"
                 + "# TYPE test_counter_total counter\n"
                 + $"test_counter_total{{otel_scope_name='{Utils.GetCurrentMethodName()}'}} \\+Inf\n"
+                + "$").Replace('\'', '"'),
+            Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(long.MaxValue)]
+    public void SumLongSerializesBoundaryValues(long value)
+    {
+        var buffer = new byte[85000];
+        var metrics = new List<Metric>();
+
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+        using (var provider = Sdk.CreateMeterProviderBuilder()
+                                 .AddMeter(meter.Name)
+                                 .AddInMemoryExporter(metrics)
+                                 .Build())
+        {
+            var counter = meter.CreateCounter<long>("test_counter");
+            counter.Add(value);
+
+            provider.ForceFlush();
+        }
+
+        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        Assert.Matches(
+            ("^"
+                + "# TYPE test_counter_total counter\n"
+                + $"test_counter_total{{otel_scope_name='{Utils.GetCurrentMethodName()}'}} {value.ToString(CultureInfo.InvariantCulture)}\n"
                 + "$").Replace('\'', '"'),
             Encoding.UTF8.GetString(buffer, 0, cursor));
     }
@@ -512,7 +591,7 @@ public sealed class PrometheusSerializerTests
                 + $"test_histogram_bucket{{otel_scope_name='{Utils.GetCurrentMethodName()}',le='7500'}} 1\n"
                 + $"test_histogram_bucket{{otel_scope_name='{Utils.GetCurrentMethodName()}',le='10000'}} 1\n"
                 + $"test_histogram_bucket{{otel_scope_name='{Utils.GetCurrentMethodName()}',le='\\+Inf'}} 3\n"
-                + $"test_histogram_sum{{otel_scope_name='{Utils.GetCurrentMethodName()}'}} Nan\n"
+                + $"test_histogram_sum{{otel_scope_name='{Utils.GetCurrentMethodName()}'}} NaN\n"
                 + $"test_histogram_count{{otel_scope_name='{Utils.GetCurrentMethodName()}'}} 3\n"
                 + "$").Replace('\'', '"'),
             Encoding.UTF8.GetString(buffer, 0, cursor));
@@ -696,6 +775,200 @@ public sealed class PrometheusSerializerTests
             Encoding.UTF8.GetString(buffer, 0, cursor));
     }
 
+    [Fact]
+    public void WriteAsciiStringNoEscapeWritesAsciiBytes()
+    {
+        var value = "metric_name_total";
+        var buffer = new byte[64];
+
+        var cursor = PrometheusSerializer.WriteAsciiStringNoEscape(buffer, 0, value);
+
+        Assert.Equal("metric_name_total", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Fact]
+    public void WriteAsciiStringNoEscapeThrowsExceptionWhenBufferTooSmall()
+    {
+        var buffer = new byte[4];
+
+        Assert.Throws<IndexOutOfRangeException>(() => PrometheusSerializer.WriteAsciiStringNoEscape(buffer, 0, "metric"));
+    }
+
+    [Fact]
+    public void WriteLabelValueEscapesSpecialCharacters()
+    {
+        var buffer = new byte[128];
+
+        var cursor = PrometheusSerializer.WriteLabelValue(buffer, 0, "\"line1\\\nline2\"");
+
+        Assert.Equal("\\\"line1\\\\\\nline2\\\"", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Theory]
+#pragma warning disable xUnit1045 // Avoid using TheoryData type arguments that might not be serializable
+    [MemberData(nameof(LabelValueBoundaryCases))]
+#pragma warning restore xUnit1045 // Avoid using TheoryData type arguments that might not be serializable
+    public void WriteMetricSerializesStaticMeterTagBoundaryValues(object? meterTagValue, string expectedTagValue)
+    {
+        var output = WriteGaugeMetricWithMeterTags(new KeyValuePair<string, object?>("meter_tag", meterTagValue));
+
+        Assert.Equal(
+            ("# TYPE test_gauge gauge\n"
+             + $"test_gauge{{otel_scope_name='test_meter',meter_tag='{expectedTagValue}'}} 123\n").Replace('\'', '"'),
+            output);
+    }
+
+    [Fact]
+    public void WriteLabelFormatsTypedValues()
+    {
+        var buffer = new byte[128];
+
+        var cursor = PrometheusSerializer.WriteLabel(buffer, 0, "value", 18446744073709551615UL);
+
+        Assert.Equal("value=\"18446744073709551615\"", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Theory]
+    [InlineData(long.MinValue)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(long.MaxValue)]
+    public void WriteLongMatchesInvariantFormatting(long value)
+    {
+        var buffer = new byte[64];
+
+        var cursor = PrometheusSerializer.WriteLong(buffer, 0, value);
+
+        Assert.Equal(value.ToString(CultureInfo.InvariantCulture), Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, "-Inf")]
+    [InlineData(-1234.5, "-1234.5")]
+    [InlineData(0d, "0")]
+    [InlineData(1234.5, "1234.5")]
+    [InlineData(double.PositiveInfinity, "+Inf")]
+    public void WriteDoubleMatchesInvariantFormatting(double value, string expected)
+    {
+        var buffer = new byte[64];
+
+        var cursor = PrometheusSerializer.WriteDouble(buffer, 0, value);
+
+        Assert.Equal(expected, Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Fact]
+    public void WriteDoubleFormatsNaN()
+    {
+        var buffer = new byte[64];
+
+        var cursor = PrometheusSerializer.WriteDouble(buffer, 0, double.NaN);
+
+        Assert.Equal("NaN", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Fact]
+    public void WriteUnicodeStringPreservesUtf16CodeUnitEncoding()
+    {
+        const string value = "rocket:\uD83D\uDE80";
+        var buffer = new byte[128];
+
+        var cursor = PrometheusSerializer.WriteUnicodeString(buffer, 0, value);
+        var actual = ToHexString(buffer, cursor);
+
+        Assert.Equal("726F636B65743AEDA0BDEDBA80", actual);
+    }
+
+#if NET
+    [Fact]
+    public void WriteHistogramMetricSerializesStaticTagsWithoutPreSerializedTags()
+    {
+        var buffer = new byte[85000];
+
+        var metric = GetSingleHistogramMetric(
+            meterName: "\u65e5\u672c",
+            meterTags: [new KeyValuePair<string, object?>(string.Empty, "meterTagValue")]);
+
+        var prometheusMetric = new PrometheusMetric(metric.Name, metric.Unit, PrometheusType.Histogram, disableTotalNameSuffixForCounters: false);
+
+        var cursor = PrometheusSerializer.WriteMetric(buffer, 0, metric, prometheusMetric, openMetricsRequested: false);
+        var output = Encoding.UTF8.GetString(buffer, 0, cursor);
+
+        Assert.Contains("test_histogram_bucket{otel_scope_name=\"\u65e5\u672c\",_=\"meterTagValue\",le=\"0\"} 0\n", output, StringComparison.Ordinal);
+        Assert.Contains("test_histogram_sum{otel_scope_name=\"\u65e5\u672c\",_=\"meterTagValue\"} 18\n", output, StringComparison.Ordinal);
+        Assert.Contains("test_histogram_count{otel_scope_name=\"\u65e5\u672c\",_=\"meterTagValue\"} 1\n", output, StringComparison.Ordinal);
+    }
+
+    private static Metric GetSingleHistogramMetric(string meterName, params KeyValuePair<string, object?>[] meterTags)
+    {
+        var metrics = new List<Metric>();
+
+        using var meter = new Meter(name: meterName, version: null, tags: meterTags);
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+        var histogram = meter.CreateHistogram<double>("test_histogram");
+        histogram.Record(18);
+
+        provider.ForceFlush();
+
+        return metrics.Single();
+    }
+#endif
+
+    private static string ToHexString(byte[] buffer, int length)
+    {
+        var chars = new char[length * 2];
+
+        for (var i = 0; i < length; i++)
+        {
+            var value = buffer[i];
+            chars[i * 2] = GetHexValue(value >> 4);
+            chars[(i * 2) + 1] = GetHexValue(value & 0xF);
+        }
+
+        return new string(chars);
+
+        static char GetHexValue(int value) => (char)(value < 10 ? '0' + value : 'A' + (value - 10));
+    }
+
     private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics = false)
         => PrometheusSerializer.WriteMetric(buffer, cursor, metric, PrometheusMetric.Create(metric, false), useOpenMetrics);
+
+    private static string WriteGaugeMetricWithMeterTags(params KeyValuePair<string, object?>[] meterTags)
+    {
+        var buffer = new byte[85000];
+        var metrics = new List<Metric>();
+
+        using var meter = new Meter(name: "test_meter", version: null, tags: meterTags);
+        using (var provider = Sdk.CreateMeterProviderBuilder()
+                                 .AddMeter(meter.Name)
+                                 .AddInMemoryExporter(metrics)
+                                 .Build())
+        {
+            meter.CreateObservableGauge("test_gauge", () => 123);
+            provider.ForceFlush();
+        }
+
+        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        return Encoding.UTF8.GetString(buffer, 0, cursor);
+    }
+
+    private sealed class CustomFormattable(decimal value) : IFormattable
+    {
+        public string ToString(string? format, IFormatProvider? formatProvider)
+            => value.ToString(format, formatProvider);
+
+        public override string ToString()
+            => value.ToString(CultureInfo.CurrentCulture);
+    }
+
+    private sealed class CustomObject(string value)
+    {
+        public override string ToString() => value;
+    }
 }


### PR DESCRIPTION
## Changes

- Cherry-pick test coverage improvements from #7170 to extend unit tests, add fuzz tests and extend benchmarks.
- Fix incorrect Prometheus serialization for `NaN`, infinities and float and double precision.
- Fix incorrect Prometheus serialization of some UTF-8 strings.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
