### PR TITLE
[Exporter.Prometheus] Fix non-ASCII metric names

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -11,6 +11,9 @@ Notes](../../RELEASENOTES.md).
   `PrometheusAspNetCoreOptions`.
   ([#7176](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7176))
 
+* Fix non-ASCII characters in metric names not being serialized correctly.
+  ([#7184](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7184))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -20,7 +20,8 @@ Notes](../../RELEASENOTES.md).
   significant digits to represent such values.
   ([#7179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7179))
 
-* Fix non-ASCII characters in metric names not being serialized correctly.
+* Fix non-ASCII characters in metric names and unit strings not being sanitized
+  correctly during Prometheus serialization.
   ([#7184](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7184))
 
 ## 1.15.3-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -17,6 +17,9 @@ Notes](../../RELEASENOTES.md).
   `PrometheusHttpListenerOptions`.
   ([#7176](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7176))
 
+* Fix non-ASCII characters in metric names not being serialized correctly.
+  ([#7184](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7184))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -26,7 +26,8 @@ Notes](../../RELEASENOTES.md).
   significant digits to represent such values.
   ([#7179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7179))
 
-* Fix non-ASCII characters in metric names not being serialized correctly.
+* Fix non-ASCII characters in metric names and unit strings not being sanitized
+  correctly during Prometheus serialization.
   ([#7184](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7184))
 
 ## 1.15.3-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using OpenTelemetry.Metrics;
 
@@ -86,7 +87,7 @@ internal sealed class PrometheusMetric
         {
             var c = metricUnit[i];
 
-            if (!char.IsLetterOrDigit(c) && c != ':')
+            if (!IsAsciiLetterOrDigit(c) && c != ':')
             {
                 if (!lastCharUnderscore)
                 {
@@ -97,11 +98,7 @@ internal sealed class PrometheusMetric
             }
             else
             {
-                if (sb != null)
-                {
-                    sb.Append(c);
-                }
-
+                sb?.Append(c);
                 lastCharUnderscore = false;
             }
         }
@@ -119,7 +116,7 @@ internal sealed class PrometheusMetric
         {
             var c = metricName[i];
 
-            if (i == 0 && char.IsNumber(c))
+            if (i == 0 && IsAsciiDigit(c))
             {
                 sb ??= CreateStringBuilder(metricName);
                 sb.Append('_');
@@ -127,7 +124,7 @@ internal sealed class PrometheusMetric
                 continue;
             }
 
-            if (!char.IsLetterOrDigit(c) && c != ':')
+            if (!IsAsciiLetterOrDigit(c) && c != ':')
             {
                 if (!lastCharUnderscore)
                 {
@@ -145,6 +142,11 @@ internal sealed class PrometheusMetric
         }
 
         return sb?.ToString() ?? metricName;
+
+        static StringBuilder CreateStringBuilder(string value)
+        {
+            return new(value.Length);
+        }
     }
 
     internal static string RemoveAnnotations(string unit)
@@ -214,10 +216,21 @@ internal sealed class PrometheusMetric
         };
     }
 
-    private static StringBuilder CreateStringBuilder(string value)
-    {
-        return new(value.Length);
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAsciiDigit(char value) =>
+#if NET
+        char.IsAsciiDigit(value);
+#else
+        value is >= '0' and <= '9';
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAsciiLetterOrDigit(char value) =>
+#if NET
+        char.IsAsciiLetterOrDigit(value);
+#else
+        value is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9');
+#endif
 
     private static string SanitizeOpenMetricsName(string metricName)
         => metricName.EndsWith("_total", StringComparison.Ordinal) ? metricName.Substring(0, metricName.Length - 6) : metricName;

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
@@ -57,6 +57,10 @@ public sealed class PrometheusMetricTests
         => AssertSanitizeMetricName("sample_metric_name__:_per_meter", "sample_metric_name_:_per_meter");
 
     [Fact]
+    public void SanitizeMetricName_ReplacesNonAsciiCharacters()
+        => AssertSanitizeMetricName("A\u010A", "A_");
+
+    [Fact]
     public void Unit_Annotation_None()
         => Assert.Equal("Test", PrometheusMetric.RemoveAnnotations("Test"));
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
@@ -181,14 +181,17 @@ public sealed class PrometheusMetricTests
         => AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
 
     [Fact]
-    public void OpenMetricsMetadataName_Counter_NotAppendTotal() => AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes");
+    public void OpenMetricsMetadataName_Counter_NotAppendTotal()
+        => AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes");
 
     [Fact]
     public void OpenMetricsMetadataName_Counter_DisableSuffixTotal_NotAppendTotal()
         => AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, true, "db_bytes_written_bytes");
 
     [Theory]
+#pragma warning disable xUnit1045 // Avoid using TheoryData type arguments that might not be serializable
     [MemberData(nameof(GetPrometheusType_Data))]
+#pragma warning restore xUnit1045 // Avoid using TheoryData type arguments that might not be serializable
     public void GetPrometheusType_MapsOpenTelemetryMetricsTypeToPrometheus(MetricsMappingTestData mappingTestData)
     {
         var result = PrometheusMetric.GetPrometheusType(mappingTestData.OpenTelemetryMetricType);
@@ -390,6 +393,10 @@ public sealed class PrometheusMetricTests
     [Fact]
     public void SanitizeMetricUnit_RemoveMultipleUnsupportedCharacters()
         => AssertSanitizeMetricUnit("##/RU!", "RU");
+
+    [Fact]
+    public void SanitizeMetricUnit_ReplacesNonAsciiCharacters()
+        => AssertSanitizeMetricUnit("s\u010A", "s");
 
     [Fact]
     public void Name_UnitWithHash_Sanitized()

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -210,6 +210,17 @@ public sealed class PrometheusSerializerTests
     }
 
     [Fact]
+    public void WriteMetricNameSanitizesNonAsciiCharacters()
+    {
+        var buffer = new byte[32];
+        var metric = new PrometheusMetric("A\u010A", string.Empty, PrometheusType.Gauge, disableTotalNameSuffixForCounters: false);
+
+        var cursor = PrometheusSerializer.WriteMetricName(buffer, 0, metric, openMetricsRequested: false);
+
+        Assert.Equal("A_", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Fact]
     public void GaugeDoubleSubnormal()
     {
         var buffer = new byte[85000];

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -271,6 +271,17 @@ public sealed class PrometheusSerializerTests
     }
 
     [Fact]
+    public void WriteMetricNameSanitizesNonAsciiUnitCharacters()
+    {
+        var buffer = new byte[32];
+        var metric = new PrometheusMetric("metric", "s\u010A", PrometheusType.Gauge, disableTotalNameSuffixForCounters: false);
+
+        var cursor = PrometheusSerializer.WriteMetricName(buffer, 0, metric, openMetricsRequested: false);
+
+        Assert.Equal("metric_s", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Fact]
     public void GaugeDoubleSubnormal()
     {
         var buffer = new byte[85000];


### PR DESCRIPTION
## Changes

Fix non-ASCII characters in metric names being truncated to single bytes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
