### PR TITLE
[OpenTelemetry] Fix-up exception pointer clearing

### DIFF
--- a/src/OpenTelemetry/Trace/Processor/ExceptionProcessor.cs
+++ b/src/OpenTelemetry/Trace/Processor/ExceptionProcessor.cs
@@ -46,13 +46,6 @@ internal sealed class ExceptionProcessor : BaseProcessor<Activity>
     /// <inheritdoc />
     public override void OnEnd(Activity activity)
     {
-        var pointers = this.fnGetExceptionPointers();
-
-        if (pointers == IntPtr.Zero)
-        {
-            return;
-        }
-
         var snapshot = activity.GetTagValue(ExceptionPointersKey) as IntPtr?;
 
         if (snapshot != null)
@@ -60,7 +53,9 @@ internal sealed class ExceptionProcessor : BaseProcessor<Activity>
             activity.SetTag(ExceptionPointersKey, null);
         }
 
-        if (snapshot != pointers)
+        var pointers = this.fnGetExceptionPointers();
+
+        if (pointers != IntPtr.Zero && snapshot != pointers)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             activity.SetStatus(Status.Error);

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTests.cs
@@ -93,17 +93,7 @@ public class ExceptionProcessorTests
 
         Assert.NotNull(activity5);
         Assert.Equal(StatusCode.Unset, activity5.GetStatus().StatusCode);
-#if !NETFRAMEWORK
-        if (Environment.Is64BitProcess)
-        {
-            // In this rare case, the following Activity tag will not get cleaned up due to perf consideration.
-            Assert.NotNull(GetTagValue(activity5, "otel.exception_pointers"));
-        }
-        else
-        {
-            Assert.Null(GetTagValue(activity5, "otel.exception_pointers"));
-        }
-#endif
+        Assert.Null(GetTagValue(activity5, "otel.exception_pointers"));
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

Fix `otel.exception_pointers` not always being cleaned up.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
