### PR TITLE
[OpenTelementry] Ignore invalid `OTEL_BSP` values

### DIFF
--- a/src/OpenTelemetry/BatchExportProcessorOptions.cs
+++ b/src/OpenTelemetry/BatchExportProcessorOptions.cs
@@ -29,4 +29,32 @@ public class BatchExportProcessorOptions<T>
     /// Gets or sets the maximum batch size of every export. It must be smaller or equal to <see cref="MaxQueueSize"/>. The default value is 512.
     /// </summary>
     public int MaxExportBatchSize { get; set; } = BatchExportProcessor<T>.DefaultMaxExportBatchSize;
+
+    internal static void ApplyValidatedConfiguration(
+        BatchExportProcessorOptions<T> options,
+        int maxQueueSize,
+        int maxExportBatchSize,
+        int exporterTimeoutMilliseconds,
+        int scheduledDelayMilliseconds)
+    {
+        if (maxQueueSize > 0)
+        {
+            options.MaxQueueSize = maxQueueSize;
+        }
+
+        if (maxExportBatchSize > 0 && maxExportBatchSize <= options.MaxQueueSize)
+        {
+            options.MaxExportBatchSize = maxExportBatchSize;
+        }
+
+        if (exporterTimeoutMilliseconds >= 0)
+        {
+            options.ExporterTimeoutMilliseconds = exporterTimeoutMilliseconds;
+        }
+
+        if (scheduledDelayMilliseconds > 0)
+        {
+            options.ScheduledDelayMilliseconds = scheduledDelayMilliseconds;
+        }
+    }
 }

--- a/src/OpenTelemetry/BatchExportProcessorOptions.cs
+++ b/src/OpenTelemetry/BatchExportProcessorOptions.cs
@@ -37,24 +37,39 @@ public class BatchExportProcessorOptions<T>
         int exporterTimeoutMilliseconds,
         int scheduledDelayMilliseconds)
     {
+        var candidateMaxQueueSize = options.MaxQueueSize;
+        var candidateMaxExportBatchSize = options.MaxExportBatchSize;
+        var candidateExporterTimeoutMilliseconds = options.ExporterTimeoutMilliseconds;
+        var candidateScheduledDelayMilliseconds = options.ScheduledDelayMilliseconds;
+
         if (maxQueueSize > 0)
         {
-            options.MaxQueueSize = maxQueueSize;
+            candidateMaxQueueSize = maxQueueSize;
         }
 
-        if (maxExportBatchSize > 0 && maxExportBatchSize <= options.MaxQueueSize)
+        if (maxExportBatchSize > 0)
         {
-            options.MaxExportBatchSize = maxExportBatchSize;
+            candidateMaxExportBatchSize = maxExportBatchSize;
+        }
+
+        if (candidateMaxExportBatchSize > candidateMaxQueueSize)
+        {
+            candidateMaxExportBatchSize = candidateMaxQueueSize;
         }
 
         if (exporterTimeoutMilliseconds >= 0)
         {
-            options.ExporterTimeoutMilliseconds = exporterTimeoutMilliseconds;
+            candidateExporterTimeoutMilliseconds = exporterTimeoutMilliseconds;
         }
 
         if (scheduledDelayMilliseconds > 0)
         {
-            options.ScheduledDelayMilliseconds = scheduledDelayMilliseconds;
+            candidateScheduledDelayMilliseconds = scheduledDelayMilliseconds;
         }
+
+        options.MaxQueueSize = candidateMaxQueueSize;
+        options.MaxExportBatchSize = candidateMaxExportBatchSize;
+        options.ExporterTimeoutMilliseconds = candidateExporterTimeoutMilliseconds;
+        options.ScheduledDelayMilliseconds = candidateScheduledDelayMilliseconds;
     }
 }

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -7,7 +7,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Fix incorrect validation of `OTEL_BSP_*` environment variables.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7187](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7187))
 
 ## 1.15.3
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,7 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Fix incorrect validation of `OTEL_BSP_*` environment variables.
+* Fix incorrect validation of `OTEL_BSP_*` and `OTEL_BLRP_*` environment
+  variables.
   ([#7187](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7187))
 
 ## 1.15.3

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fix incorrect validation of `OTEL_BSP_*` environment variables.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry/Logs/Processor/BatchExportLogRecordProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/Processor/BatchExportLogRecordProcessorOptions.cs
@@ -32,24 +32,36 @@ public class BatchExportLogRecordProcessorOptions : BatchExportProcessorOptions<
 
     internal BatchExportLogRecordProcessorOptions(IConfiguration configuration)
     {
+        var maxQueueSize = this.MaxQueueSize;
+        var maxExportBatchSize = this.MaxExportBatchSize;
+        var exporterTimeoutMilliseconds = this.ExporterTimeoutMilliseconds;
+        var scheduledDelayMilliseconds = this.ScheduledDelayMilliseconds;
+
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, ExporterTimeoutEnvVarKey, out var value))
         {
-            this.ExporterTimeoutMilliseconds = value;
+            exporterTimeoutMilliseconds = value;
         }
 
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, MaxExportBatchSizeEnvVarKey, out value))
         {
-            this.MaxExportBatchSize = value;
+            maxExportBatchSize = value;
         }
 
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, MaxQueueSizeEnvVarKey, out value))
         {
-            this.MaxQueueSize = value;
+            maxQueueSize = value;
         }
 
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, ScheduledDelayEnvVarKey, out value))
         {
-            this.ScheduledDelayMilliseconds = value;
+            scheduledDelayMilliseconds = value;
         }
+
+        BatchExportProcessorOptions<LogRecord>.ApplyValidatedConfiguration(
+            this,
+            maxQueueSize,
+            maxExportBatchSize,
+            exporterTimeoutMilliseconds,
+            scheduledDelayMilliseconds);
     }
 }

--- a/src/OpenTelemetry/Logs/Processor/BatchExportLogRecordProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/Processor/BatchExportLogRecordProcessorOptions.cs
@@ -57,7 +57,7 @@ public class BatchExportLogRecordProcessorOptions : BatchExportProcessorOptions<
             scheduledDelayMilliseconds = value;
         }
 
-        BatchExportProcessorOptions<LogRecord>.ApplyValidatedConfiguration(
+        ApplyValidatedConfiguration(
             this,
             maxQueueSize,
             maxExportBatchSize,

--- a/src/OpenTelemetry/Trace/Processor/BatchExportActivityProcessorOptions.cs
+++ b/src/OpenTelemetry/Trace/Processor/BatchExportActivityProcessorOptions.cs
@@ -32,24 +32,36 @@ public class BatchExportActivityProcessorOptions : BatchExportProcessorOptions<A
 
     internal BatchExportActivityProcessorOptions(IConfiguration configuration)
     {
+        var maxQueueSize = this.MaxQueueSize;
+        var maxExportBatchSize = this.MaxExportBatchSize;
+        var exporterTimeoutMilliseconds = this.ExporterTimeoutMilliseconds;
+        var scheduledDelayMilliseconds = this.ScheduledDelayMilliseconds;
+
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, ExporterTimeoutEnvVarKey, out var value))
         {
-            this.ExporterTimeoutMilliseconds = value;
+            exporterTimeoutMilliseconds = value;
         }
 
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, MaxExportBatchSizeEnvVarKey, out value))
         {
-            this.MaxExportBatchSize = value;
+            maxExportBatchSize = value;
         }
 
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, MaxQueueSizeEnvVarKey, out value))
         {
-            this.MaxQueueSize = value;
+            maxQueueSize = value;
         }
 
         if (configuration.TryGetIntValue(OpenTelemetrySdkEventSource.Log, ScheduledDelayEnvVarKey, out value))
         {
-            this.ScheduledDelayMilliseconds = value;
+            scheduledDelayMilliseconds = value;
         }
+
+        BatchExportProcessorOptions<Activity>.ApplyValidatedConfiguration(
+            this,
+            maxQueueSize,
+            maxExportBatchSize,
+            exporterTimeoutMilliseconds,
+            scheduledDelayMilliseconds);
     }
 }

--- a/src/OpenTelemetry/Trace/Processor/BatchExportActivityProcessorOptions.cs
+++ b/src/OpenTelemetry/Trace/Processor/BatchExportActivityProcessorOptions.cs
@@ -57,7 +57,7 @@ public class BatchExportActivityProcessorOptions : BatchExportProcessorOptions<A
             scheduledDelayMilliseconds = value;
         }
 
-        BatchExportProcessorOptions<Activity>.ApplyValidatedConfiguration(
+        ApplyValidatedConfiguration(
             this,
             maxQueueSize,
             maxExportBatchSize,

--- a/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTests.cs
@@ -51,7 +51,7 @@ public sealed class BatchExportLogRecordProcessorOptionsTests : IDisposable
     {
         var values = new Dictionary<string, string?>()
         {
-            [BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey] = "1",
+            [BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey] = "3",
             [BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey] = "2",
             [BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey] = "3",
             [BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey] = "4",
@@ -63,7 +63,7 @@ public sealed class BatchExportLogRecordProcessorOptionsTests : IDisposable
 
         var options = new BatchExportLogRecordProcessorOptions(configuration);
 
-        Assert.Equal(1, options.MaxQueueSize);
+        Assert.Equal(3, options.MaxQueueSize);
         Assert.Equal(2, options.MaxExportBatchSize);
         Assert.Equal(3, options.ExporterTimeoutMilliseconds);
         Assert.Equal(4, options.ScheduledDelayMilliseconds);

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTests.cs
@@ -94,6 +94,18 @@ public sealed class BatchExportActivityProcessorOptionsTests
     }
 
     [Fact]
+    public void BatchExportProcessorOptions_MaxQueueSizeLowerThanEffectiveMaxExportBatchSizeClampsBatchSize()
+    {
+        using (EnvironmentVariableScope.Create(BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey, "10"))
+        {
+            var options = new BatchExportActivityProcessorOptions();
+
+            Assert.Equal(10, options.MaxQueueSize);
+            Assert.Equal(10, options.MaxExportBatchSize);
+        }
+    }
+
+    [Fact]
     public void BatchExportProcessorOptions_SetterOverridesEnvironmentVariable()
     {
         using (EnvironmentVariableScope.Create(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "123"))

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTests.cs
@@ -6,19 +6,8 @@ using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 
-public sealed class BatchExportActivityProcessorOptionsTests : IDisposable
+public sealed class BatchExportActivityProcessorOptionsTests
 {
-    public BatchExportActivityProcessorOptionsTests()
-    {
-        ClearEnvVars();
-    }
-
-    public void Dispose()
-    {
-        ClearEnvVars();
-        GC.SuppressFinalize(this);
-    }
-
     [Fact]
     public void BatchExportProcessorOptions_Defaults()
     {
@@ -33,17 +22,21 @@ public sealed class BatchExportActivityProcessorOptionsTests : IDisposable
     [Fact]
     public void BatchExportProcessorOptions_EnvironmentVariableOverride()
     {
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "1");
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey, "2");
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey, "3");
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey, "4");
+        using (EnvironmentVariableScope.Create(
+            [
+                (BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "1"),
+                (BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey, "2"),
+                (BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey, "3"),
+                (BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey, "4"),
+            ]))
+        {
+            var options = new BatchExportActivityProcessorOptions();
 
-        var options = new BatchExportActivityProcessorOptions();
-
-        Assert.Equal(1, options.ExporterTimeoutMilliseconds);
-        Assert.Equal(2, options.MaxExportBatchSize);
-        Assert.Equal(3, options.MaxQueueSize);
-        Assert.Equal(4, options.ScheduledDelayMilliseconds);
+            Assert.Equal(1, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(2, options.MaxExportBatchSize);
+            Assert.Equal(3, options.MaxQueueSize);
+            Assert.Equal(4, options.ScheduledDelayMilliseconds);
+        }
     }
 
     [Fact]
@@ -51,7 +44,7 @@ public sealed class BatchExportActivityProcessorOptionsTests : IDisposable
     {
         var values = new Dictionary<string, string?>()
         {
-            [BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey] = "1",
+            [BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey] = "3",
             [BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey] = "2",
             [BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey] = "3",
             [BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey] = "4",
@@ -63,7 +56,7 @@ public sealed class BatchExportActivityProcessorOptionsTests : IDisposable
 
         var options = new BatchExportActivityProcessorOptions(configuration);
 
-        Assert.Equal(1, options.MaxQueueSize);
+        Assert.Equal(3, options.MaxQueueSize);
         Assert.Equal(2, options.MaxExportBatchSize);
         Assert.Equal(3, options.ExporterTimeoutMilliseconds);
         Assert.Equal(4, options.ScheduledDelayMilliseconds);
@@ -72,30 +65,46 @@ public sealed class BatchExportActivityProcessorOptionsTests : IDisposable
     [Fact]
     public void BatchExportProcessorOptions_InvalidEnvironmentVariableOverride()
     {
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "invalid");
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey, "invalid");
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey, "invalid");
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey, "invalid");
+        using (EnvironmentVariableScope.Create(
+            [
+                (BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "invalid"),
+                (BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey, "invalid"),
+                (BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey, "invalid"),
+                (BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey, "invalid"),
+            ]))
+        {
+            var options = new BatchExportActivityProcessorOptions();
 
-        var options = new BatchExportActivityProcessorOptions();
+            Assert.Equal(30000, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(512, options.MaxExportBatchSize);
+            Assert.Equal(2048, options.MaxQueueSize);
+            Assert.Equal(5000, options.ScheduledDelayMilliseconds);
+        }
+    }
 
-        Assert.Equal(30000, options.ExporterTimeoutMilliseconds);
-        Assert.Equal(512, options.MaxExportBatchSize);
-        Assert.Equal(2048, options.MaxQueueSize);
-        Assert.Equal(5000, options.ScheduledDelayMilliseconds);
+    [Fact]
+    public void BatchExportProcessorOptions_InvalidNumericEnvironmentVariableOverrideFallsBackToDefaults()
+    {
+        using (EnvironmentVariableScope.Create(BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey, "0"))
+        {
+            var options = new BatchExportActivityProcessorOptions();
+
+            Assert.Equal(2048, options.MaxQueueSize);
+        }
     }
 
     [Fact]
     public void BatchExportProcessorOptions_SetterOverridesEnvironmentVariable()
     {
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "123");
-
-        var options = new BatchExportActivityProcessorOptions
+        using (EnvironmentVariableScope.Create(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "123"))
         {
-            ExporterTimeoutMilliseconds = 89000,
-        };
+            var options = new BatchExportActivityProcessorOptions
+            {
+                ExporterTimeoutMilliseconds = 89000,
+            };
 
-        Assert.Equal(89000, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(89000, options.ExporterTimeoutMilliseconds);
+        }
     }
 
     [Fact]
@@ -105,13 +114,5 @@ public sealed class BatchExportActivityProcessorOptionsTests : IDisposable
         Assert.Equal("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey);
         Assert.Equal("OTEL_BSP_MAX_QUEUE_SIZE", BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey);
         Assert.Equal("OTEL_BSP_SCHEDULE_DELAY", BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey);
-    }
-
-    private static void ClearEnvVars()
-    {
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, null);
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey, null);
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.MaxQueueSizeEnvVarKey, null);
-        Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey, null);
     }
 }


### PR DESCRIPTION
## Changes

Only apply `OTEL_BSP` environment variables to configuration when they are valid.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
