### PR TITLE
[Prometheus.HttpListener] Support scrape HTTP response caching

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
@@ -10,6 +10,8 @@ OpenTelemetry.Exporter.PrometheusHttpListenerOptions.UriPrefixes.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.PrometheusHttpListenerOptions() -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeEndpointPath.get -> string?
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeEndpointPath.set -> void
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds.get -> int
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds.set -> void
 OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions
 static OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions.AddPrometheusHttpListener(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions.AddPrometheusHttpListener(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, string? name, System.Action<OpenTelemetry.Exporter.PrometheusHttpListenerOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -32,6 +32,8 @@ Notes](../../RELEASENOTES.md).
 
 * Add support for caching the scrape endpoint HTTP responses using the
   `PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds` option.
+  The default value is `300` milliseconds. Set the option to `0` to disable
+  response caching.
   ([#7189](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7189))
 
 ## 1.15.3-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -19,7 +19,7 @@ Notes](../../RELEASENOTES.md).
 
 * Add support for caching the scrape endpoint HTTP responses using the
   `PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds` option.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7189](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7189))
 
 ## 1.15.3-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -17,6 +17,10 @@ Notes](../../RELEASENOTES.md).
   `PrometheusHttpListenerOptions`.
   ([#7176](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7176))
 
+* Add support for caching the scrape endpoint HTTP responses using the
+  `PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds` option.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
@@ -67,7 +67,7 @@ public static class PrometheusHttpListenerMeterProviderBuilderExtensions
     {
         var exporter = new PrometheusExporter(new PrometheusExporterOptions
         {
-            ScrapeResponseCacheDurationMilliseconds = 0,
+            ScrapeResponseCacheDurationMilliseconds = options.ScrapeResponseCacheDurationMilliseconds,
             DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters,
         });
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -18,6 +18,14 @@ public class PrometheusHttpListenerOptions
     private IReadOnlyCollection<string> uriPrefixes = ["http://localhost:9464/"];
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="PrometheusHttpListenerOptions"/> class.
+    /// </summary>
+    public PrometheusHttpListenerOptions()
+    {
+        this.ScrapeResponseCacheDurationMilliseconds = 300;
+    }
+
+    /// <summary>
     /// Gets or sets the Host name the HTTP listener will bind to. Defaults to <c>localhost</c>.
     /// </summary>
     public string Host { get; set; } = "localhost";
@@ -36,6 +44,22 @@ public class PrometheusHttpListenerOptions
     /// Gets or sets a value indicating whether addition of _total suffix for counter metric names is disabled. Default value: <see langword="false"/>.
     /// </summary>
     public bool DisableTotalNameSuffixForCounters { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cache duration in milliseconds for scrape responses. Default value: 300.
+    /// </summary>
+    /// <remarks>
+    /// Note: Specify 0 to disable response caching.
+    /// </remarks>
+    public int ScrapeResponseCacheDurationMilliseconds
+    {
+        get => field;
+        set
+        {
+            Guard.ThrowIfOutOfRange(value, min: 0);
+            field = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the URI (Uniform Resource Identifier) prefixes to use for the http listener.

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md
@@ -50,6 +50,12 @@ for more details.
 
 Defines the Prometheus scrape endpoint path. Default value: `"/metrics"`.
 
+### ScrapeResponseCacheDurationMilliseconds
+
+Configures scrape endpoint response caching. Multiple scrape requests within the
+cache duration time period will receive the same previously generated response.
+The default value is `300`. Set to `0` to disable response caching.
+
 ## Troubleshooting
 
 This component uses an

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -13,8 +13,8 @@ public sealed class PrometheusCollectionManagerTests
     [Theory]
     [InlineData(0, true)] // disable cache
     [InlineData(0, false)] // disable cache
-    [InlineData(300, true)] // default value for HttpListener
-    [InlineData(300, false)] // default value for HttpListener
+    [InlineData(300, true)] // default value
+    [InlineData(300, false)] // default value
     public async Task EnterExitCollectTest(int scrapeResponseCacheDurationMilliseconds, bool openMetricsRequested)
     {
         var testTimeout = TimeSpan.FromMinutes(1);

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -11,6 +11,8 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests;
 public sealed class PrometheusCollectionManagerTests
 {
     [Theory]
+    [InlineData(0, true)] // disable cache
+    [InlineData(0, false)] // disable cache
     [InlineData(300, true)] // default value for HttpListener
     [InlineData(300, false)] // default value for HttpListener
     public async Task EnterExitCollectTest(int scrapeResponseCacheDurationMilliseconds, bool openMetricsRequested)
@@ -24,7 +26,7 @@ public sealed class PrometheusCollectionManagerTests
         using (var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meter.Name)
 #if PROMETHEUS_HTTP_LISTENER
-            .AddPrometheusHttpListener()
+            .AddPrometheusHttpListener(x => x.ScrapeResponseCacheDurationMilliseconds = scrapeResponseCacheDurationMilliseconds)
 #elif PROMETHEUS_ASPNETCORE
             .AddPrometheusExporter(x => x.ScrapeResponseCacheDurationMilliseconds = scrapeResponseCacheDurationMilliseconds)
 #endif

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -11,12 +11,8 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests;
 public sealed class PrometheusCollectionManagerTests
 {
     [Theory]
-    [InlineData(0, true)] // disable cache, default value for HttpListener
-    [InlineData(0, false)] // disable cache, default value for HttpListener
-#if PROMETHEUS_ASPNETCORE
-    [InlineData(300, true)] // default value for AspNetCore, no possibility to set on HttpListener
-    [InlineData(300, false)] // default value for AspNetCore, no possibility to set on HttpListener
-#endif
+    [InlineData(300, true)] // default value for HttpListener
+    [InlineData(300, false)] // default value for HttpListener
     public async Task EnterExitCollectTest(int scrapeResponseCacheDurationMilliseconds, bool openMetricsRequested)
     {
         var testTimeout = TimeSpan.FromMinutes(1);

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
@@ -29,4 +29,17 @@ public sealed class PrometheusHttpListenerMeterProviderBuilderExtensionsTests
         Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
         Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
     }
+
+    [Fact]
+    public void TestAddPrometheusHttpListener_UsesConfiguredCacheDuration()
+    {
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddPrometheusHttpListener(options => options.ScrapeResponseCacheDurationMilliseconds = 123)
+            .Build();
+
+#pragma warning disable CA2000 // MeterProvider owns exporter lifecycle
+        Assert.True(meterProvider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
+        Assert.Equal(123, exporter!.ScrapeResponseCacheDurationMilliseconds);
+    }
 }


### PR DESCRIPTION
## Changes

Add support for caching HTTP responses in `OpenTelementry.Exporter.Prometheus.HttpListener`.

This creates parity with the ASP.NET Core exporter instead of forcing it to be disabled.

If we'd rather keep the current behaviour by default, I can change the default back to 0.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
