### PR TITLE
Refactor sampler config to use `SamplerOptions` and `IOptions`

### DIFF
--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -383,6 +383,26 @@ The supported values for `OTEL_TRACES_SAMPLER` are:
 The options `traceidratio` and `parentbased_traceidratio` may have the sampler
 probability configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.
 
+The same settings may be configured in code, or bound from a configuration
+source such as `appsettings.json`, using `SamplerOptions`:
+
+```csharp
+services.Configure<SamplerOptions>(options =>
+{
+    options.Type = "traceidratio";
+    options.TraceIdRatio = 0.25;
+});
+```
+
+```csharp
+services.Configure<SamplerOptions>(
+    configuration.GetSection("OpenTelemetry:Sampler"));
+```
+
+Values set using `SamplerOptions` take precedence over the environment
+variables. A sampler set using `SetSampler` takes precedence over both, in
+which case the configured values are ignored.
+
 Follow [this](../extending-the-sdk/README.md#sampler) document
 to learn about writing custom samplers.
 

--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+OpenTelemetry.Trace.SamplerOptions
+OpenTelemetry.Trace.SamplerOptions.SamplerArg.get -> double?
+OpenTelemetry.Trace.SamplerOptions.SamplerArg.set -> void
+OpenTelemetry.Trace.SamplerOptions.SamplerType.get -> string?
+OpenTelemetry.Trace.SamplerOptions.SamplerType.set -> void

--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 OpenTelemetry.Trace.SamplerOptions
-OpenTelemetry.Trace.SamplerOptions.SamplerArg.get -> double?
-OpenTelemetry.Trace.SamplerOptions.SamplerArg.set -> void
-OpenTelemetry.Trace.SamplerOptions.SamplerType.get -> string?
-OpenTelemetry.Trace.SamplerOptions.SamplerType.set -> void
+OpenTelemetry.Trace.SamplerOptions.SamplerOptions() -> void
+OpenTelemetry.Trace.SamplerOptions.TraceIdRatio.get -> double?
+OpenTelemetry.Trace.SamplerOptions.TraceIdRatio.set -> void
+OpenTelemetry.Trace.SamplerOptions.Type.get -> string?
+OpenTelemetry.Trace.SamplerOptions.Type.set -> void

--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 OpenTelemetry.Trace.AlwaysRecordSampler
 OpenTelemetry.Trace.AlwaysRecordSampler.AlwaysRecordSampler(OpenTelemetry.Trace.Sampler! rootSampler) -> void
+OpenTelemetry.Trace.SamplerOptions
+OpenTelemetry.Trace.SamplerOptions.SamplerArg.get -> double?
+OpenTelemetry.Trace.SamplerOptions.SamplerArg.set -> void
+OpenTelemetry.Trace.SamplerOptions.SamplerType.get -> string?
+OpenTelemetry.Trace.SamplerOptions.SamplerType.set -> void
 override OpenTelemetry.Trace.AlwaysRecordSampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult

--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,8 +1,9 @@
 OpenTelemetry.Trace.AlwaysRecordSampler
 OpenTelemetry.Trace.AlwaysRecordSampler.AlwaysRecordSampler(OpenTelemetry.Trace.Sampler! rootSampler) -> void
 OpenTelemetry.Trace.SamplerOptions
-OpenTelemetry.Trace.SamplerOptions.SamplerArg.get -> double?
-OpenTelemetry.Trace.SamplerOptions.SamplerArg.set -> void
-OpenTelemetry.Trace.SamplerOptions.SamplerType.get -> string?
-OpenTelemetry.Trace.SamplerOptions.SamplerType.set -> void
+OpenTelemetry.Trace.SamplerOptions.SamplerOptions() -> void
+OpenTelemetry.Trace.SamplerOptions.TraceIdRatio.get -> double?
+OpenTelemetry.Trace.SamplerOptions.TraceIdRatio.set -> void
+OpenTelemetry.Trace.SamplerOptions.Type.get -> string?
+OpenTelemetry.Trace.SamplerOptions.Type.set -> void
 override OpenTelemetry.Trace.AlwaysRecordSampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,8 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Introduce SamplerOptions to encapsulate trace sampler configuration, parsing
-  OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG from IConfiguration.
+* Introduce `SamplerOptions` to encapsulate trace sampler configuration, parsing
+  `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` from `IConfiguration`.
   ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
 
 ## 1.15.3

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Introduce SamplerOptions to encapsulate trace sampler configuration, parsing
+  OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG from IConfiguration.
+  ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Introduce `SamplerOptions` to encapsulate trace sampler configuration, parsing
+  `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` from `IConfiguration`.
+  ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,8 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Introduce `SamplerOptions` to encapsulate trace sampler configuration, parsing
-  `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` from `IConfiguration`.
+* Added `SamplerOptions`, which allows the trace sampler to be configured using
+  the options pattern (inluding binding from `appsettings.json`) in addition to
+  the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables.
   ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
 
 ## 1.18.0

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -7,7 +7,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Added `SamplerOptions`, which allows the trace sampler to be configured using
-  the options pattern (inluding binding from `appsettings.json`) in addition to
+  the options pattern (including binding from `appsettings.json`) in addition to
   the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables.
   ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -20,7 +20,7 @@ Notes](../../RELEASENOTES.md).
   `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` from `IConfiguration`.
 
 * Added `SamplerOptions`, which allows the trace sampler to be configured using
-  the options pattern (inluding binding from `appsettings.json`) in addition to
+  the options pattern (including binding from `appsettings.json`) in addition to
   the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables.
   ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -16,9 +16,6 @@ Notes](../../RELEASENOTES.md).
 * Added `AlwaysRecordSampler`.
   ([#7695](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7695))
 
-* Introduce `SamplerOptions` to encapsulate trace sampler configuration, parsing
-  `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` from `IConfiguration`.
-
 * Added `SamplerOptions`, which allows the trace sampler to be configured using
   the options pattern (including binding from `appsettings.json`) in addition to
   the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -16,6 +16,10 @@ Notes](../../RELEASENOTES.md).
 * Added `AlwaysRecordSampler`.
   ([#7695](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7695))
 
+* Introduce `SamplerOptions` to encapsulate trace sampler configuration, parsing
+  `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` from `IConfiguration`.
+  ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -18,6 +18,10 @@ Notes](../../RELEASENOTES.md).
 
 * Introduce `SamplerOptions` to encapsulate trace sampler configuration, parsing
   `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` from `IConfiguration`.
+
+* Added `SamplerOptions`, which allows the trace sampler to be configured using
+  the options pattern (inluding binding from `appsettings.json`) in addition to
+  the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables.
   ([#7192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7192))
 
 ## 1.18.0

--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ internal static class ProviderBuilderServiceCollectionExtensions
 #pragma warning disable CS8604 // Possible null reference argument.
         services.TryAddSingleton<TracerProviderBuilderSdk>();
         services.RegisterOptionsFactory(configuration => new BatchExportActivityProcessorOptions(configuration));
+        services.RegisterOptionsFactory(configuration => new SamplerOptions(configuration));
         services.RegisterOptionsFactory(
             (sp, configuration, name) => new ActivityExportProcessorOptions(
                 sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));

--- a/src/OpenTelemetry/Trace/SamplerFactory.cs
+++ b/src/OpenTelemetry/Trace/SamplerFactory.cs
@@ -21,32 +21,31 @@ internal static class SamplerFactory
                 return sampler;
             }
 
-            switch (samplerType)
-            {
-                case var _ when string.Equals(samplerType, SamplerOptions.AlwaysOnType, StringComparison.OrdinalIgnoreCase):
-                    sampler = AlwaysOnSampler.Instance;
-                    break;
-                case var _ when string.Equals(samplerType, SamplerOptions.AlwaysOffType, StringComparison.OrdinalIgnoreCase):
-                    sampler = AlwaysOffSampler.Instance;
-                    break;
-                case var _ when string.Equals(samplerType, SamplerOptions.TraceIdRatioType, StringComparison.OrdinalIgnoreCase):
-                    sampler = new TraceIdRatioBasedSampler(ReadTraceIdRatio(options));
-                    break;
-                case var _ when string.Equals(samplerType, SamplerOptions.ParentBasedAlwaysOnType, StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
-                    break;
-                case var _ when string.Equals(samplerType, SamplerOptions.ParentBasedAlwaysOffType, StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
-                    break;
-                case var _ when string.Equals(samplerType, SamplerOptions.ParentBasedTraceIdRatioType, StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
-                    break;
-                default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(samplerType);
-                    break;
-            }
+            // Normalizing once is cheaper to read than a case-insensitive comparison against
+            // each supported value. Every supported value is lowercase ASCII, so lowercasing is
+            // equivalent to an ordinal case-insensitive comparison here.
+#pragma warning disable CA1308 // Normalize strings to uppercase
+            var normalizedType = samplerType.Trim().ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
 
-            if (sampler != null)
+            sampler = normalizedType switch
+            {
+                SamplerOptions.AlwaysOnType => AlwaysOnSampler.Instance,
+                SamplerOptions.AlwaysOffType => AlwaysOffSampler.Instance,
+                SamplerOptions.TraceIdRatioType => new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)),
+                SamplerOptions.ParentBasedAlwaysOnType => new ParentBasedSampler(AlwaysOnSampler.Instance),
+                SamplerOptions.ParentBasedAlwaysOffType => new ParentBasedSampler(AlwaysOffSampler.Instance),
+                SamplerOptions.ParentBasedTraceIdRatioType =>
+                    new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options))),
+                _ => null,
+            };
+
+            if (sampler is null)
+            {
+                // The unrecognized value is reported exactly as it was configured.
+                OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(samplerType);
+            }
+            else
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
@@ -65,34 +64,24 @@ internal static class SamplerFactory
             traceIdRatio = fromArg;
         }
 
-        if (traceIdRatio is double ratio
-            && !double.IsNaN(ratio)
-            && !double.IsInfinity(ratio)
-            && ratio >= 0.0
-            && ratio <= 1.0)
+        if (traceIdRatio is double ratio and >= 0.0 and <= 1.0)
         {
             return ratio;
         }
 
-        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(DescribeUnusableTraceIdRatio(options, traceIdRatio));
+        if (options.Argument != null || options.TraceIdRatio != null)
+        {
+            // Only report a diagnostic when a value was actually configured. The specification
+            // requires the default of 1.0 to be used when no argument is set.
+            OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(DescribeUnusableTraceIdRatio(options));
+        }
 
         return 1.0;
     }
 
-    private static string DescribeUnusableTraceIdRatio(SamplerOptions options, double? effectiveRatio)
-    {
-        var argument = options.Argument;
-
-        if (effectiveRatio is not double ratio)
-        {
-            // The configuration string could not be parsed, so it is the only value to report.
-            return argument ?? string.Empty;
-        }
-
-        return argument != null
-            && SamplerOptions.TryParseTraceIdRatio(argument, out var parsed)
-            && parsed.Equals(ratio)
-                ? argument
-                : ratio.ToString(CultureInfo.InvariantCulture);
-    }
+    private static string DescribeUnusableTraceIdRatio(SamplerOptions options) =>
+        options.Argument is string argument
+            && options.TraceIdRatio.Equals(options.ConfiguredTraceIdRatio)
+                ? argument // verbatim configured string, including trailing zero or separator
+                : options.TraceIdRatio?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
 }

--- a/src/OpenTelemetry/Trace/SamplerFactory.cs
+++ b/src/OpenTelemetry/Trace/SamplerFactory.cs
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+internal static class SamplerFactory
+{
+    internal static Sampler GetSampler(SamplerOptions options, Sampler? stateSampler)
+    {
+        var sampler = stateSampler;
+
+        if (options.Type is string samplerType && !string.IsNullOrWhiteSpace(samplerType))
+        {
+            if (sampler != null)
+            {
+                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
+                    $"Trace sampler configuration value '{samplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
+                return sampler;
+            }
+
+            switch (samplerType)
+            {
+                case var _ when string.Equals(samplerType, SamplerOptions.AlwaysOnType, StringComparison.OrdinalIgnoreCase):
+                    sampler = AlwaysOnSampler.Instance;
+                    break;
+                case var _ when string.Equals(samplerType, SamplerOptions.AlwaysOffType, StringComparison.OrdinalIgnoreCase):
+                    sampler = AlwaysOffSampler.Instance;
+                    break;
+                case var _ when string.Equals(samplerType, SamplerOptions.TraceIdRatioType, StringComparison.OrdinalIgnoreCase):
+                    sampler = new TraceIdRatioBasedSampler(ReadTraceIdRatio(options));
+                    break;
+                case var _ when string.Equals(samplerType, SamplerOptions.ParentBasedAlwaysOnType, StringComparison.OrdinalIgnoreCase):
+                    sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
+                    break;
+                case var _ when string.Equals(samplerType, SamplerOptions.ParentBasedAlwaysOffType, StringComparison.OrdinalIgnoreCase):
+                    sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
+                    break;
+                case var _ when string.Equals(samplerType, SamplerOptions.ParentBasedTraceIdRatioType, StringComparison.OrdinalIgnoreCase):
+                    sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
+                    break;
+                default:
+                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(samplerType);
+                    break;
+            }
+
+            if (sampler != null)
+            {
+                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
+            }
+        }
+
+        return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
+    }
+
+    private static double ReadTraceIdRatio(SamplerOptions options)
+    {
+        var traceIdRatio = options.TraceIdRatio;
+
+        if (traceIdRatio is null && options.Argument is string arg
+            && SamplerOptions.TryParseTraceIdRatio(arg, out var fromArg))
+        {
+            traceIdRatio = fromArg;
+        }
+
+        if (traceIdRatio is double ratio
+            && !double.IsNaN(ratio)
+            && !double.IsInfinity(ratio)
+            && ratio >= 0.0
+            && ratio <= 1.0)
+        {
+            return ratio;
+        }
+
+        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(DescribeUnusableTraceIdRatio(options, traceIdRatio));
+
+        return 1.0;
+    }
+
+    private static string DescribeUnusableTraceIdRatio(SamplerOptions options, double? effectiveRatio)
+    {
+        var argument = options.Argument;
+
+        if (effectiveRatio is not double ratio)
+        {
+            // The configuration string could not be parsed, so it is the only value to report.
+            return argument ?? string.Empty;
+        }
+
+        return argument != null
+            && SamplerOptions.TryParseTraceIdRatio(argument, out var parsed)
+            && parsed.Equals(ratio)
+                ? argument
+                : ratio.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/OpenTelemetry/Trace/SamplerFactory.cs
+++ b/src/OpenTelemetry/Trace/SamplerFactory.cs
@@ -21,9 +21,6 @@ internal static class SamplerFactory
                 return sampler;
             }
 
-            // Normalizing once is cheaper to read than a case-insensitive comparison against
-            // each supported value. Every supported value is lowercase ASCII, so lowercasing is
-            // equivalent to an ordinal case-insensitive comparison here.
 #pragma warning disable CA1308 // Normalize strings to uppercase
             var normalizedType = samplerType.Trim().ToLowerInvariant();
 #pragma warning restore CA1308 // Normalize strings to uppercase

--- a/src/OpenTelemetry/Trace/SamplerFactory.cs
+++ b/src/OpenTelemetry/Trace/SamplerFactory.cs
@@ -61,6 +61,8 @@ internal static class SamplerFactory
             traceIdRatio = fromArg;
         }
 
+        // NaN fails both relational patterns, which is required because TraceIdRatio is a
+        // settable property and can be assigned NaN programmatically even though parsing rejects it.
         if (traceIdRatio is double ratio and >= 0.0 and <= 1.0)
         {
             return ratio;
@@ -78,7 +80,7 @@ internal static class SamplerFactory
 
     private static string DescribeUnusableTraceIdRatio(SamplerOptions options) =>
         options.Argument is string argument
-            && options.TraceIdRatio.Equals(options.ConfiguredTraceIdRatio)
+            && options.TraceIdRatio == options.ConfiguredTraceIdRatio
                 ? argument // verbatim configured string, including trailing zero or separator
                 : options.TraceIdRatio?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
 }

--- a/src/OpenTelemetry/Trace/SamplerOptions.cs
+++ b/src/OpenTelemetry/Trace/SamplerOptions.cs
@@ -36,10 +36,10 @@ public sealed class SamplerOptions
             this.SamplerArgRaw = samplerArgStr;
 
             if (double.TryParse(
-                samplerArgStr,
-                NumberStyles.Float | NumberStyles.AllowThousands,
-                CultureInfo.InvariantCulture,
-                out var parsedArg))
+                    samplerArgStr,
+                    NumberStyles.Float | NumberStyles.AllowThousands,
+                    CultureInfo.InvariantCulture,
+                    out var parsedArg))
             {
                 // Bypass the public setter so that SamplerArgRaw is not cleared.
                 this.samplerArg = parsedArg;

--- a/src/OpenTelemetry/Trace/SamplerOptions.cs
+++ b/src/OpenTelemetry/Trace/SamplerOptions.cs
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Options for configuring the trace sampler.
+/// OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG environment variables
+/// are parsed during object construction.
+/// </summary>
+public sealed class SamplerOptions
+{
+    internal const string TracesSamplerConfigKey = "OTEL_TRACES_SAMPLER";
+    internal const string TracesSamplerArgConfigKey = "OTEL_TRACES_SAMPLER_ARG";
+
+    // Unlike some other options classes, we don't have a public parameterless constructor.
+    // The internal-only constructor is the right long-term design for any new options class using
+    // DelegatingOptionsFactory. Consumers never instantiate SamplerOptions directly, so there's no
+    // need for a public constructor. The public constructor on BatchExportActivityProcessorOptions
+    // pre-dates this pattern and is a historical artefact, not a template to follow for new work.
+
+    private double? samplerArg;
+
+    internal SamplerOptions(IConfiguration configuration)
+    {
+        if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var samplerType))
+        {
+            this.SamplerType = samplerType;
+        }
+
+        if (configuration.TryGetStringValue(TracesSamplerArgConfigKey, out var samplerArgStr))
+        {
+            this.SamplerArgRaw = samplerArgStr;
+
+            if (double.TryParse(
+                samplerArgStr,
+                NumberStyles.Float | NumberStyles.AllowThousands,
+                CultureInfo.InvariantCulture,
+                out var parsedArg))
+            {
+                // Bypass the public setter so that SamplerArgRaw is not cleared.
+                this.samplerArg = parsedArg;
+            }
+
+            // If unparsable, samplerArg stays null; SamplerArgRaw carries the bad string
+            // for ReadTraceIdRatio to log when called for ratio-based samplers. This matches
+            // the behavior prior to introducing this options type.
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the sampler type.
+    /// </summary>
+    public string? SamplerType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sampler argument.
+    /// </summary>
+    public double? SamplerArg
+    {
+        get => this.samplerArg;
+        set
+        {
+            this.samplerArg = value;
+            this.SamplerArgRaw = null; // no original config string when set programmatically
+        }
+    }
+
+    /// <summary>
+    /// Gets the original configuration string so it can be logged.
+    /// </summary>
+    internal string? SamplerArgRaw { get; private set; }
+}

--- a/src/OpenTelemetry/Trace/SamplerOptions.cs
+++ b/src/OpenTelemetry/Trace/SamplerOptions.cs
@@ -16,6 +16,13 @@ public sealed class SamplerOptions
     internal const string TracesSamplerConfigKey = "OTEL_TRACES_SAMPLER";
     internal const string TracesSamplerArgConfigKey = "OTEL_TRACES_SAMPLER_ARG";
 
+    internal const string AlwaysOnType = "always_on";
+    internal const string AlwaysOffType = "always_off";
+    internal const string TraceIdRatioType = "traceidratio";
+    internal const string ParentBasedAlwaysOnType = "parentbased_always_on";
+    internal const string ParentBasedAlwaysOffType = "parentbased_always_off";
+    internal const string ParentBasedTraceIdRatioType = "parentbased_traceidratio";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SamplerOptions"/> class.
     /// </summary>
@@ -35,7 +42,8 @@ public sealed class SamplerOptions
         {
             this.Argument = argument;
 
-            if (TryParseTraceIdRatio(argument, out var traceIdRatio))
+            if (IsTraceIdRatioSampler(this.Type)
+                && TryParseTraceIdRatio(argument, out var traceIdRatio))
             {
                 this.TraceIdRatio = traceIdRatio;
             }
@@ -67,6 +75,10 @@ public sealed class SamplerOptions
     /// can be reported exactly as it was configured when the sampler uses it.
     /// </summary>
     internal string? Argument { get; }
+
+    internal static bool IsTraceIdRatioSampler(string? type)
+        => string.Equals(type, TraceIdRatioType, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(type, ParentBasedTraceIdRatioType, StringComparison.OrdinalIgnoreCase);
 
     internal static bool TryParseTraceIdRatio(string value, out double traceIdRatio)
         => double.TryParse(

--- a/src/OpenTelemetry/Trace/SamplerOptions.cs
+++ b/src/OpenTelemetry/Trace/SamplerOptions.cs
@@ -92,10 +92,14 @@ public sealed class SamplerOptions
             || string.Equals(trimmed, ParentBasedTraceIdRatioType, StringComparison.OrdinalIgnoreCase);
     }
 
+    // A ratio must be a finite number. NaN and infinity parse successfully but are not
+    // usable values, so they are rejected here rather than being stored as a candidate ratio.
     internal static bool TryParseTraceIdRatio(string value, out double traceIdRatio)
         => double.TryParse(
             value,
             NumberStyles.Float | NumberStyles.AllowThousands,
             CultureInfo.InvariantCulture,
-            out traceIdRatio);
+            out traceIdRatio)
+            && !double.IsNaN(traceIdRatio)
+            && !double.IsInfinity(traceIdRatio);
 }

--- a/src/OpenTelemetry/Trace/SamplerOptions.cs
+++ b/src/OpenTelemetry/Trace/SamplerOptions.cs
@@ -7,8 +7,8 @@ using Microsoft.Extensions.Configuration;
 namespace OpenTelemetry.Trace;
 
 /// <summary>
-/// Options for configuring the trace sampler.
-/// OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG environment variables
+/// Trace sampler options.
+/// <c>OTEL_TRACES_SAMPLER</c> and <c>OTEL_TRACES_SAMPLER_ARG</c> environment variables
 /// are parsed during object construction.
 /// </summary>
 public sealed class SamplerOptions
@@ -16,61 +16,62 @@ public sealed class SamplerOptions
     internal const string TracesSamplerConfigKey = "OTEL_TRACES_SAMPLER";
     internal const string TracesSamplerArgConfigKey = "OTEL_TRACES_SAMPLER_ARG";
 
-    // Unlike some other options classes, we don't have a public parameterless constructor.
-    // The internal-only constructor is the right long-term design for any new options class using
-    // DelegatingOptionsFactory. Consumers never instantiate SamplerOptions directly, so there's no
-    // need for a public constructor. The public constructor on BatchExportActivityProcessorOptions
-    // pre-dates this pattern and is a historical artefact, not a template to follow for new work.
-
-    private double? samplerArg;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamplerOptions"/> class.
+    /// </summary>
+    public SamplerOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+    {
+    }
 
     internal SamplerOptions(IConfiguration configuration)
     {
-        if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var samplerType))
+        if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var type))
         {
-            this.SamplerType = samplerType;
+            this.Type = type;
         }
 
-        if (configuration.TryGetStringValue(TracesSamplerArgConfigKey, out var samplerArgStr))
+        if (configuration.TryGetStringValue(TracesSamplerArgConfigKey, out var argument))
         {
-            this.SamplerArgRaw = samplerArgStr;
+            this.Argument = argument;
 
-            if (double.TryParse(
-                    samplerArgStr,
-                    NumberStyles.Float | NumberStyles.AllowThousands,
-                    CultureInfo.InvariantCulture,
-                    out var parsedArg))
+            if (TryParseTraceIdRatio(argument, out var traceIdRatio))
             {
-                // Bypass the public setter so that SamplerArgRaw is not cleared.
-                this.samplerArg = parsedArg;
+                this.TraceIdRatio = traceIdRatio;
             }
-
-            // If unparsable, samplerArg stays null; SamplerArgRaw carries the bad string
-            // for ReadTraceIdRatio to log when called for ratio-based samplers. This matches
-            // the behavior prior to introducing this options type.
         }
     }
 
     /// <summary>
-    /// Gets or sets the sampler type.
+    /// Gets or sets the sampler to use. When unset, the SDK falls back to
+    /// <c>parentbased_always_on</c>. Supported values are <c>always_on</c>, <c>always_off</c>, <c>traceidratio</c>,
+    /// <c>parentbased_always_on</c>, <c>parentbased_always_off</c>, and
+    /// <c>parentbased_traceidratio</c>.
     /// </summary>
-    public string? SamplerType { get; set; }
+    /// <remarks>
+    /// Note: A sampler set programmatically using
+    /// <see cref="TracerProviderBuilderExtensions.SetSampler(TracerProviderBuilder, Sampler)"/>
+    /// takes precedence over this value.
+    /// </remarks>
+    public string? Type { get; set; }
 
     /// <summary>
-    /// Gets or sets the sampler argument.
+    /// Gets or sets the sampling probability, a value in the <c>[0.0, 1.0]</c> range.
+    /// When unset or invalid, the SDK falls back to <c>1.0</c>. Only used when
+    /// <see cref="Type"/> is <c>traceidratio</c> or <c>parentbased_traceidratio</c>.
     /// </summary>
-    public double? SamplerArg
-    {
-        get => this.samplerArg;
-        set
-        {
-            this.samplerArg = value;
-            this.SamplerArgRaw = null; // no original config string when set programmatically
-        }
-    }
+    public double? TraceIdRatio { get; set; }
 
     /// <summary>
-    /// Gets the original configuration string so it can be logged.
+    /// Gets the verbatim <c>OTEL_TRACES_SAMPLER_ARG</c> value, retained so that an unusable value
+    /// can be reported exactly as it was configured when the sampler uses it.
     /// </summary>
-    internal string? SamplerArgRaw { get; private set; }
+    internal string? Argument { get; }
+
+    internal static bool TryParseTraceIdRatio(string value, out double traceIdRatio)
+        => double.TryParse(
+            value,
+            NumberStyles.Float | NumberStyles.AllowThousands,
+            CultureInfo.InvariantCulture,
+            out traceIdRatio);
 }

--- a/src/OpenTelemetry/Trace/SamplerOptions.cs
+++ b/src/OpenTelemetry/Trace/SamplerOptions.cs
@@ -46,6 +46,7 @@ public sealed class SamplerOptions
                 && TryParseTraceIdRatio(argument, out var traceIdRatio))
             {
                 this.TraceIdRatio = traceIdRatio;
+                this.ConfiguredTraceIdRatio = traceIdRatio;
             }
         }
     }
@@ -57,7 +58,7 @@ public sealed class SamplerOptions
     /// <c>parentbased_traceidratio</c>.
     /// </summary>
     /// <remarks>
-    /// Note: A sampler set programmatically using
+    /// A sampler set programmatically using
     /// <see cref="TracerProviderBuilderExtensions.SetSampler(TracerProviderBuilder, Sampler)"/>
     /// takes precedence over this value.
     /// </remarks>
@@ -76,9 +77,20 @@ public sealed class SamplerOptions
     /// </summary>
     internal string? Argument { get; }
 
+    /// <summary>
+    /// Gets the <see cref="TraceIdRatio"/> value parsed from <c>OTEL_TRACES_SAMPLER_ARG</c>,
+    /// retained so that a value later replaced by the options pipeline can be distinguished from
+    /// the configured one when reporting an unusable value.
+    /// </summary>
+    internal double? ConfiguredTraceIdRatio { get; }
+
     internal static bool IsTraceIdRatioSampler(string? type)
-        => string.Equals(type, TraceIdRatioType, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(type, ParentBasedTraceIdRatioType, StringComparison.OrdinalIgnoreCase);
+    {
+        var trimmed = type?.Trim();
+
+        return string.Equals(trimmed, TraceIdRatioType, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(trimmed, ParentBasedTraceIdRatioType, StringComparison.OrdinalIgnoreCase);
+    }
 
     internal static bool TryParseTraceIdRatio(string value, out double traceIdRatio)
         => double.TryParse(

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -432,7 +432,7 @@ internal sealed class TracerProviderSdk : TracerProvider
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
 
-            return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
+            return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
         }
 
         return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -6,8 +6,8 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -15,9 +15,6 @@ namespace OpenTelemetry.Trace;
 
 internal sealed class TracerProviderSdk : TracerProvider
 {
-    internal const string TracesSamplerConfigKey = "OTEL_TRACES_SAMPLER";
-    internal const string TracesSamplerArgConfigKey = "OTEL_TRACES_SAMPLER_ARG";
-
     internal readonly IServiceProvider ServiceProvider;
     internal IDisposable? OwnedServiceProvider;
     internal int ShutdownCount;
@@ -59,7 +56,9 @@ internal sealed class TracerProviderSdk : TracerProvider
         resourceBuilder.ServiceProvider = serviceProvider;
         this.Resource = resourceBuilder.Build();
 
-        this.Sampler = GetSampler(serviceProvider!.GetRequiredService<IConfiguration>(), state.Sampler);
+        this.Sampler = GetSampler(
+            serviceProvider!.GetRequiredService<IOptions<SamplerOptions>>().Value,
+            state.Sampler);
         OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Sampler added = \"{this.Sampler.GetType()}\".");
 
         this.supportLegacyActivity = state.LegacyActivityOperationNames.Count > 0;
@@ -386,49 +385,45 @@ internal sealed class TracerProviderSdk : TracerProvider
         base.Dispose(disposing);
     }
 
-    private static Sampler GetSampler(IConfiguration configuration, Sampler? stateSampler)
+    private static Sampler GetSampler(SamplerOptions options, Sampler? stateSampler)
     {
         var sampler = stateSampler;
 
-        if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var configValue))
+        if (!string.IsNullOrWhiteSpace(options.SamplerType))
         {
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{configValue}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
+                    $"Trace sampler configuration value '{options.SamplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
                 return sampler;
             }
 
-            switch (configValue)
+            switch (options.SamplerType)
             {
-                case var _ when string.Equals(configValue, "always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOnSampler.Instance;
                     break;
-                case var _ when string.Equals(configValue, "always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOffSampler.Instance;
                     break;
-                case var _ when string.Equals(configValue, "traceidratio", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
                     {
-                        var traceIdRatio = ReadTraceIdRatio(configuration);
+                        var traceIdRatio = ReadTraceIdRatio(options);
                         sampler = new TraceIdRatioBasedSampler(traceIdRatio);
                         break;
                     }
 
-                case var _ when string.Equals(configValue, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
                     break;
-                case var _ when string.Equals(configValue, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
                     break;
-                case var _ when string.Equals(configValue, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
-                    {
-                        var traceIdRatio = ReadTraceIdRatio(configuration);
-                        sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(traceIdRatio));
-                        break;
-                    }
-
+                case var _ when string.Equals(options.SamplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
+                    sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
+                    break;
                 default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(configValue);
+                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(options.SamplerType!);
                     break;
             }
 
@@ -436,26 +431,31 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
+
+            return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
         }
 
         return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
     }
 
-    private static double ReadTraceIdRatio(IConfiguration configuration)
+    private static double ReadTraceIdRatio(SamplerOptions options)
     {
-        if (configuration.TryGetStringValue(TracesSamplerArgConfigKey, out var configValue) &&
-                double.TryParse(configValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var traceIdRatio) &&
-                !double.IsNaN(traceIdRatio) &&
-                !double.IsInfinity(traceIdRatio) &&
-                traceIdRatio >= 0.0 &&
-                traceIdRatio <= 1.0)
+        var samplerArg = options.SamplerArg;
+        if (samplerArg.HasValue
+            && !double.IsNaN(samplerArg.Value)
+            && !double.IsInfinity(samplerArg.Value)
+            && samplerArg.Value >= 0.0
+            && samplerArg.Value <= 1.0)
         {
-            return traceIdRatio;
+            return samplerArg.Value;
         }
-        else
-        {
-            OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(configValue ?? string.Empty);
-        }
+
+        // No valid ratio. Log the original config string for diagnostic fidelity and fall back to 1.0.
+        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(
+            options.SamplerArgRaw
+            ?? (samplerArg.HasValue
+                ? samplerArg.Value.ToString(CultureInfo.InvariantCulture)
+                : string.Empty));
 
         return 1.0;
     }

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -6,8 +6,8 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -15,9 +15,6 @@ namespace OpenTelemetry.Trace;
 
 internal sealed class TracerProviderSdk : TracerProvider
 {
-    internal const string TracesSamplerConfigKey = "OTEL_TRACES_SAMPLER";
-    internal const string TracesSamplerArgConfigKey = "OTEL_TRACES_SAMPLER_ARG";
-
     internal readonly IServiceProvider ServiceProvider;
     internal IDisposable? OwnedServiceProvider;
     internal int ShutdownCount;
@@ -61,7 +58,9 @@ internal sealed class TracerProviderSdk : TracerProvider
             resourceBuilder.ServiceProvider = serviceProvider;
             this.Resource = resourceBuilder.Build();
 
-            this.Sampler = GetSampler(serviceProvider!.GetRequiredService<IConfiguration>(), state.Sampler);
+            this.Sampler = GetSampler(
+                serviceProvider!.GetRequiredService<IOptions<SamplerOptions>>().Value,
+                state.Sampler);
             OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Sampler added = \"{this.Sampler.GetType()}\".");
 
             this.supportLegacyActivity = state.LegacyActivityOperationNames.Count > 0;
@@ -397,49 +396,45 @@ internal sealed class TracerProviderSdk : TracerProvider
         base.Dispose(disposing);
     }
 
-    private static Sampler GetSampler(IConfiguration configuration, Sampler? stateSampler)
+    private static Sampler GetSampler(SamplerOptions options, Sampler? stateSampler)
     {
         var sampler = stateSampler;
 
-        if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var configValue))
+        if (!string.IsNullOrWhiteSpace(options.SamplerType))
         {
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{configValue}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
+                    $"Trace sampler configuration value '{options.SamplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
                 return sampler;
             }
 
-            switch (configValue)
+            switch (options.SamplerType)
             {
-                case var _ when string.Equals(configValue, "always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOnSampler.Instance;
                     break;
-                case var _ when string.Equals(configValue, "always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOffSampler.Instance;
                     break;
-                case var _ when string.Equals(configValue, "traceidratio", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
                     {
-                        var traceIdRatio = ReadTraceIdRatio(configuration);
+                        var traceIdRatio = ReadTraceIdRatio(options);
                         sampler = new TraceIdRatioBasedSampler(traceIdRatio);
                         break;
                     }
 
-                case var _ when string.Equals(configValue, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
                     break;
-                case var _ when string.Equals(configValue, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(options.SamplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
                     break;
-                case var _ when string.Equals(configValue, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
-                    {
-                        var traceIdRatio = ReadTraceIdRatio(configuration);
-                        sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(traceIdRatio));
-                        break;
-                    }
-
+                case var _ when string.Equals(options.SamplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
+                    sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
+                    break;
                 default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(configValue);
+                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(options.SamplerType!);
                     break;
             }
 
@@ -447,26 +442,31 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
+
+            return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
         }
 
         return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
     }
 
-    private static double ReadTraceIdRatio(IConfiguration configuration)
+    private static double ReadTraceIdRatio(SamplerOptions options)
     {
-        if (configuration.TryGetStringValue(TracesSamplerArgConfigKey, out var configValue) &&
-                double.TryParse(configValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var traceIdRatio) &&
-                !double.IsNaN(traceIdRatio) &&
-                !double.IsInfinity(traceIdRatio) &&
-                traceIdRatio >= 0.0 &&
-                traceIdRatio <= 1.0)
+        var samplerArg = options.SamplerArg;
+        if (samplerArg.HasValue
+            && !double.IsNaN(samplerArg.Value)
+            && !double.IsInfinity(samplerArg.Value)
+            && samplerArg.Value >= 0.0
+            && samplerArg.Value <= 1.0)
         {
-            return traceIdRatio;
+            return samplerArg.Value;
         }
-        else
-        {
-            OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(configValue ?? string.Empty);
-        }
+
+        // No valid ratio. Log the original config string for diagnostic fidelity and fall back to 1.0.
+        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(
+            options.SamplerArgRaw
+            ?? (samplerArg.HasValue
+                ? samplerArg.Value.ToString(CultureInfo.InvariantCulture)
+                : string.Empty));
 
         return 1.0;
     }

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -400,41 +400,37 @@ internal sealed class TracerProviderSdk : TracerProvider
     {
         var sampler = stateSampler;
 
-        if (!string.IsNullOrWhiteSpace(options.SamplerType))
+        if (options.Type is string samplerType && !string.IsNullOrWhiteSpace(samplerType))
         {
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{options.SamplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
+                    $"Trace sampler configuration value '{samplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
                 return sampler;
             }
 
-            switch (options.SamplerType)
+            switch (samplerType)
             {
-                case var _ when string.Equals(options.SamplerType, "always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOnSampler.Instance;
                     break;
-                case var _ when string.Equals(options.SamplerType, "always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOffSampler.Instance;
                     break;
-                case var _ when string.Equals(options.SamplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
-                    {
-                        var traceIdRatio = ReadTraceIdRatio(options);
-                        sampler = new TraceIdRatioBasedSampler(traceIdRatio);
-                        break;
-                    }
-
-                case var _ when string.Equals(options.SamplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
+                    sampler = new TraceIdRatioBasedSampler(ReadTraceIdRatio(options));
+                    break;
+                case var _ when string.Equals(samplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
                     break;
-                case var _ when string.Equals(options.SamplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
                     break;
-                case var _ when string.Equals(options.SamplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
                     break;
                 default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(options.SamplerType!);
+                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(samplerType);
                     break;
             }
 
@@ -442,8 +438,6 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
-
-            return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
         }
 
         return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
@@ -451,24 +445,37 @@ internal sealed class TracerProviderSdk : TracerProvider
 
     private static double ReadTraceIdRatio(SamplerOptions options)
     {
-        var samplerArg = options.SamplerArg;
-        if (samplerArg.HasValue
-            && !double.IsNaN(samplerArg.Value)
-            && !double.IsInfinity(samplerArg.Value)
-            && samplerArg.Value >= 0.0
-            && samplerArg.Value <= 1.0)
+        var traceIdRatio = options.TraceIdRatio;
+
+        if (traceIdRatio is double ratio
+            && !double.IsNaN(ratio)
+            && !double.IsInfinity(ratio)
+            && ratio >= 0.0
+            && ratio <= 1.0)
         {
-            return samplerArg.Value;
+            return ratio;
         }
 
-        // No valid ratio. Log the original config string for diagnostic fidelity and fall back to 1.0.
-        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(
-            options.SamplerArgRaw
-            ?? (samplerArg.HasValue
-                ? samplerArg.Value.ToString(CultureInfo.InvariantCulture)
-                : string.Empty));
+        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(DescribeUnusableTraceIdRatio(options));
 
         return 1.0;
+    }
+
+    private static string DescribeUnusableTraceIdRatio(SamplerOptions options)
+    {
+        var argument = options.Argument;
+
+        if (options.TraceIdRatio is not double ratio)
+        {
+            // The configuration string could not be parsed, so it is the only value to report.
+            return argument ?? string.Empty;
+        }
+
+        return argument != null
+            && SamplerOptions.TryParseTraceIdRatio(argument, out var parsed)
+            && parsed.Equals(ratio)
+                ? argument
+                : ratio.ToString(CultureInfo.InvariantCulture);
     }
 
     private static ActivitySamplingResult ComputeActivitySamplingResult(

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -443,7 +443,7 @@ internal sealed class TracerProviderSdk : TracerProvider
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
 
-            return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
+            return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
         }
 
         return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -58,7 +57,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             resourceBuilder.ServiceProvider = serviceProvider;
             this.Resource = resourceBuilder.Build();
 
-            this.Sampler = GetSampler(
+            this.Sampler = SamplerFactory.GetSampler(
                 serviceProvider!.GetRequiredService<IOptions<SamplerOptions>>().Value,
                 state.Sampler);
             OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Sampler added = \"{this.Sampler.GetType()}\".");
@@ -394,88 +393,6 @@ internal sealed class TracerProviderSdk : TracerProvider
         }
 
         base.Dispose(disposing);
-    }
-
-    private static Sampler GetSampler(SamplerOptions options, Sampler? stateSampler)
-    {
-        var sampler = stateSampler;
-
-        if (options.Type is string samplerType && !string.IsNullOrWhiteSpace(samplerType))
-        {
-            if (sampler != null)
-            {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{samplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
-                return sampler;
-            }
-
-            switch (samplerType)
-            {
-                case var _ when string.Equals(samplerType, "always_on", StringComparison.OrdinalIgnoreCase):
-                    sampler = AlwaysOnSampler.Instance;
-                    break;
-                case var _ when string.Equals(samplerType, "always_off", StringComparison.OrdinalIgnoreCase):
-                    sampler = AlwaysOffSampler.Instance;
-                    break;
-                case var _ when string.Equals(samplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
-                    sampler = new TraceIdRatioBasedSampler(ReadTraceIdRatio(options));
-                    break;
-                case var _ when string.Equals(samplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
-                    break;
-                case var _ when string.Equals(samplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
-                    break;
-                case var _ when string.Equals(samplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
-                    break;
-                default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(samplerType);
-                    break;
-            }
-
-            if (sampler != null)
-            {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
-            }
-        }
-
-        return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
-    }
-
-    private static double ReadTraceIdRatio(SamplerOptions options)
-    {
-        var traceIdRatio = options.TraceIdRatio;
-
-        if (traceIdRatio is double ratio
-            && !double.IsNaN(ratio)
-            && !double.IsInfinity(ratio)
-            && ratio >= 0.0
-            && ratio <= 1.0)
-        {
-            return ratio;
-        }
-
-        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(DescribeUnusableTraceIdRatio(options));
-
-        return 1.0;
-    }
-
-    private static string DescribeUnusableTraceIdRatio(SamplerOptions options)
-    {
-        var argument = options.Argument;
-
-        if (options.TraceIdRatio is not double ratio)
-        {
-            // The configuration string could not be parsed, so it is the only value to report.
-            return argument ?? string.Empty;
-        }
-
-        return argument != null
-            && SamplerOptions.TryParseTraceIdRatio(argument, out var parsed)
-            && parsed.Equals(ratio)
-                ? argument
-                : ratio.ToString(CultureInfo.InvariantCulture);
     }
 
     private static ActivitySamplingResult ComputeActivitySamplingResult(

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -58,7 +57,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             resourceBuilder.ServiceProvider = serviceProvider;
             this.Resource = resourceBuilder.Build();
 
-            this.Sampler = GetSampler(
+            this.Sampler = SamplerFactory.GetSampler(
                 serviceProvider!.GetRequiredService<IOptions<SamplerOptions>>().Value,
                 state.Sampler);
             OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Sampler added = \"{this.Sampler.GetType()}\".");
@@ -394,88 +393,6 @@ internal sealed class TracerProviderSdk : TracerProvider
         }
 
         base.Dispose(disposing);
-    }
-
-    private static Sampler GetSampler(SamplerOptions options, Sampler? stateSampler)
-    {
-        var sampler = stateSampler;
-
-        if (options.Type is string samplerType && !string.IsNullOrWhiteSpace(samplerType))
-        {
-            if (sampler != null)
-            {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{samplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
-                return sampler;
-            }
-
-            switch (samplerType)
-            {
-                case var _ when string.Equals(samplerType, "always_on", StringComparison.OrdinalIgnoreCase):
-                    sampler = AlwaysOnSampler.Instance;
-                    break;
-                case var _ when string.Equals(samplerType, "always_off", StringComparison.OrdinalIgnoreCase):
-                    sampler = AlwaysOffSampler.Instance;
-                    break;
-                case var _ when string.Equals(samplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
-                    sampler = new TraceIdRatioBasedSampler(ReadTraceIdRatio(options));
-                    break;
-                case var _ when string.Equals(samplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
-                    break;
-                case var _ when string.Equals(samplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
-                    break;
-                case var _ when string.Equals(samplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
-                    sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
-                    break;
-                default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(samplerType);
-                    break;
-            }
-
-            if (sampler != null)
-            {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
-            }
-        }
-
-        return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
-    }
-
-    private static double ReadTraceIdRatio(SamplerOptions options)
-    {
-        var traceIdRatio = options.TraceIdRatio;
-
-        if (traceIdRatio is double ratio
-            && !double.IsNaN(ratio)
-            && !double.IsInfinity(ratio)
-            && ratio >= 0.0
-            && ratio <= 1.0)
-        {
-            return ratio;
-        }
-
-        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(DescribeUnusableTraceIdRatio(options));
-
-        return 1.0;
-    }
-
-    private static string DescribeUnusableTraceIdRatio(SamplerOptions options)
-    {
-        var argument = options.Argument;
-
-        if (options.TraceIdRatio is not double ratio)
-        {
-            // The configuration string could not be parsed, so it is the only value to report.
-            return argument ?? string.Empty;
-        }
-
-        return argument != null
-            && SamplerOptions.TryParseTraceIdRatio(argument, out var parsed)
-            && parsed.Equals(ratio)
-                ? argument
-                : ratio.ToString(CultureInfo.InvariantCulture);
     }
 
     private static void ApplySamplingAttributes<TState>(

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -400,41 +400,37 @@ internal sealed class TracerProviderSdk : TracerProvider
     {
         var sampler = stateSampler;
 
-        if (!string.IsNullOrWhiteSpace(options.SamplerType))
+        if (options.Type is string samplerType && !string.IsNullOrWhiteSpace(samplerType))
         {
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{options.SamplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
+                    $"Trace sampler configuration value '{samplerType}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
                 return sampler;
             }
 
-            switch (options.SamplerType)
+            switch (samplerType)
             {
-                case var _ when string.Equals(options.SamplerType, "always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOnSampler.Instance;
                     break;
-                case var _ when string.Equals(options.SamplerType, "always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = AlwaysOffSampler.Instance;
                     break;
-                case var _ when string.Equals(options.SamplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
-                    {
-                        var traceIdRatio = ReadTraceIdRatio(options);
-                        sampler = new TraceIdRatioBasedSampler(traceIdRatio);
-                        break;
-                    }
-
-                case var _ when string.Equals(options.SamplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "traceidratio", StringComparison.OrdinalIgnoreCase):
+                    sampler = new TraceIdRatioBasedSampler(ReadTraceIdRatio(options));
+                    break;
+                case var _ when string.Equals(samplerType, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOnSampler.Instance);
                     break;
-                case var _ when string.Equals(options.SamplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(AlwaysOffSampler.Instance);
                     break;
-                case var _ when string.Equals(options.SamplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
+                case var _ when string.Equals(samplerType, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
                     sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ReadTraceIdRatio(options)));
                     break;
                 default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(options.SamplerType!);
+                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(samplerType);
                     break;
             }
 
@@ -442,8 +438,6 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
-
-            return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
         }
 
         return sampler ?? new ParentBasedSampler(AlwaysOnSampler.Instance);
@@ -451,24 +445,37 @@ internal sealed class TracerProviderSdk : TracerProvider
 
     private static double ReadTraceIdRatio(SamplerOptions options)
     {
-        var samplerArg = options.SamplerArg;
-        if (samplerArg.HasValue
-            && !double.IsNaN(samplerArg.Value)
-            && !double.IsInfinity(samplerArg.Value)
-            && samplerArg.Value >= 0.0
-            && samplerArg.Value <= 1.0)
+        var traceIdRatio = options.TraceIdRatio;
+
+        if (traceIdRatio is double ratio
+            && !double.IsNaN(ratio)
+            && !double.IsInfinity(ratio)
+            && ratio >= 0.0
+            && ratio <= 1.0)
         {
-            return samplerArg.Value;
+            return ratio;
         }
 
-        // No valid ratio. Log the original config string for diagnostic fidelity and fall back to 1.0.
-        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(
-            options.SamplerArgRaw
-            ?? (samplerArg.HasValue
-                ? samplerArg.Value.ToString(CultureInfo.InvariantCulture)
-                : string.Empty));
+        OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(DescribeUnusableTraceIdRatio(options));
 
         return 1.0;
+    }
+
+    private static string DescribeUnusableTraceIdRatio(SamplerOptions options)
+    {
+        var argument = options.Argument;
+
+        if (options.TraceIdRatio is not double ratio)
+        {
+            // The configuration string could not be parsed, so it is the only value to report.
+            return argument ?? string.Empty;
+        }
+
+        return argument != null
+            && SamplerOptions.TryParseTraceIdRatio(argument, out var parsed)
+            && parsed.Equals(ratio)
+                ? argument
+                : ratio.ToString(CultureInfo.InvariantCulture);
     }
 
     private static void ApplySamplingAttributes<TState>(

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -169,6 +169,63 @@ public class OpenTelemetryServicesExtensionsTests
     }
 
     [Fact]
+    public void AddOpenTelemetry_WithTracing_SamplerResolvedFromHostConfigurationTest()
+    {
+        using var clearSamplerEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerConfigKey, null);
+        using var clearSamplerArgEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerArgConfigKey, null);
+
+        var builder = new HostBuilder()
+            .ConfigureAppConfiguration(configBuilder =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                    [SamplerOptions.TracesSamplerArgConfigKey] = "0.25",
+                });
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddOpenTelemetry().WithTracing();
+            });
+
+        using var host = builder.Build();
+
+        var tracerProvider = host.Services.GetRequiredService<TracerProvider>() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{0.250000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_WithTracing_ConfigureSamplerOptionsOverridesHostConfigurationTest()
+    {
+        using var clearSamplerEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerConfigKey, null);
+        using var clearSamplerArgEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerArgConfigKey, null);
+
+        var builder = new HostBuilder()
+            .ConfigureAppConfiguration(configBuilder =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                    [SamplerOptions.TracesSamplerArgConfigKey] = "0.1",
+                });
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddOpenTelemetry().WithTracing();
+                services.Configure<SamplerOptions>(o => o.SamplerArg = 0.9);
+            });
+
+        using var host = builder.Build();
+
+        var tracerProvider = host.Services.GetRequiredService<TracerProvider>() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{0.900000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
     public void AddOpenTelemetry_WithTracing_NestedResolutionUsingConfigureTest()
     {
         var innerTestExecuted = false;

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -177,8 +177,11 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public void AddOpenTelemetry_WithTracing_SamplerResolvedFromHostConfigurationTest()
     {
-        using var clearSamplerEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerConfigKey, null);
-        using var clearSamplerArgEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerArgConfigKey, null);
+        using var environment = EnvironmentVariableScope.Create(
+            [
+                (SamplerOptions.TracesSamplerConfigKey, null),
+                (SamplerOptions.TracesSamplerArgConfigKey, null),
+            ]);
 
         var builder = new HostBuilder()
             .ConfigureAppConfiguration(configBuilder =>
@@ -205,8 +208,11 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public void AddOpenTelemetry_WithTracing_ConfigureSamplerOptionsOverridesHostConfigurationTest()
     {
-        using var clearSamplerEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerConfigKey, null);
-        using var clearSamplerArgEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerArgConfigKey, null);
+        using var environment = EnvironmentVariableScope.Create(
+            [
+                (SamplerOptions.TracesSamplerConfigKey, null),
+                (SamplerOptions.TracesSamplerArgConfigKey, null),
+            ]);
 
         var builder = new HostBuilder()
             .ConfigureAppConfiguration(configBuilder =>
@@ -220,7 +226,7 @@ public class OpenTelemetryServicesExtensionsTests
             .ConfigureServices(services =>
             {
                 services.AddOpenTelemetry().WithTracing();
-                services.Configure<SamplerOptions>(o => o.SamplerArg = 0.9);
+                services.Configure<SamplerOptions>(o => o.TraceIdRatio = 0.9);
             });
 
         using var host = builder.Build();

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -175,6 +175,63 @@ public class OpenTelemetryServicesExtensionsTests
     }
 
     [Fact]
+    public void AddOpenTelemetry_WithTracing_SamplerResolvedFromHostConfigurationTest()
+    {
+        using var clearSamplerEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerConfigKey, null);
+        using var clearSamplerArgEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerArgConfigKey, null);
+
+        var builder = new HostBuilder()
+            .ConfigureAppConfiguration(configBuilder =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                    [SamplerOptions.TracesSamplerArgConfigKey] = "0.25",
+                });
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddOpenTelemetry().WithTracing();
+            });
+
+        using var host = builder.Build();
+
+        var tracerProvider = host.Services.GetRequiredService<TracerProvider>() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{0.250000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_WithTracing_ConfigureSamplerOptionsOverridesHostConfigurationTest()
+    {
+        using var clearSamplerEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerConfigKey, null);
+        using var clearSamplerArgEnv = EnvironmentVariableScope.Create(SamplerOptions.TracesSamplerArgConfigKey, null);
+
+        var builder = new HostBuilder()
+            .ConfigureAppConfiguration(configBuilder =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                    [SamplerOptions.TracesSamplerArgConfigKey] = "0.1",
+                });
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddOpenTelemetry().WithTracing();
+                services.Configure<SamplerOptions>(o => o.SamplerArg = 0.9);
+            });
+
+        using var host = builder.Build();
+
+        var tracerProvider = host.Services.GetRequiredService<TracerProvider>() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{0.900000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
     public void AddOpenTelemetry_WithTracing_NestedResolutionUsingConfigureTest()
     {
         var innerTestExecuted = false;

--- a/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
@@ -1,0 +1,562 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Tests;
+using Xunit;
+
+namespace OpenTelemetry.Trace.Tests;
+
+public sealed class SamplerOptionsTests : IDisposable
+{
+    public SamplerOptionsTests()
+    {
+        ClearSamplerEnvVars();
+    }
+
+    [Fact]
+    public void SamplerOptions_NoConfigurationKeys_Defaults()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+        var options = new SamplerOptions(configuration);
+
+        Assert.Null(options.SamplerType);
+        Assert.Null(options.SamplerArg);
+    }
+
+    [Fact]
+    public void SamplerOptions_TracesSampler_FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
+            })
+            .Build();
+
+        var options = new SamplerOptions(configuration);
+
+        Assert.Equal("always_on", options.SamplerType);
+    }
+
+    [Fact]
+    public void SamplerOptions_TracesSamplerArg_Parse()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerArgConfigKey] = "0.5",
+            })
+            .Build();
+
+        var options = new SamplerOptions(configuration);
+
+        Assert.Equal(0.5, options.SamplerArg);
+    }
+
+    [Fact]
+    public void SamplerOptions_TracesSamplerArg_Invalid_LeavesNullAndPreservesRaw()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerArgConfigKey] = "banana",
+            })
+            .Build();
+
+        var options = new SamplerOptions(configuration);
+
+        // SamplerArg is null because the string couldn't be parsed.
+        Assert.Null(options.SamplerArg);
+
+        // SamplerArgRaw preserves the original string for ReadTraceIdRatio to use in its diagnostic.
+        Assert.Equal("banana", options.SamplerArgRaw);
+    }
+
+    [Fact]
+    public void SamplerOptions_InvalidArgWithNonRatioSampler_NoEvent55()
+    {
+        // OTEL_TRACES_SAMPLER_ARG is only evaluated for ratio-based samplers. A bad arg value
+        // combined with a sampler type that ignores the arg must not produce a diagnostic.
+        // NOTE: This specifically preserves the existing behavior before introducing SamplerOptions.
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
+                [SamplerOptions.TracesSamplerArgConfigKey] = "banana",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(eventListener.Messages, e => e.EventId == 55);
+    }
+
+    [Fact]
+    public void SamplerOptions_ConfigureOverridesEnvironmentVariable()
+    {
+        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerConfigKey, "always_off");
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o => o.SamplerType = "always_on"));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void SamplerOptions_ConfigureOverridesSamplerArg()
+    {
+        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerConfigKey, "traceidratio");
+        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerArgConfigKey, "0.1");
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o => o.SamplerArg = 0.9));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{0.900000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void SamplerOptions_ConfigureFromSection()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Sampler:SamplerType"] = "traceidratio",
+                ["Sampler:SamplerArg"] = "0.4",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.Configure<SamplerOptions>(configuration.GetSection("Sampler")));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{0.400000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void TracerProvider_NoSamplerConfiguration_UsesDefaultSampler_NoDiagnostics()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = EmptySamplerConfiguration();
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(
+            eventListener.Messages,
+            e => e.EventId == 46 && e.Payload != null && ((string)e.Payload[0]!).Contains("has been ignored because a value", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TracerProvider_ProgrammaticSamplerWithoutConfiguration_NoIgnoredDiagnostic()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = EmptySamplerConfiguration();
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+        builder.SetSampler(new AlwaysOnSampler());
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(
+            eventListener.Messages,
+            e => e.EventId == 46 && e.Payload != null && ((string)e.Payload[0]!).Contains("has been ignored because a value", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TracerProvider_ConfigurationWithProgrammaticSampler_EmitsIgnoredDiagnostic()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+        builder.SetSampler(new AlwaysOffSampler());
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("AlwaysOffSampler", tracerProvider.Sampler.Description);
+        Assert.Contains(
+            eventListener.Messages,
+            e => e.EventId == 46
+                && e.Payload != null
+                && ((string)e.Payload[0]!).Contains("has been ignored because a value", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TracerProvider_AlwaysOn_FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void TracerProvider_AlwaysOff_FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "always_off",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("AlwaysOffSampler", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void TracerProvider_ParentBasedAlwaysOn_FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "parentbased_always_on",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void TracerProvider_ParentBasedAlwaysOff_FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "parentbased_always_off",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("ParentBased{AlwaysOffSampler}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void TracerProvider_TraceIdRatio_FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                [SamplerOptions.TracesSamplerArgConfigKey] = "0.3",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.IsType<TraceIdRatioBasedSampler>(tracerProvider.Sampler);
+        Assert.Equal("TraceIdRatioBasedSampler{0.300000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void TracerProvider_ParentBasedTraceIdRatio_FromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "parentbased_traceidratio",
+                [SamplerOptions.TracesSamplerArgConfigKey] = "0.3",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("ParentBased{TraceIdRatioBasedSampler{0.300000}}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void TracerProvider_TraceIdRatio_NoArg_DefaultsToOne_LogsEmptyArg()
+    {
+        // Matches pre-options behaviour
+
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        Assert.Contains(
+            eventListener.Messages,
+            e => e.EventId == 55 && e.Payload != null && string.IsNullOrEmpty((string)e.Payload[0]!));
+    }
+
+    [Fact]
+    public void TracerProvider_TraceIdRatio_OutOfRange_LogsAndUsesDefaultRatio()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                [SamplerOptions.TracesSamplerArgConfigKey] = "1.5",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        Assert.Contains(
+            eventListener.Messages,
+            e => e.EventId == 55 && e.Payload != null && (string)e.Payload[0]! == "1.5");
+    }
+
+    [Fact]
+    public void TracerProvider_TraceIdRatio_OutOfRange_LogsOriginalConfigString()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                [SamplerOptions.TracesSamplerArgConfigKey] = "2.0",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        Assert.Contains(
+            eventListener.Messages,
+            e => e.EventId == 55 && e.Payload != null && (string)e.Payload[0]! == "2.0");
+    }
+
+    [Fact]
+    public void TracerProvider_TraceIdRatio_UnparsableArg_LogsFromReadTraceIdRatio()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
+                [SamplerOptions.TracesSamplerArgConfigKey] = "not_a_double",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        Assert.Single(eventListener.Messages, e => e.EventId == 55);
+        Assert.Contains(
+            eventListener.Messages,
+            e => e.EventId == 55 && e.Payload != null && (string)e.Payload[0]! == "not_a_double");
+    }
+
+    [Fact]
+    public void TracerProvider_UnknownSampler_LogsAndUsesDefault()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = "unknown_sampler",
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
+        Assert.Contains(
+            eventListener.Messages,
+            e => e.EventId == 54 && e.Payload != null && (string)e.Payload[0]! == "unknown_sampler");
+    }
+
+    [Fact]
+    public void TracerProvider_EmptySamplerTypeKey_TreatedAsUnset()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [SamplerOptions.TracesSamplerConfigKey] = string.Empty,
+            })
+            .Build();
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(eventListener.Messages, e => e.EventId == 54);
+    }
+
+    [Fact]
+    public void TracerProvider_TraceIdRatio_ProgrammaticOutOfRangeArg_FallsBackToDefaultAndLogs()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o =>
+        {
+            o.SamplerType = "traceidratio";
+            o.SamplerArg = 2.0; // out of [0.0, 1.0]; SamplerArgRaw is null (no config string)
+        }));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        Assert.Contains(eventListener.Messages, e => e.EventId == 55);
+    }
+
+    [Fact]
+    public void TracerProvider_TraceIdRatio_ProgrammaticNaNArg_FallsBackToDefaultAndLogs()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o =>
+        {
+            o.SamplerType = "traceidratio";
+            o.SamplerArg = double.NaN;
+        }));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        Assert.Contains(eventListener.Messages, e => e.EventId == 55);
+    }
+
+    [Fact]
+    public void TracerProvider_WhitespaceSamplerType_TreatedAsUnset()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o => o.SamplerType = "   "));
+
+        using var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(eventListener.Messages, e => e.EventId == 54);
+    }
+
+    public void Dispose()
+    {
+        ClearSamplerEnvVars();
+        GC.SuppressFinalize(this);
+    }
+
+    private static IConfiguration EmptySamplerConfiguration()
+        => new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+    private static void ReplaceRootConfiguration(IServiceCollection services, IConfiguration configuration)
+    {
+        for (var i = services.Count - 1; i >= 0; i--)
+        {
+            if (services[i].ServiceType == typeof(IConfiguration))
+            {
+                services.RemoveAt(i);
+            }
+        }
+
+        services.AddSingleton(configuration);
+    }
+
+    private static void ClearSamplerEnvVars()
+    {
+        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerConfigKey, null);
+        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerArgConfigKey, null);
+    }
+}

--- a/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
@@ -73,17 +73,21 @@ public sealed class SamplerOptionsTests
         Assert.Equal("0.5", options.Argument);
     }
 
-    [Fact]
-    public void TracesSamplerArg_Unparsable_LeavesTraceIdRatioNullAndRetainsArgument()
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("nan")] // Parses as a double, but is not a finite ratio.
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    public void TracesSamplerArg_NotParsableAsRatio_LeavesTraceIdRatioNullAndRetainsArgument(string argValue)
     {
         var options = CreateOptions(
             (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.TraceIdRatioType),
-            (SamplerOptions.TracesSamplerArgConfigKey, "banana"));
+            (SamplerOptions.TracesSamplerArgConfigKey, argValue));
 
-        // TraceIdRatio is null because the value could not be parsed. Argument retains the
-        // verbatim string so it can be reported if the configured sampler uses it.
+        // TraceIdRatio is null because the value could not be parsed as a finite ratio. Argument
+        // retains the verbatim string so it can be reported if the configured sampler uses it.
         Assert.Null(options.TraceIdRatio);
-        Assert.Equal("banana", options.Argument);
+        Assert.Equal(argValue, options.Argument);
     }
 
     [Fact]
@@ -301,6 +305,8 @@ public sealed class SamplerOptionsTests
     [InlineData("1,5", "1,5")] // Thousands separators are permitted, so this parses to 15.
     [InlineData("-0.1", "-0.1")]
     [InlineData("NaN", "NaN")]
+    [InlineData("nan", "nan")] // Casing is preserved, so the reported value is not a reformat.
+    [InlineData("Infinity", "Infinity")]
     public void InvalidArgWithRatioSampler_LogsValueAndUsesDefaultRatio(string argValue, string expectedPayload)
     {
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);

--- a/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
@@ -210,6 +210,36 @@ public sealed class SamplerOptionsTests
             e => e.EventId == TracesSamplerConfigInvalidEventId);
     }
 
+    [Theory]
+    [InlineData(" always_off ", "AlwaysOffSampler")]
+    [InlineData("	parentbased_always_off	", "ParentBased{AlwaysOffSampler}")]
+    public void PaddedSamplerType_TrimmedBeforeMatching(string samplerType, string expectedDescription)
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerConfigKey, samplerType)));
+
+        Assert.Equal(expectedDescription, tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(
+            eventListener.Messages,
+            e => e.EventId == TracesSamplerConfigInvalidEventId);
+    }
+
+    [Fact]
+    public void PaddedRatioSamplerType_AppliesConfiguredArgument()
+    {
+        var configuration = BuildConfiguration(
+            (SamplerOptions.TracesSamplerConfigKey, " traceidratio "),
+            (SamplerOptions.TracesSamplerArgConfigKey, "0.25"));
+
+        Assert.Equal(0.25, new SamplerOptions(configuration).TraceIdRatio);
+
+        using var tracerProvider = BuildTracerProvider(configuration);
+
+        Assert.Equal("TraceIdRatioBasedSampler{0.250000}", tracerProvider.Sampler.Description);
+    }
+
     [Fact]
     public void UnknownSamplerType_LogsAndUsesDefault()
     {
@@ -241,17 +271,37 @@ public sealed class SamplerOptionsTests
             e => e.EventId == TracesSamplerArgConfigInvalidEventId);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoArgWithRatioSampler_UsesDefaultRatioWithoutDiagnostics(string? argValue)
+    {
+        // The specification defines the default ratio as 1.0 when OTEL_TRACES_SAMPLER_ARG is not
+        // set, so there is no invalid value to report.
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration(
+                (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.TraceIdRatioType),
+                (SamplerOptions.TracesSamplerArgConfigKey, argValue)));
+
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(
+            eventListener.Messages,
+            e => e.EventId == TracesSamplerArgConfigInvalidEventId);
+    }
+
     // The configured value is always reported exactly as it was written, including a trailing
     // zero or a thousands separator which would be lost by formatting the parsed value.
     [Theory]
-    [InlineData(null, "")] // No arg configured at all.
     [InlineData("banana", "banana")] // Unparsable.
     [InlineData("1.5", "1.5")] // Parsable but out of range.
     [InlineData("2.0", "2.0")]
     [InlineData("1,5", "1,5")] // Thousands separators are permitted, so this parses to 15.
     [InlineData("-0.1", "-0.1")]
     [InlineData("NaN", "NaN")]
-    public void InvalidArgWithRatioSampler_LogsValueAndUsesDefaultRatio(string? argValue, string expectedPayload)
+    public void InvalidArgWithRatioSampler_LogsValueAndUsesDefaultRatio(string argValue, string expectedPayload)
     {
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
 

--- a/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
@@ -19,6 +19,17 @@ public sealed class SamplerOptionsTests
     private const string IgnoredSamplerMessageFragment = "has been ignored because a value";
 
     [Fact]
+    public void SamplerTypeConstants_MatchSpecValues()
+    {
+        Assert.Equal("always_on", SamplerOptions.AlwaysOnType);
+        Assert.Equal("always_off", SamplerOptions.AlwaysOffType);
+        Assert.Equal("traceidratio", SamplerOptions.TraceIdRatioType);
+        Assert.Equal("parentbased_always_on", SamplerOptions.ParentBasedAlwaysOnType);
+        Assert.Equal("parentbased_always_off", SamplerOptions.ParentBasedAlwaysOffType);
+        Assert.Equal("parentbased_traceidratio", SamplerOptions.ParentBasedTraceIdRatioType);
+    }
+
+    [Fact]
     public void NoConfigurationKeys_PropertiesAreNull()
     {
         var options = CreateOptions();
@@ -31,9 +42,9 @@ public sealed class SamplerOptionsTests
     [Fact]
     public void TracesSampler_ReadFromConfiguration()
     {
-        var options = CreateOptions((SamplerOptions.TracesSamplerConfigKey, "always_on"));
+        var options = CreateOptions((SamplerOptions.TracesSamplerConfigKey, SamplerOptions.AlwaysOnType));
 
-        Assert.Equal("always_on", options.Type);
+        Assert.Equal(SamplerOptions.AlwaysOnType, options.Type);
     }
 
     [Theory]
@@ -41,18 +52,33 @@ public sealed class SamplerOptionsTests
     [InlineData("1", 1.0)]
     [InlineData("0", 0.0)]
     [InlineData("2.0", 2.0)] // Out of range values are parsed here and rejected when read.
-    public void TracesSamplerArg_ParsedIntoTraceIdRatio(string argValue, double expected)
+    public void TracesSamplerArg_WithRatioType_ParsedIntoTraceIdRatio(string argValue, double expected)
     {
-        var options = CreateOptions((SamplerOptions.TracesSamplerArgConfigKey, argValue));
+        var options = CreateOptions(
+            (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.TraceIdRatioType),
+            (SamplerOptions.TracesSamplerArgConfigKey, argValue));
 
         Assert.Equal(expected, options.TraceIdRatio);
         Assert.Equal(argValue, options.Argument);
     }
 
     [Fact]
+    public void TracesSamplerArg_WithoutRatioType_TraceIdRatioNotParsed()
+    {
+        // OTEL_TRACES_SAMPLER_ARG is sampler-specific. The ratio interpretation only applies
+        // to traceidratio and parentbased_traceidratio, so parsing is skipped for other types.
+        var options = CreateOptions((SamplerOptions.TracesSamplerArgConfigKey, "0.5"));
+
+        Assert.Null(options.TraceIdRatio);
+        Assert.Equal("0.5", options.Argument);
+    }
+
+    [Fact]
     public void TracesSamplerArg_Unparsable_LeavesTraceIdRatioNullAndRetainsArgument()
     {
-        var options = CreateOptions((SamplerOptions.TracesSamplerArgConfigKey, "banana"));
+        var options = CreateOptions(
+            (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.TraceIdRatioType),
+            (SamplerOptions.TracesSamplerArgConfigKey, "banana"));
 
         // TraceIdRatio is null because the value could not be parsed. Argument retains the
         // verbatim string so it can be reported if the configured sampler uses it.
@@ -65,13 +91,13 @@ public sealed class SamplerOptionsTests
     {
         using var environment = EnvironmentVariableScope.Create(
             [
-                (SamplerOptions.TracesSamplerConfigKey, "traceidratio"),
+                (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.TraceIdRatioType),
                 (SamplerOptions.TracesSamplerArgConfigKey, "0.25"),
             ]);
 
         var options = new SamplerOptions();
 
-        Assert.Equal("traceidratio", options.Type);
+        Assert.Equal(SamplerOptions.TraceIdRatioType, options.Type);
         Assert.Equal(0.25, options.TraceIdRatio);
     }
 
@@ -82,12 +108,12 @@ public sealed class SamplerOptionsTests
         // requires a public parameterless constructor.
         var services = new ServiceCollection();
         services.AddOptions();
-        services.Configure<SamplerOptions>(o => o.Type = "always_on");
+        services.Configure<SamplerOptions>(o => o.Type = SamplerOptions.AlwaysOnType);
 
         using var serviceProvider = services.BuildServiceProvider();
 
         Assert.Equal(
-            "always_on",
+            SamplerOptions.AlwaysOnType,
             serviceProvider.GetRequiredService<IOptions<SamplerOptions>>().Value.Type);
     }
 
@@ -95,10 +121,10 @@ public sealed class SamplerOptionsTests
     public void Configure_OverridesEnvironmentVariableType()
     {
         using var environment = EnvironmentVariableScope.Create(
-            SamplerOptions.TracesSamplerConfigKey, "always_off");
+            SamplerOptions.TracesSamplerConfigKey, SamplerOptions.AlwaysOffType);
 
         using var tracerProvider = BuildTracerProvider(
-            configureServices: s => s.Configure<SamplerOptions>(o => o.Type = "always_on"));
+            configureServices: s => s.Configure<SamplerOptions>(o => o.Type = SamplerOptions.AlwaysOnType));
 
         Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
     }
@@ -108,7 +134,7 @@ public sealed class SamplerOptionsTests
     {
         using var environment = EnvironmentVariableScope.Create(
             [
-                (SamplerOptions.TracesSamplerConfigKey, "traceidratio"),
+                (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.TraceIdRatioType),
                 (SamplerOptions.TracesSamplerArgConfigKey, "0.1"),
             ]);
 
@@ -122,7 +148,7 @@ public sealed class SamplerOptionsTests
     public void Configure_BindsFromConfigurationSection()
     {
         var configuration = BuildConfiguration(
-            ("Sampler:Type", "traceidratio"),
+            ("Sampler:Type", SamplerOptions.TraceIdRatioType),
             ("Sampler:TraceIdRatio", "0.4"));
 
         using var tracerProvider = BuildTracerProvider(
@@ -161,7 +187,7 @@ public sealed class SamplerOptionsTests
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
 
         using var tracerProvider = BuildTracerProvider(
-            configuration: BuildConfiguration((SamplerOptions.TracesSamplerConfigKey, "always_on")),
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerConfigKey, SamplerOptions.AlwaysOnType)),
             configureBuilder: b => b.SetSampler(new AlwaysOffSampler()));
 
         Assert.Equal("AlwaysOffSampler", tracerProvider.Sampler.Description);
@@ -206,7 +232,7 @@ public sealed class SamplerOptionsTests
 
         using var tracerProvider = BuildTracerProvider(
             configuration: BuildConfiguration(
-                (SamplerOptions.TracesSamplerConfigKey, "always_on"),
+                (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.AlwaysOnType),
                 (SamplerOptions.TracesSamplerArgConfigKey, "banana")));
 
         Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
@@ -231,7 +257,7 @@ public sealed class SamplerOptionsTests
 
         using var tracerProvider = BuildTracerProvider(
             configuration: BuildConfiguration(
-                (SamplerOptions.TracesSamplerConfigKey, "traceidratio"),
+                (SamplerOptions.TracesSamplerConfigKey, SamplerOptions.TraceIdRatioType),
                 (SamplerOptions.TracesSamplerArgConfigKey, argValue)));
 
         Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
@@ -258,7 +284,7 @@ public sealed class SamplerOptionsTests
             configuration: BuildConfiguration((SamplerOptions.TracesSamplerArgConfigKey, argValue)),
             configureServices: s => s.Configure<SamplerOptions>(o =>
             {
-                o.Type = "traceidratio";
+                o.Type = SamplerOptions.TraceIdRatioType;
                 o.TraceIdRatio = traceIdRatio;
             }));
 
@@ -275,7 +301,7 @@ public sealed class SamplerOptionsTests
             configuration: BuildConfiguration((SamplerOptions.TracesSamplerArgConfigKey, "banana")),
             configureServices: s => s.Configure<SamplerOptions>(o =>
             {
-                o.Type = "traceidratio";
+                o.Type = SamplerOptions.TraceIdRatioType;
                 o.TraceIdRatio = 0.25;
             }));
 
@@ -283,6 +309,34 @@ public sealed class SamplerOptionsTests
         Assert.DoesNotContain(
             eventListener.Messages,
             e => e.EventId == TracesSamplerArgConfigInvalidEventId);
+    }
+
+    [Fact]
+    public void ProgrammaticTypeWithConfiguredArg_FallsBackToArgument()
+    {
+        // When Type is set programmatically and OTEL_TRACES_SAMPLER_ARG is in config but
+        // OTEL_TRACES_SAMPLER is not, the constructor guard skips parsing. ReadTraceIdRatio
+        // falls back to Argument so the ratio still takes effect.
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerArgConfigKey, "0.5")),
+            configureServices: s => s.Configure<SamplerOptions>(o => o.Type = SamplerOptions.TraceIdRatioType));
+
+        Assert.Equal("TraceIdRatioBasedSampler{0.500000}", tracerProvider.Sampler.Description);
+    }
+
+    [Fact]
+    public void ProgrammaticTypeWithInvalidConfiguredArg_LogsAndUsesDefaultRatio()
+    {
+        // The fallback parse in ReadTraceIdRatio correctly reports the value that was
+        // tried and rejected, not a "could not parse" message.
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerArgConfigKey, "1.5")),
+            configureServices: s => s.Configure<SamplerOptions>(o => o.Type = SamplerOptions.TraceIdRatioType));
+
+        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
+        AssertPayload(eventListener, TracesSamplerArgConfigInvalidEventId, "1.5");
     }
 
     private static SamplerOptions CreateOptions(params (string Key, string? Value)[] configuration)

--- a/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplerOptionsTests.cs
@@ -1,562 +1,335 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Tracing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 
-public sealed class SamplerOptionsTests : IDisposable
+public sealed class SamplerOptionsTests
 {
-    public SamplerOptionsTests()
+    private const int TracerProviderSdkEventId = 46;
+    private const int TracesSamplerConfigInvalidEventId = 54;
+    private const int TracesSamplerArgConfigInvalidEventId = 55;
+
+    private const string IgnoredSamplerMessageFragment = "has been ignored because a value";
+
+    [Fact]
+    public void NoConfigurationKeys_PropertiesAreNull()
     {
-        ClearSamplerEnvVars();
+        var options = CreateOptions();
+
+        Assert.Null(options.Type);
+        Assert.Null(options.TraceIdRatio);
+        Assert.Null(options.Argument);
     }
 
     [Fact]
-    public void SamplerOptions_NoConfigurationKeys_Defaults()
+    public void TracesSampler_ReadFromConfiguration()
     {
-        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
-        var options = new SamplerOptions(configuration);
+        var options = CreateOptions((SamplerOptions.TracesSamplerConfigKey, "always_on"));
 
-        Assert.Null(options.SamplerType);
-        Assert.Null(options.SamplerArg);
+        Assert.Equal("always_on", options.Type);
+    }
+
+    [Theory]
+    [InlineData("0.5", 0.5)]
+    [InlineData("1", 1.0)]
+    [InlineData("0", 0.0)]
+    [InlineData("2.0", 2.0)] // Out of range values are parsed here and rejected when read.
+    public void TracesSamplerArg_ParsedIntoTraceIdRatio(string argValue, double expected)
+    {
+        var options = CreateOptions((SamplerOptions.TracesSamplerArgConfigKey, argValue));
+
+        Assert.Equal(expected, options.TraceIdRatio);
+        Assert.Equal(argValue, options.Argument);
     }
 
     [Fact]
-    public void SamplerOptions_TracesSampler_FromConfiguration()
+    public void TracesSamplerArg_Unparsable_LeavesTraceIdRatioNullAndRetainsArgument()
     {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
-            })
-            .Build();
+        var options = CreateOptions((SamplerOptions.TracesSamplerArgConfigKey, "banana"));
 
-        var options = new SamplerOptions(configuration);
-
-        Assert.Equal("always_on", options.SamplerType);
+        // TraceIdRatio is null because the value could not be parsed. Argument retains the
+        // verbatim string so it can be reported if the configured sampler uses it.
+        Assert.Null(options.TraceIdRatio);
+        Assert.Equal("banana", options.Argument);
     }
 
     [Fact]
-    public void SamplerOptions_TracesSamplerArg_Parse()
+    public void ParameterlessConstructor_ReadsEnvironmentVariables()
     {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerArgConfigKey] = "0.5",
-            })
-            .Build();
+        using var environment = EnvironmentVariableScope.Create(
+            [
+                (SamplerOptions.TracesSamplerConfigKey, "traceidratio"),
+                (SamplerOptions.TracesSamplerArgConfigKey, "0.25"),
+            ]);
 
-        var options = new SamplerOptions(configuration);
+        var options = new SamplerOptions();
 
-        Assert.Equal(0.5, options.SamplerArg);
+        Assert.Equal("traceidratio", options.Type);
+        Assert.Equal(0.25, options.TraceIdRatio);
     }
 
     [Fact]
-    public void SamplerOptions_TracesSamplerArg_Invalid_LeavesNullAndPreservesRaw()
+    public void ResolvedFromServiceCollectionWithoutTracing()
     {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerArgConfigKey] = "banana",
-            })
-            .Build();
+        // The options type must be usable through the standard options pipeline, which
+        // requires a public parameterless constructor.
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.Configure<SamplerOptions>(o => o.Type = "always_on");
 
-        var options = new SamplerOptions(configuration);
+        using var serviceProvider = services.BuildServiceProvider();
 
-        // SamplerArg is null because the string couldn't be parsed.
-        Assert.Null(options.SamplerArg);
-
-        // SamplerArgRaw preserves the original string for ReadTraceIdRatio to use in its diagnostic.
-        Assert.Equal("banana", options.SamplerArgRaw);
+        Assert.Equal(
+            "always_on",
+            serviceProvider.GetRequiredService<IOptions<SamplerOptions>>().Value.Type);
     }
 
     [Fact]
-    public void SamplerOptions_InvalidArgWithNonRatioSampler_NoEvent55()
+    public void Configure_OverridesEnvironmentVariableType()
     {
-        // OTEL_TRACES_SAMPLER_ARG is only evaluated for ratio-based samplers. A bad arg value
-        // combined with a sampler type that ignores the arg must not produce a diagnostic.
-        // NOTE: This specifically preserves the existing behavior before introducing SamplerOptions.
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+        using var environment = EnvironmentVariableScope.Create(
+            SamplerOptions.TracesSamplerConfigKey, "always_off");
 
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
-                [SamplerOptions.TracesSamplerArgConfigKey] = "banana",
-            })
-            .Build();
+        using var tracerProvider = BuildTracerProvider(
+            configureServices: s => s.Configure<SamplerOptions>(o => o.Type = "always_on"));
 
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
-        Assert.DoesNotContain(eventListener.Messages, e => e.EventId == 55);
-    }
-
-    [Fact]
-    public void SamplerOptions_ConfigureOverridesEnvironmentVariable()
-    {
-        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerConfigKey, "always_off");
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o => o.SamplerType = "always_on"));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
         Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
     }
 
     [Fact]
-    public void SamplerOptions_ConfigureOverridesSamplerArg()
+    public void Configure_OverridesEnvironmentVariableTraceIdRatio()
     {
-        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerConfigKey, "traceidratio");
-        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerArgConfigKey, "0.1");
+        using var environment = EnvironmentVariableScope.Create(
+            [
+                (SamplerOptions.TracesSamplerConfigKey, "traceidratio"),
+                (SamplerOptions.TracesSamplerArgConfigKey, "0.1"),
+            ]);
 
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o => o.SamplerArg = 0.9));
+        using var tracerProvider = BuildTracerProvider(
+            configureServices: s => s.Configure<SamplerOptions>(o => o.TraceIdRatio = 0.9));
 
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
         Assert.Equal("TraceIdRatioBasedSampler{0.900000}", tracerProvider.Sampler.Description);
     }
 
     [Fact]
-    public void SamplerOptions_ConfigureFromSection()
+    public void Configure_BindsFromConfigurationSection()
     {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Sampler:SamplerType"] = "traceidratio",
-                ["Sampler:SamplerArg"] = "0.4",
-            })
-            .Build();
+        var configuration = BuildConfiguration(
+            ("Sampler:Type", "traceidratio"),
+            ("Sampler:TraceIdRatio", "0.4"));
 
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => s.Configure<SamplerOptions>(configuration.GetSection("Sampler")));
+        using var tracerProvider = BuildTracerProvider(
+            configureServices: s => s.Configure<SamplerOptions>(configuration.GetSection("Sampler")));
 
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
         Assert.Equal("TraceIdRatioBasedSampler{0.400000}", tracerProvider.Sampler.Description);
     }
 
     [Fact]
-    public void TracerProvider_NoSamplerConfiguration_UsesDefaultSampler_NoDiagnostics()
+    public void NoConfiguration_UsesDefaultSamplerWithoutDiagnostics()
     {
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
 
-        var configuration = EmptySamplerConfiguration();
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
+        using var tracerProvider = BuildTracerProvider(configuration: BuildConfiguration());
 
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
+        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(eventListener.Messages, IsSamplerIgnoredEvent);
+    }
 
-        Assert.NotNull(tracerProvider);
+    [Fact]
+    public void ProgrammaticSamplerWithoutConfiguration_NoIgnoredDiagnostic()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration(),
+            configureBuilder: b => b.SetSampler(new AlwaysOnSampler()));
+
+        Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(eventListener.Messages, IsSamplerIgnoredEvent);
+    }
+
+    [Fact]
+    public void ProgrammaticSamplerWithConfiguration_EmitsIgnoredDiagnostic()
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerConfigKey, "always_on")),
+            configureBuilder: b => b.SetSampler(new AlwaysOffSampler()));
+
+        Assert.Equal("AlwaysOffSampler", tracerProvider.Sampler.Description);
+        Assert.Contains(eventListener.Messages, IsSamplerIgnoredEvent);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankSamplerType_TreatedAsUnsetWithoutDiagnostics(string samplerType)
+    {
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerConfigKey, samplerType)));
+
         Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
         Assert.DoesNotContain(
             eventListener.Messages,
-            e => e.EventId == 46 && e.Payload != null && ((string)e.Payload[0]!).Contains("has been ignored because a value", StringComparison.Ordinal));
+            e => e.EventId == TracesSamplerConfigInvalidEventId);
     }
 
     [Fact]
-    public void TracerProvider_ProgrammaticSamplerWithoutConfiguration_NoIgnoredDiagnostic()
+    public void UnknownSamplerType_LogsAndUsesDefault()
     {
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
 
-        var configuration = EmptySamplerConfiguration();
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-        builder.SetSampler(new AlwaysOnSampler());
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerConfigKey, "unknown_sampler")));
 
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
+        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
+        AssertPayload(eventListener, TracesSamplerConfigInvalidEventId, "unknown_sampler");
+    }
 
-        Assert.NotNull(tracerProvider);
+    [Fact]
+    public void InvalidArgWithNonRatioSampler_NoDiagnostic()
+    {
+        // OTEL_TRACES_SAMPLER_ARG is only evaluated for ratio based samplers. Per the
+        // specification each sampler defines its own expected input, so an invalid arg
+        // combined with a sampler which ignores it must not produce a diagnostic.
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
+
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration(
+                (SamplerOptions.TracesSamplerConfigKey, "always_on"),
+                (SamplerOptions.TracesSamplerArgConfigKey, "banana")));
+
         Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
         Assert.DoesNotContain(
             eventListener.Messages,
-            e => e.EventId == 46 && e.Payload != null && ((string)e.Payload[0]!).Contains("has been ignored because a value", StringComparison.Ordinal));
+            e => e.EventId == TracesSamplerArgConfigInvalidEventId);
     }
 
-    [Fact]
-    public void TracerProvider_ConfigurationWithProgrammaticSampler_EmitsIgnoredDiagnostic()
+    // The configured value is always reported exactly as it was written, including a trailing
+    // zero or a thousands separator which would be lost by formatting the parsed value.
+    [Theory]
+    [InlineData(null, "")] // No arg configured at all.
+    [InlineData("banana", "banana")] // Unparsable.
+    [InlineData("1.5", "1.5")] // Parsable but out of range.
+    [InlineData("2.0", "2.0")]
+    [InlineData("1,5", "1,5")] // Thousands separators are permitted, so this parses to 15.
+    [InlineData("-0.1", "-0.1")]
+    [InlineData("NaN", "NaN")]
+    public void InvalidArgWithRatioSampler_LogsValueAndUsesDefaultRatio(string? argValue, string expectedPayload)
     {
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
 
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
-            })
-            .Build();
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration(
+                (SamplerOptions.TracesSamplerConfigKey, "traceidratio"),
+                (SamplerOptions.TracesSamplerArgConfigKey, argValue)));
 
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-        builder.SetSampler(new AlwaysOffSampler());
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("AlwaysOffSampler", tracerProvider.Sampler.Description);
-        Assert.Contains(
-            eventListener.Messages,
-            e => e.EventId == 46
-                && e.Payload != null
-                && ((string)e.Payload[0]!).Contains("has been ignored because a value", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public void TracerProvider_AlwaysOn_FromConfiguration()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "always_on",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("AlwaysOnSampler", tracerProvider.Sampler.Description);
-    }
-
-    [Fact]
-    public void TracerProvider_AlwaysOff_FromConfiguration()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "always_off",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("AlwaysOffSampler", tracerProvider.Sampler.Description);
-    }
-
-    [Fact]
-    public void TracerProvider_ParentBasedAlwaysOn_FromConfiguration()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "parentbased_always_on",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
-    }
-
-    [Fact]
-    public void TracerProvider_ParentBasedAlwaysOff_FromConfiguration()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "parentbased_always_off",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("ParentBased{AlwaysOffSampler}", tracerProvider.Sampler.Description);
-    }
-
-    [Fact]
-    public void TracerProvider_TraceIdRatio_FromConfiguration()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
-                [SamplerOptions.TracesSamplerArgConfigKey] = "0.3",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.IsType<TraceIdRatioBasedSampler>(tracerProvider.Sampler);
-        Assert.Equal("TraceIdRatioBasedSampler{0.300000}", tracerProvider.Sampler.Description);
-    }
-
-    [Fact]
-    public void TracerProvider_ParentBasedTraceIdRatio_FromConfiguration()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "parentbased_traceidratio",
-                [SamplerOptions.TracesSamplerArgConfigKey] = "0.3",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("ParentBased{TraceIdRatioBasedSampler{0.300000}}", tracerProvider.Sampler.Description);
-    }
-
-    [Fact]
-    public void TracerProvider_TraceIdRatio_NoArg_DefaultsToOne_LogsEmptyArg()
-    {
-        // Matches pre-options behaviour
-
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
-
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
         Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
-        Assert.Contains(
-            eventListener.Messages,
-            e => e.EventId == 55 && e.Payload != null && string.IsNullOrEmpty((string)e.Payload[0]!));
+        Assert.Single(eventListener.Messages, e => e.EventId == TracesSamplerArgConfigInvalidEventId);
+        AssertPayload(eventListener, TracesSamplerArgConfigInvalidEventId, expectedPayload);
     }
 
-    [Fact]
-    public void TracerProvider_TraceIdRatio_OutOfRange_LogsAndUsesDefaultRatio()
+    // A configured value is present in every case, to prove the diagnostic reports the
+    // programmatic value which actually caused the fallback rather than the ignored one.
+    [Theory]
+    [InlineData("0.5", 2.0, "2")] // Configured value is usable, so the override is at fault.
+    [InlineData("0.5", -0.1, "-0.1")]
+    [InlineData("0.5", double.NaN, "NaN")]
+    [InlineData("2.0", 3.0, "3")] // Both are unusable, but only the override is in effect.
+    [InlineData("banana", 3.0, "3")]
+    public void ProgrammaticInvalidTraceIdRatio_LogsEffectiveValueAndUsesDefaultRatio(
+        string argValue,
+        double traceIdRatio,
+        string expectedPayload)
     {
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
 
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerArgConfigKey, argValue)),
+            configureServices: s => s.Configure<SamplerOptions>(o =>
             {
-                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
-                [SamplerOptions.TracesSamplerArgConfigKey] = "1.5",
-            })
-            .Build();
+                o.Type = "traceidratio";
+                o.TraceIdRatio = traceIdRatio;
+            }));
 
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
         Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
-        Assert.Contains(
-            eventListener.Messages,
-            e => e.EventId == 55 && e.Payload != null && (string)e.Payload[0]! == "1.5");
+        AssertPayload(eventListener, TracesSamplerArgConfigInvalidEventId, expectedPayload);
     }
 
     [Fact]
-    public void TracerProvider_TraceIdRatio_OutOfRange_LogsOriginalConfigString()
+    public void ProgrammaticValidTraceIdRatio_OverridesUnusableConfiguredValueWithoutDiagnostics()
     {
         using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
 
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
+        using var tracerProvider = BuildTracerProvider(
+            configuration: BuildConfiguration((SamplerOptions.TracesSamplerArgConfigKey, "banana")),
+            configureServices: s => s.Configure<SamplerOptions>(o =>
             {
-                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
-                [SamplerOptions.TracesSamplerArgConfigKey] = "2.0",
-            })
+                o.Type = "traceidratio";
+                o.TraceIdRatio = 0.25;
+            }));
+
+        Assert.Equal("TraceIdRatioBasedSampler{0.250000}", tracerProvider.Sampler.Description);
+        Assert.DoesNotContain(
+            eventListener.Messages,
+            e => e.EventId == TracesSamplerArgConfigInvalidEventId);
+    }
+
+    private static SamplerOptions CreateOptions(params (string Key, string? Value)[] configuration)
+        => new(BuildConfiguration(configuration));
+
+    private static IConfiguration BuildConfiguration(params (string Key, string? Value)[] values)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(values.ToDictionary(v => v.Key, v => v.Value))
             .Build();
 
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
-        Assert.Contains(
-            eventListener.Messages,
-            e => e.EventId == 55 && e.Payload != null && (string)e.Payload[0]! == "2.0");
-    }
-
-    [Fact]
-    public void TracerProvider_TraceIdRatio_UnparsableArg_LogsFromReadTraceIdRatio()
+    private static TracerProviderSdk BuildTracerProvider(
+        IConfiguration? configuration = null,
+        Action<IServiceCollection>? configureServices = null,
+        Action<TracerProviderBuilder>? configureBuilder = null)
     {
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
-
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "traceidratio",
-                [SamplerOptions.TracesSamplerArgConfigKey] = "not_a_double",
-            })
-            .Build();
-
         var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
 
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
-        Assert.Single(eventListener.Messages, e => e.EventId == 55);
-        Assert.Contains(
-            eventListener.Messages,
-            e => e.EventId == 55 && e.Payload != null && (string)e.Payload[0]! == "not_a_double");
-    }
-
-    [Fact]
-    public void TracerProvider_UnknownSampler_LogsAndUsesDefault()
-    {
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
-
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = "unknown_sampler",
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
-        Assert.Contains(
-            eventListener.Messages,
-            e => e.EventId == 54 && e.Payload != null && (string)e.Payload[0]! == "unknown_sampler");
-    }
-
-    [Fact]
-    public void TracerProvider_EmptySamplerTypeKey_TreatedAsUnset()
-    {
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
-
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [SamplerOptions.TracesSamplerConfigKey] = string.Empty,
-            })
-            .Build();
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => ReplaceRootConfiguration(s, configuration));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
-        Assert.DoesNotContain(eventListener.Messages, e => e.EventId == 54);
-    }
-
-    [Fact]
-    public void TracerProvider_TraceIdRatio_ProgrammaticOutOfRangeArg_FallsBackToDefaultAndLogs()
-    {
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o =>
+        builder.ConfigureServices(services =>
         {
-            o.SamplerType = "traceidratio";
-            o.SamplerArg = 2.0; // out of [0.0, 1.0]; SamplerArgRaw is null (no config string)
-        }));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
-        Assert.Contains(eventListener.Messages, e => e.EventId == 55);
-    }
-
-    [Fact]
-    public void TracerProvider_TraceIdRatio_ProgrammaticNaNArg_FallsBackToDefaultAndLogs()
-    {
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o =>
-        {
-            o.SamplerType = "traceidratio";
-            o.SamplerArg = double.NaN;
-        }));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("TraceIdRatioBasedSampler{1.000000}", tracerProvider.Sampler.Description);
-        Assert.Contains(eventListener.Messages, e => e.EventId == 55);
-    }
-
-    [Fact]
-    public void TracerProvider_WhitespaceSamplerType_TreatedAsUnset()
-    {
-        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log);
-
-        var builder = Sdk.CreateTracerProviderBuilder();
-        builder.ConfigureServices(s => s.Configure<SamplerOptions>(o => o.SamplerType = "   "));
-
-        using var tracerProvider = builder.Build() as TracerProviderSdk;
-
-        Assert.NotNull(tracerProvider);
-        Assert.Equal("ParentBased{AlwaysOnSampler}", tracerProvider.Sampler.Description);
-        Assert.DoesNotContain(eventListener.Messages, e => e.EventId == 54);
-    }
-
-    public void Dispose()
-    {
-        ClearSamplerEnvVars();
-        GC.SuppressFinalize(this);
-    }
-
-    private static IConfiguration EmptySamplerConfiguration()
-        => new ConfigurationBuilder().AddInMemoryCollection([]).Build();
-
-    private static void ReplaceRootConfiguration(IServiceCollection services, IConfiguration configuration)
-    {
-        for (var i = services.Count - 1; i >= 0; i--)
-        {
-            if (services[i].ServiceType == typeof(IConfiguration))
+            // Registered last so it replaces the environment variable only configuration
+            // added by the SDK, which uses TryAddSingleton.
+            if (configuration != null)
             {
-                services.RemoveAt(i);
+                services.AddSingleton(configuration);
             }
-        }
 
-        services.AddSingleton(configuration);
+            configureServices?.Invoke(services);
+        });
+
+        configureBuilder?.Invoke(builder);
+
+        var tracerProvider = builder.Build() as TracerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+
+        return tracerProvider;
     }
 
-    private static void ClearSamplerEnvVars()
-    {
-        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerConfigKey, null);
-        Environment.SetEnvironmentVariable(SamplerOptions.TracesSamplerArgConfigKey, null);
-    }
+    private static bool IsSamplerIgnoredEvent(EventWrittenEventArgs e)
+        => e.EventId == TracerProviderSdkEventId
+            && e.Payload != null
+            && ((string)e.Payload[0]!).Contains(IgnoredSamplerMessageFragment, StringComparison.Ordinal);
+
+    private static void AssertPayload(TestEventListener eventListener, int eventId, string expectedPayload)
+        => Assert.Contains(
+            eventListener.Messages,
+            e => e.EventId == eventId
+                && e.Payload != null
+                && (string)e.Payload[0]! == expectedPayload);
 }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
@@ -1061,6 +1061,7 @@ public sealed class TracerProviderSdkTests : IDisposable
     [InlineData("always_on", null, "AlwaysOnSampler")]
     [InlineData("always_off", null, "AlwaysOffSampler")]
     [InlineData("always_OFF", null, "AlwaysOffSampler")]
+    [InlineData("traceidratio", null, "TraceIdRatioBasedSampler{1.000000}")]
     [InlineData("traceidratio", "0.5", "TraceIdRatioBasedSampler{0.500000}")]
     [InlineData("traceidratio", "not_a_double", "TraceIdRatioBasedSampler{1.000000}")]
     [InlineData("traceidratio", "2.0", "TraceIdRatioBasedSampler{1.000000}")]
@@ -1078,8 +1079,8 @@ public sealed class TracerProviderSdkTests : IDisposable
 
         configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [TracerProviderSdk.TracesSamplerConfigKey] = configValue,
-            [TracerProviderSdk.TracesSamplerArgConfigKey] = argValue,
+            [SamplerOptions.TracesSamplerConfigKey] = configValue,
+            [SamplerOptions.TracesSamplerArgConfigKey] = argValue,
         });
 
         var builder = Sdk.CreateTracerProviderBuilder();
@@ -1098,7 +1099,7 @@ public sealed class TracerProviderSdkTests : IDisposable
         var configBuilder = new ConfigurationBuilder();
         configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [TracerProviderSdk.TracesSamplerConfigKey] = "always_off",
+            [SamplerOptions.TracesSamplerConfigKey] = "always_off",
         });
 
         var builder = Sdk.CreateTracerProviderBuilder();

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
@@ -1095,6 +1095,7 @@ public sealed class TracerProviderSdkTests : IDisposable
     [InlineData("always_on", null, "AlwaysOnSampler")]
     [InlineData("always_off", null, "AlwaysOffSampler")]
     [InlineData("always_OFF", null, "AlwaysOffSampler")]
+    [InlineData("traceidratio", null, "TraceIdRatioBasedSampler{1.000000}")]
     [InlineData("traceidratio", "0.5", "TraceIdRatioBasedSampler{0.500000}")]
     [InlineData("traceidratio", "not_a_double", "TraceIdRatioBasedSampler{1.000000}")]
     [InlineData("traceidratio", "2.0", "TraceIdRatioBasedSampler{1.000000}")]
@@ -1112,8 +1113,8 @@ public sealed class TracerProviderSdkTests : IDisposable
 
         configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [TracerProviderSdk.TracesSamplerConfigKey] = configValue,
-            [TracerProviderSdk.TracesSamplerArgConfigKey] = argValue,
+            [SamplerOptions.TracesSamplerConfigKey] = configValue,
+            [SamplerOptions.TracesSamplerArgConfigKey] = argValue,
         });
 
         var builder = Sdk.CreateTracerProviderBuilder();
@@ -1132,7 +1133,7 @@ public sealed class TracerProviderSdkTests : IDisposable
         var configBuilder = new ConfigurationBuilder();
         configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [TracerProviderSdk.TracesSamplerConfigKey] = "always_off",
+            [SamplerOptions.TracesSamplerConfigKey] = "always_off",
         });
 
         var builder = Sdk.CreateTracerProviderBuilder();


### PR DESCRIPTION
Fixes #7178

## Changes

- Introduce `SamplerOptions` to encapsulate trace sampler configuration, parsing OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG from IConfiguration.
- Refactor `TracerProviderSdk` to resolve sampler settings via `IOptions<SamplerOptions>`, enabling standard options pipeline overrides and improved diagnostics.
- Add tests for configuration, overrides, and error handling.
- Update public API and diagnostics to reflect new options-based approach.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)