### PR TITLE
[Infra] Polyfill Stopwatch.GetElapsedTime

### DIFF
--- a/OpenTelemetry.slnx
+++ b/OpenTelemetry.slnx
@@ -155,6 +155,7 @@
     <File Path="src/Shared/SemanticConventions.cs" />
     <File Path="src/Shared/SpanAttributeConstants.cs" />
     <File Path="src/Shared/StatusHelper.cs" />
+    <File Path="src/Shared/StopwatchExtensions.cs" />
     <File Path="src/Shared/ThreadSafeRandom.cs" />
   </Folder>
   <Folder Name="/Shared/Configuration/">

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -52,7 +52,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
 
     protected override void OnShutdown(int timeoutMilliseconds)
     {
-        var sw = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         try
         {
@@ -65,16 +65,12 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
 
         this.thread.Join(timeoutMilliseconds);
 
-        if (sw != null)
+        if (timestamp is { } startedAt)
         {
-            var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
+            timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+        }
 
-            base.OnShutdown((int)Math.Max(timeout, 0));
-        }
-        else
-        {
-            base.OnShutdown(timeoutMilliseconds);
-        }
+        base.OnShutdown(timeoutMilliseconds);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterTransmissionHandler.cs
@@ -35,12 +35,8 @@ internal class OtlpExporterTransmissionHandler : IDisposable
         {
             var deadlineUtc = DateTime.UtcNow.AddMilliseconds(this.TimeoutMilliseconds);
             var response = this.ExportClient.SendExportRequest(request, contentLength, deadlineUtc);
-            if (response.Success)
-            {
-                return true;
-            }
 
-            return this.OnSubmitRequestFailure(request, contentLength, response);
+            return response.Success || this.OnSubmitRequestFailure(request, contentLength, response);
         }
         catch (Exception ex)
         {
@@ -65,15 +61,13 @@ internal class OtlpExporterTransmissionHandler : IDisposable
     {
         Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
-        var sw = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         this.OnShutdown(timeoutMilliseconds);
 
-        if (sw != null)
+        if (timestamp is { } startedAt)
         {
-            var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
-
-            return this.ExportClient.Shutdown((int)Math.Max(timeout, 0));
+            timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
         }
 
         return this.ExportClient.Shutdown(timeoutMilliseconds);

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -97,18 +97,12 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
 
     /// <inheritdoc/>
     protected override bool OnForceFlush(int timeoutMilliseconds)
-    {
-        return this.worker.WaitForExport(timeoutMilliseconds);
-    }
+        => this.worker.WaitForExport(timeoutMilliseconds);
 
     /// <inheritdoc/>
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
-        Stopwatch? shutdownStopwatch = null;
-        if (timeoutMilliseconds > 0)
-        {
-            shutdownStopwatch = Stopwatch.StartNew();
-        }
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         var result = this.worker.Shutdown(timeoutMilliseconds);
 
@@ -124,18 +118,12 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
             return this.exporter.Shutdown(0) && result;
         }
 
-        int remainingTimeout = timeoutMilliseconds;
-        if (shutdownStopwatch != null)
+        if (timestamp is { } startedAt)
         {
-            shutdownStopwatch.Stop();
-            remainingTimeout -= (int)shutdownStopwatch.ElapsedMilliseconds;
-            if (remainingTimeout < 0)
-            {
-                remainingTimeout = 0;
-            }
+            timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
         }
 
-        return this.exporter.Shutdown(remainingTimeout) && result;
+        return this.exporter.Shutdown(timeoutMilliseconds) && result;
     }
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry/CompositeProcessor.cs
+++ b/src/OpenTelemetry/CompositeProcessor.cs
@@ -63,18 +63,18 @@ public class CompositeProcessor<T> : BaseProcessor<T>
     /// <inheritdoc/>
     public override void OnEnd(T data)
     {
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            cur.Value.OnEnd(data);
+            current.Value.OnEnd(data);
         }
     }
 
     /// <inheritdoc/>
     public override void OnStart(T data)
     {
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            cur.Value.OnStart(data);
+            current.Value.OnStart(data);
         }
     }
 
@@ -82,9 +82,9 @@ public class CompositeProcessor<T> : BaseProcessor<T>
     {
         base.SetParentProvider(parentProvider);
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            cur.Value.SetParentProvider(parentProvider);
+            current.Value.SetParentProvider(parentProvider);
         }
     }
 
@@ -92,9 +92,9 @@ public class CompositeProcessor<T> : BaseProcessor<T>
     {
         var list = new List<BaseProcessor<T>>();
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            list.Add(cur.Value);
+            list.Add(current.Value);
         }
 
         return list;
@@ -104,23 +104,17 @@ public class CompositeProcessor<T> : BaseProcessor<T>
     protected override bool OnForceFlush(int timeoutMilliseconds)
     {
         var result = true;
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            if (sw == null)
+            if (timestamp is { } startedAt)
             {
-                result = cur.Value.ForceFlush() && result;
+                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
             }
-            else
-            {
-                var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
 
-                // notify all the processors, even if we run overtime
-                result = cur.Value.ForceFlush((int)Math.Max(timeout, 0)) && result;
-            }
+            // Notify all the processors, even if we run overtime
+            result = current.Value.ForceFlush(timeoutMilliseconds) && result;
         }
 
         return result;
@@ -130,23 +124,17 @@ public class CompositeProcessor<T> : BaseProcessor<T>
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
         var result = true;
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            if (sw == null)
+            if (timestamp is { } startedAt)
             {
-                result = cur.Value.Shutdown() && result;
+                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
             }
-            else
-            {
-                var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
 
-                // notify all the processors, even if we run overtime
-                result = cur.Value.Shutdown((int)Math.Max(timeout, 0)) && result;
-            }
+            // Notify all the processors, even if we run overtime
+            result = current.Value.Shutdown(timeoutMilliseconds) && result;
         }
 
         return result;
@@ -159,11 +147,11 @@ public class CompositeProcessor<T> : BaseProcessor<T>
         {
             if (disposing)
             {
-                for (var cur = this.Head; cur != null; cur = cur.Next)
+                for (var current = this.Head; current != null; current = current.Next)
                 {
                     try
                     {
-                        cur.Value.Dispose();
+                        current.Value.Dispose();
                     }
                     catch (Exception ex)
                     {

--- a/src/OpenTelemetry/CompositeProcessor.cs
+++ b/src/OpenTelemetry/CompositeProcessor.cs
@@ -104,17 +104,20 @@ public class CompositeProcessor<T> : BaseProcessor<T>
     protected override bool OnForceFlush(int timeoutMilliseconds)
     {
         var result = true;
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
         long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         for (var current = this.Head; current != null; current = current.Next)
         {
+            var currentTimeoutMilliseconds = timeoutMilliseconds;
+
             if (timestamp is { } startedAt)
             {
-                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+                currentTimeoutMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
             }
 
             // Notify all the processors, even if we run overtime
-            result = current.Value.ForceFlush(timeoutMilliseconds) && result;
+            result = current.Value.ForceFlush(currentTimeoutMilliseconds) && result;
         }
 
         return result;
@@ -124,17 +127,20 @@ public class CompositeProcessor<T> : BaseProcessor<T>
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
         var result = true;
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
         long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         for (var current = this.Head; current != null; current = current.Next)
         {
+            var currentTimeoutMilliseconds = timeoutMilliseconds;
+
             if (timestamp is { } startedAt)
             {
-                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+                currentTimeoutMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
             }
 
             // Notify all the processors, even if we run overtime
-            result = current.Value.Shutdown(timeoutMilliseconds) && result;
+            result = current.Value.Shutdown(currentTimeoutMilliseconds) && result;
         }
 
         return result;

--- a/src/OpenTelemetry/Internal/BatchExportTaskWorker.cs
+++ b/src/OpenTelemetry/Internal/BatchExportTaskWorker.cs
@@ -146,6 +146,7 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
 
     private async Task<bool> WaitForExportAsync(int timeoutMilliseconds, long targetHead)
     {
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
         long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         // There is a chance that the export task finished processing all the data from the queue,
@@ -158,12 +159,14 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
 
             if (timestamp is { } startedAt)
             {
-                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+                var remainingMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
 
-                if (timeoutMilliseconds <= 0)
+                if (remainingMilliseconds <= 0)
                 {
                     return this.CircularBuffer.RemovedCount >= targetHead;
                 }
+
+                timeout = Math.Min(remainingMilliseconds, pollingMilliseconds);
             }
 
             try

--- a/src/OpenTelemetry/Internal/BatchExportTaskWorker.cs
+++ b/src/OpenTelemetry/Internal/BatchExportTaskWorker.cs
@@ -39,9 +39,7 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
 
     /// <inheritdoc/>
     public override void Start()
-    {
-        this.workerTask = Task.Run(this.ExporterProcAsync);
-    }
+        => this.workerTask = Task.Run(this.ExporterProcAsync);
 
     /// <inheritdoc/>
     public override bool TriggerExport()
@@ -97,6 +95,7 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
             return true;
         }
 
+        // Otherwise we can just wait for the export to complete synchronously
         return this.WaitForExportAsync(timeoutMilliseconds, head).GetAwaiter().GetResult();
     }
 
@@ -125,12 +124,7 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
             return true;
         }
 
-        if (timeoutMilliseconds == 0)
-        {
-            return true;
-        }
-
-        return this.workerTask.Wait(timeoutMilliseconds);
+        return timeoutMilliseconds == 0 || this.workerTask.Wait(timeoutMilliseconds);
     }
 
     /// <inheritdoc/>
@@ -152,9 +146,7 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
 
     private async Task<bool> WaitForExportAsync(int timeoutMilliseconds, long targetHead)
     {
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         // There is a chance that the export task finished processing all the data from the queue,
         // and signaled before we enter wait here, use polling to prevent being blocked indefinitely.
@@ -163,15 +155,15 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
         while (true)
         {
             var timeout = pollingMilliseconds;
-            if (sw != null)
+
+            if (timestamp is { } startedAt)
             {
-                var remaining = timeoutMilliseconds - sw.ElapsedMilliseconds;
-                if (remaining <= 0)
+                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+
+                if (timeoutMilliseconds <= 0)
                 {
                     return this.CircularBuffer.RemovedCount >= targetHead;
                 }
-
-                timeout = Math.Min((int)remaining, pollingMilliseconds);
             }
 
             try
@@ -185,7 +177,7 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
                     this.dataExportedNotification.Task,
                     this.shutdownCompletionSource.Task,
                     Task.Delay(timeout, combinedTokenSource.Token)).ConfigureAwait(false);
-#if NET8_0_OR_GREATER
+#if NET
                 await combinedTokenSource.CancelAsync().ConfigureAwait(false);
 #else
                 combinedTokenSource.Cancel();
@@ -229,7 +221,7 @@ internal sealed class BatchExportTaskWorker<T> : BatchExportWorker<T>
                         await Task.WhenAny(
                             this.exportTrigger.WaitAsync(waitAndDelayCts.Token),
                             Task.Delay(this.ScheduledDelayMilliseconds, waitAndDelayCts.Token)).ConfigureAwait(false);
-#if NET8_0_OR_GREATER
+#if NET
                         await waitAndDelayCts.CancelAsync().ConfigureAwait(false);
 #else
                         waitAndDelayCts.Cancel();

--- a/src/OpenTelemetry/Internal/BatchExportThreadWorker.cs
+++ b/src/OpenTelemetry/Internal/BatchExportThreadWorker.cs
@@ -45,9 +45,7 @@ internal sealed class BatchExportThreadWorker<T> : BatchExportWorker<T>
 
     /// <inheritdoc/>
     public override void Start()
-    {
-        this.exporterThread.Start();
-    }
+        => this.exporterThread.Start();
 
     /// <inheritdoc/>
     public override bool TriggerExport()
@@ -86,9 +84,7 @@ internal sealed class BatchExportThreadWorker<T> : BatchExportWorker<T>
 
         var triggers = new WaitHandle[] { this.dataExportedNotification, this.shutdownTrigger };
 
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         // There is a chance that the export thread finished processing all the data from the queue,
         // and signaled before we enter wait here, use polling to prevent being blocked indefinitely.
@@ -96,34 +92,25 @@ internal sealed class BatchExportThreadWorker<T> : BatchExportWorker<T>
 
         while (true)
         {
-            if (sw == null)
-            {
-                try
-                {
-                    WaitHandle.WaitAny(triggers, pollingMilliseconds);
-                }
-                catch (ObjectDisposedException)
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
+            var timeout = pollingMilliseconds;
 
-                if (timeout <= 0)
+            if (timestamp is { } startedAt)
+            {
+                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+
+                if (timeoutMilliseconds <= 0)
                 {
                     return this.CircularBuffer.RemovedCount >= head;
                 }
+            }
 
-                try
-                {
-                    WaitHandle.WaitAny(triggers, Math.Min((int)timeout, pollingMilliseconds));
-                }
-                catch (ObjectDisposedException)
-                {
-                    return false;
-                }
+            try
+            {
+                WaitHandle.WaitAny(triggers, timeout);
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
             }
 
             if (this.CircularBuffer.RemovedCount >= head)
@@ -158,12 +145,7 @@ internal sealed class BatchExportThreadWorker<T> : BatchExportWorker<T>
             return true;
         }
 
-        if (timeoutMilliseconds == 0)
-        {
-            return true;
-        }
-
-        return this.exporterThread.Join(timeoutMilliseconds);
+        return timeoutMilliseconds == 0 || this.exporterThread.Join(timeoutMilliseconds);
     }
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry/Internal/BatchExportThreadWorker.cs
+++ b/src/OpenTelemetry/Internal/BatchExportThreadWorker.cs
@@ -84,6 +84,7 @@ internal sealed class BatchExportThreadWorker<T> : BatchExportWorker<T>
 
         var triggers = new WaitHandle[] { this.dataExportedNotification, this.shutdownTrigger };
 
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
         long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         // There is a chance that the export thread finished processing all the data from the queue,
@@ -96,12 +97,14 @@ internal sealed class BatchExportThreadWorker<T> : BatchExportWorker<T>
 
             if (timestamp is { } startedAt)
             {
-                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+                var remainingMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
 
-                if (timeoutMilliseconds <= 0)
+                if (remainingMilliseconds <= 0)
                 {
                     return this.CircularBuffer.RemovedCount >= head;
                 }
+
+                timeout = Math.Min(remainingMilliseconds, pollingMilliseconds);
             }
 
             try

--- a/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderTaskWorker.cs
+++ b/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderTaskWorker.cs
@@ -111,7 +111,8 @@ internal sealed class PeriodicExportingMetricReaderTaskWorker : PeriodicExportin
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var timeout = this.ExportIntervalMilliseconds - ((int)Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds % this.ExportIntervalMilliseconds);
+                var elapsedMilliseconds = Stopwatch.GetElapsedTime(startedAt).Ticks / TimeSpan.TicksPerMillisecond;
+                var timeout = this.ExportIntervalMilliseconds - (int)(elapsedMilliseconds % this.ExportIntervalMilliseconds);
 
                 Task? exportTriggerTask = null;
                 Task? triggeredTask = null;

--- a/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderTaskWorker.cs
+++ b/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderTaskWorker.cs
@@ -33,9 +33,7 @@ internal sealed class PeriodicExportingMetricReaderTaskWorker : PeriodicExportin
 
     /// <inheritdoc/>
     public override void Start()
-    {
-        this.workerTask = Task.Run(this.ExporterProcAsync);
-    }
+        => this.workerTask = Task.Run(this.ExporterProcAsync);
 
     /// <inheritdoc/>
     public override bool TriggerExport()
@@ -84,12 +82,7 @@ internal sealed class PeriodicExportingMetricReaderTaskWorker : PeriodicExportin
             return true;
         }
 
-        if (timeoutMilliseconds == 0)
-        {
-            return true;
-        }
-
-        return this.workerTask.Wait(timeoutMilliseconds);
+        return timeoutMilliseconds == 0 || this.workerTask.Wait(timeoutMilliseconds);
     }
 
     /// <inheritdoc/>
@@ -112,13 +105,13 @@ internal sealed class PeriodicExportingMetricReaderTaskWorker : PeriodicExportin
     private async Task ExporterProcAsync()
     {
         var cancellationToken = this.cancellationTokenSource.Token;
-        var sw = Stopwatch.StartNew();
+        var startedAt = Stopwatch.GetTimestamp();
 
         try
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var timeout = (int)(this.ExportIntervalMilliseconds - (sw.ElapsedMilliseconds % this.ExportIntervalMilliseconds));
+                var timeout = this.ExportIntervalMilliseconds - ((int)Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds % this.ExportIntervalMilliseconds);
 
                 Task? exportTriggerTask = null;
                 Task? triggeredTask = null;

--- a/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderThreadWorker.cs
+++ b/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderThreadWorker.cs
@@ -39,9 +39,7 @@ internal sealed class PeriodicExportingMetricReaderThreadWorker : PeriodicExport
 
     /// <inheritdoc/>
     public override void Start()
-    {
-        this.exporterThread.Start();
-    }
+        => this.exporterThread.Start();
 
     /// <inheritdoc/>
     public override bool TriggerExport()
@@ -75,12 +73,7 @@ internal sealed class PeriodicExportingMetricReaderThreadWorker : PeriodicExport
             return true;
         }
 
-        if (timeoutMilliseconds == 0)
-        {
-            return true;
-        }
-
-        return this.exporterThread.Join(timeoutMilliseconds);
+        return timeoutMilliseconds == 0 || this.exporterThread.Join(timeoutMilliseconds);
     }
 
     /// <inheritdoc/>
@@ -102,14 +95,13 @@ internal sealed class PeriodicExportingMetricReaderThreadWorker : PeriodicExport
 
     private void ExporterProc()
     {
-        int index;
-        int timeout;
         var triggers = new WaitHandle[] { this.exportTrigger, this.shutdownTrigger };
-        var sw = Stopwatch.StartNew();
+        var startedAt = Stopwatch.GetTimestamp();
 
         while (true)
         {
-            timeout = (int)(this.ExportIntervalMilliseconds - (sw.ElapsedMilliseconds % this.ExportIntervalMilliseconds));
+            var timeout = this.ExportIntervalMilliseconds - ((int)Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds % this.ExportIntervalMilliseconds);
+            int index;
 
             try
             {

--- a/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderThreadWorker.cs
+++ b/src/OpenTelemetry/Internal/PeriodicExportingMetricReaderThreadWorker.cs
@@ -100,7 +100,8 @@ internal sealed class PeriodicExportingMetricReaderThreadWorker : PeriodicExport
 
         while (true)
         {
-            var timeout = this.ExportIntervalMilliseconds - ((int)Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds % this.ExportIntervalMilliseconds);
+            var elapsedMilliseconds = Stopwatch.GetElapsedTime(startedAt).Ticks / TimeSpan.TicksPerMillisecond;
+            var timeout = this.ExportIntervalMilliseconds - (int)(elapsedMilliseconds % this.ExportIntervalMilliseconds);
             int index;
 
             try

--- a/src/OpenTelemetry/Metrics/Reader/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/BaseExportingMetricReader.cs
@@ -123,22 +123,16 @@ public class BaseExportingMetricReader : MetricReader
     /// <inheritdoc />
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
-        var result = true;
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
-        if (timeoutMilliseconds == Timeout.Infinite)
+        var result = this.Collect(timeoutMilliseconds);
+
+        if (timestamp is { } startedAt)
         {
-            result = this.Collect(Timeout.Infinite) && result;
-            result = this.exporter.Shutdown(Timeout.Infinite) && result;
-        }
-        else
-        {
-            var sw = Stopwatch.StartNew();
-            result = this.Collect(timeoutMilliseconds) && result;
-            var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
-            result = this.exporter.Shutdown((int)Math.Max(timeout, 0)) && result;
+            timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
         }
 
-        return result;
+        return this.exporter.Shutdown(timeoutMilliseconds) && result;
     }
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry/Metrics/Reader/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/BaseExportingMetricReader.cs
@@ -120,41 +120,15 @@ public class BaseExportingMetricReader : MetricReader
 
     /// <inheritdoc />
     internal override bool OnShutdownFromComposite(int timeoutMilliseconds)
-    {
-        var result = true;
-
-        if (timeoutMilliseconds == Timeout.Infinite)
-        {
-            result = this.CollectFromComposite(Timeout.Infinite) && result;
-            result = this.exporter.Shutdown(Timeout.Infinite) && result;
-        }
-        else
-        {
-            var sw = Stopwatch.StartNew();
-            result = this.CollectFromComposite(timeoutMilliseconds) && result;
-            var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
-            result = this.exporter.Shutdown((int)Math.Max(timeout, 0)) && result;
-        }
-
-        return result;
-    }
+        => base.OnShutdownFromComposite(timeoutMilliseconds);
 
     /// <inheritdoc />
-    protected override bool OnCollect(int timeoutMilliseconds)
-    {
-        if (this.SupportedExportModes.HasFlag(ExportModes.Push))
-        {
-            return base.OnCollect(timeoutMilliseconds);
-        }
-
-        if (this.SupportedExportModes.HasFlag(ExportModes.Pull) && PullMetricScope.IsPullAllowed)
-        {
-            return base.OnCollect(timeoutMilliseconds);
-        }
-
-        // TODO: add some error log
-        return false;
-    }
+    protected override bool OnCollect(int timeoutMilliseconds) =>
+        this.SupportedExportModes.HasFlag(ExportModes.Push)
+            ? base.OnCollect(timeoutMilliseconds)
+            : this.SupportedExportModes.HasFlag(ExportModes.Pull) &&
+              PullMetricScope.IsPullAllowed &&
+              base.OnCollect(timeoutMilliseconds);
 
     /// <inheritdoc />
     protected override bool OnShutdown(int timeoutMilliseconds)

--- a/src/OpenTelemetry/Metrics/Reader/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/CompositeMetricReader.cs
@@ -65,25 +65,23 @@ internal sealed partial class CompositeMetricReader : MetricReader
     protected override bool OnCollect(int timeoutMilliseconds)
     {
         var result = true;
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         this.CollectObservableInstruments();
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            if (sw == null)
-            {
-                result = cur.Value.CollectFromComposite(Timeout.Infinite) && result;
-            }
-            else
-            {
-                var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
+            var currentTimeoutMilliseconds = timeoutMilliseconds;
 
-                // notify all the readers, even if we run overtime
-                result = cur.Value.CollectFromComposite((int)Math.Max(timeout, 0)) && result;
+            if (timestamp is { } startedAt)
+            {
+                currentTimeoutMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
             }
+
+            // Collect observable instruments once at the composite level, then
+            // let child readers process the same snapshot.
+            result = current.Value.CollectFromComposite(currentTimeoutMilliseconds) && result;
         }
 
         return result;
@@ -93,25 +91,21 @@ internal sealed partial class CompositeMetricReader : MetricReader
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
         var result = true;
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
-
         this.CollectObservableInstruments();
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            if (sw == null)
-            {
-                result = cur.Value.ShutdownFromComposite(Timeout.Infinite) && result;
-            }
-            else
-            {
-                var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
+            var currentTimeoutMilliseconds = timeoutMilliseconds;
 
-                // notify all the readers, even if we run overtime
-                result = cur.Value.ShutdownFromComposite((int)Math.Max(timeout, 0)) && result;
+            if (timestamp is { } startedAt)
+            {
+                currentTimeoutMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
             }
+
+            // Notify all the readers, even if we run overtime
+            result = current.Value.ShutdownFromComposite(currentTimeoutMilliseconds) && result;
         }
 
         return result;
@@ -123,11 +117,11 @@ internal sealed partial class CompositeMetricReader : MetricReader
         {
             if (disposing)
             {
-                for (var cur = this.Head; cur != null; cur = cur.Next)
+                for (var current = this.Head; current != null; current = current.Next)
                 {
                     try
                     {
-                        cur.Value?.Dispose();
+                        current.Value?.Dispose();
                     }
                     catch (Exception ex)
                     {

--- a/src/OpenTelemetry/Metrics/Reader/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/CompositeMetricReader.cs
@@ -65,17 +65,20 @@ internal sealed partial class CompositeMetricReader : MetricReader
     protected override bool OnCollect(int timeoutMilliseconds = Timeout.Infinite)
     {
         var result = true;
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
         long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         for (var current = this.Head; current != null; current = current.Next)
         {
+            var currentTimeoutMilliseconds = timeoutMilliseconds;
+
             if (timestamp is { } startedAt)
             {
-                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+                currentTimeoutMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
             }
 
             // Notify all the readers, even if we run overtime
-            result = current.Value.Collect(timeoutMilliseconds) && result;
+            result = current.Value.Collect(currentTimeoutMilliseconds) && result;
         }
 
         return result;
@@ -85,17 +88,20 @@ internal sealed partial class CompositeMetricReader : MetricReader
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
         var result = true;
+        var initialTimeoutMilliseconds = timeoutMilliseconds;
         long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         for (var current = this.Head; current != null; current = current.Next)
         {
+            var currentTimeoutMilliseconds = timeoutMilliseconds;
+
             if (timestamp is { } startedAt)
             {
-                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
+                currentTimeoutMilliseconds = Stopwatch.Remaining(initialTimeoutMilliseconds, startedAt);
             }
 
             // Notify all the readers, even if we run overtime
-            result = current.Value.Shutdown(timeoutMilliseconds) && result;
+            result = current.Value.Shutdown(currentTimeoutMilliseconds) && result;
         }
 
         return result;

--- a/src/OpenTelemetry/Metrics/Reader/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/CompositeMetricReader.cs
@@ -54,35 +54,28 @@ internal sealed partial class CompositeMetricReader : MetricReader
 
     public Enumerator GetEnumerator() => new(this.Head);
 
+    // CompositeMetricReader delegates the work to its underlying readers,
+    // so CompositeMetricReader.ProcessMetrics should never be called.
+
     /// <inheritdoc/>
     internal override bool ProcessMetrics(in Batch<Metric> metrics, int timeoutMilliseconds)
-    {
-        // CompositeMetricReader delegates the work to its underlying readers,
-        // so CompositeMetricReader.ProcessMetrics should never be called.
-        throw new NotSupportedException();
-    }
+        => throw new NotSupportedException();
 
     /// <inheritdoc/>
     protected override bool OnCollect(int timeoutMilliseconds = Timeout.Infinite)
     {
         var result = true;
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            if (sw == null)
+            if (timestamp is { } startedAt)
             {
-                result = cur.Value.Collect(Timeout.Infinite) && result;
+                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
             }
-            else
-            {
-                var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
 
-                // notify all the readers, even if we run overtime
-                result = cur.Value.Collect((int)Math.Max(timeout, 0)) && result;
-            }
+            // Notify all the readers, even if we run overtime
+            result = current.Value.Collect(timeoutMilliseconds) && result;
         }
 
         return result;
@@ -92,23 +85,17 @@ internal sealed partial class CompositeMetricReader : MetricReader
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
         var result = true;
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            if (sw == null)
+            if (timestamp is { } startedAt)
             {
-                result = cur.Value.Shutdown(Timeout.Infinite) && result;
+                timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
             }
-            else
-            {
-                var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
 
-                // notify all the readers, even if we run overtime
-                result = cur.Value.Shutdown((int)Math.Max(timeout, 0)) && result;
-            }
+            // Notify all the readers, even if we run overtime
+            result = current.Value.Shutdown(timeoutMilliseconds) && result;
         }
 
         return result;
@@ -120,11 +107,11 @@ internal sealed partial class CompositeMetricReader : MetricReader
         {
             if (disposing)
             {
-                for (var cur = this.Head; cur != null; cur = cur.Next)
+                for (var current = this.Head; current != null; current = current.Next)
                 {
                     try
                     {
-                        cur.Value?.Dispose();
+                        current.Value?.Dispose();
                     }
                     catch (Exception ex)
                     {

--- a/src/OpenTelemetry/Metrics/Reader/CompositeMetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/Reader/CompositeMetricReaderExt.cs
@@ -15,9 +15,9 @@ internal sealed partial class CompositeMetricReader
     {
         var metrics = new List<Metric>(this.count);
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            var innerMetrics = cur.Value.AddMetricWithNoViews(instrument);
+            var innerMetrics = current.Value.AddMetricWithNoViews(instrument);
             if (innerMetrics.Count > 0)
             {
                 Debug.Assert(innerMetrics.Count == 1, "Multiple metrics returned without view configuration");
@@ -33,9 +33,9 @@ internal sealed partial class CompositeMetricReader
     {
         var metrics = new List<Metric>(this.count * metricStreamConfigs.Count);
 
-        for (var cur = this.Head; cur != null; cur = cur.Next)
+        for (var current = this.Head; current != null; current = current.Next)
         {
-            var innerMetrics = cur.Value.AddMetricWithViews(instrument, metricStreamConfigs);
+            var innerMetrics = current.Value.AddMetricWithViews(instrument, metricStreamConfigs);
 
             metrics.AddRange(innerMetrics);
         }

--- a/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
@@ -290,9 +290,7 @@ public abstract partial class MetricReader : IDisposable
     {
         OpenTelemetrySdkEventSource.Log.MetricReaderEvent("MetricReader.OnCollect called.");
 
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         var meterProviderSdk = this.parentProvider as MeterProviderSdk;
         meterProviderSdk?.CollectObservableInstruments();
@@ -301,45 +299,30 @@ public abstract partial class MetricReader : IDisposable
 
         var metrics = this.GetMetricsBatch();
 
-        bool result;
-        if (sw == null)
+        if (timestamp is { } startedAt)
         {
-            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics called.");
-            result = this.ProcessMetrics(metrics, Timeout.Infinite);
-            if (result)
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics succeeded.");
-            }
-            else
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics failed.");
-            }
+            timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
 
-            return result;
-        }
-        else
-        {
-            var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
-
-            if (timeout <= 0)
+            if (timeoutMilliseconds <= 0)
             {
                 OpenTelemetrySdkEventSource.Log.MetricReaderEvent("OnCollect failed timeout period has elapsed.");
                 return false;
             }
-
-            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics called.");
-            result = this.ProcessMetrics(metrics, (int)timeout);
-            if (result)
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics succeeded.");
-            }
-            else
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics failed.");
-            }
-
-            return result;
         }
+
+        OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics called.");
+
+        var result = this.ProcessMetrics(metrics, Timeout.Infinite);
+        if (result)
+        {
+            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics succeeded.");
+        }
+        else
+        {
+            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics failed.");
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
@@ -312,7 +312,7 @@ public abstract partial class MetricReader : IDisposable
 
         OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics called.");
 
-        var result = this.ProcessMetrics(metrics, Timeout.Infinite);
+        var result = this.ProcessMetrics(metrics, timeoutMilliseconds);
         if (result)
         {
             OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics succeeded.");

--- a/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
@@ -14,11 +14,11 @@ public abstract partial class MetricReader : IDisposable
 {
     private const MetricReaderTemporalityPreference MetricReaderTemporalityPreferenceUnspecified = 0;
 
-    private static readonly Func<Type, AggregationTemporality> CumulativeTemporalityPreferenceFunc = static (_) => AggregationTemporality.Cumulative;
+    private static readonly Func<Type, AggregationTemporality> CumulativeTemporalityPreferenceFunc =
+        static (_) => AggregationTemporality.Cumulative;
 
-    private static readonly Func<Type, AggregationTemporality> MonotonicDeltaTemporalityPreferenceFunc = (instrumentType) =>
-    {
-        return instrumentType.GetGenericTypeDefinition() switch
+    private static readonly Func<Type, AggregationTemporality> MonotonicDeltaTemporalityPreferenceFunc =
+        static (instrumentType) => instrumentType.GetGenericTypeDefinition() switch
         {
             var type when type == typeof(Counter<>) => AggregationTemporality.Delta,
             var type when type == typeof(ObservableCounter<>) => AggregationTemporality.Delta,
@@ -34,11 +34,9 @@ public abstract partial class MetricReader : IDisposable
             // TODO: Consider logging here because we should not fall through to this case.
             _ => AggregationTemporality.Delta,
         };
-    };
 
-    private static readonly Func<Type, AggregationTemporality> LowMemoryTemporalityPreferenceFunc = (instrumentType) =>
-    {
-        return instrumentType.GetGenericTypeDefinition() switch
+    private static readonly Func<Type, AggregationTemporality> LowMemoryTemporalityPreferenceFunc =
+        static (instrumentType) => instrumentType.GetGenericTypeDefinition() switch
         {
             var type when type == typeof(Counter<>) => AggregationTemporality.Delta,
             var type when type == typeof(Histogram<>) => AggregationTemporality.Delta,
@@ -49,12 +47,12 @@ public abstract partial class MetricReader : IDisposable
 
             _ => AggregationTemporality.Cumulative,
         };
-    };
 
     private readonly Lock newTaskLock = new();
     private readonly Lock onCollectLock = new();
     private readonly TaskCompletionSource<bool> shutdownTcs = new();
     private Func<Type, AggregationTemporality> temporalityFunc = CumulativeTemporalityPreferenceFunc;
+    private int suppressObservableInstrumentsCollection;
     private int shutdownCount;
     private TaskCompletionSource<bool>? collectionTcs;
     private BaseProvider? parentProvider;
@@ -157,7 +155,14 @@ public abstract partial class MetricReader : IDisposable
         => this.Shutdown(timeoutMilliseconds, fromComposite: true);
 
     internal void CollectObservableInstruments()
-        => (this.parentProvider as MeterProviderSdk)?.CollectObservableInstruments();
+    {
+        if (this.suppressObservableInstrumentsCollection > 0)
+        {
+            return;
+        }
+
+        (this.parentProvider as MeterProviderSdk)?.CollectObservableInstruments();
+    }
 
     internal virtual void SetParentProvider(BaseProvider parentProvider)
     {
@@ -200,12 +205,16 @@ public abstract partial class MetricReader : IDisposable
     internal virtual bool OnCollectFromComposite(int timeoutMilliseconds)
     {
         OpenTelemetrySdkEventSource.Log.MetricReaderEvent("MetricReader.OnCollectFromComposite called.");
+        this.suppressObservableInstrumentsCollection++;
 
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
-
-        return this.ProcessMetricsCollection(sw, timeoutMilliseconds);
+        try
+        {
+            return this.OnCollect(timeoutMilliseconds);
+        }
+        finally
+        {
+            this.suppressObservableInstrumentsCollection--;
+        }
     }
 
     /// <summary>
@@ -220,7 +229,18 @@ public abstract partial class MetricReader : IDisposable
     /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.
     /// </returns>
     internal virtual bool OnShutdownFromComposite(int timeoutMilliseconds)
-        => this.OnShutdown(timeoutMilliseconds);
+    {
+        this.suppressObservableInstrumentsCollection++;
+
+        try
+        {
+            return this.OnShutdown(timeoutMilliseconds);
+        }
+        finally
+        {
+            this.suppressObservableInstrumentsCollection--;
+        }
+    }
 
     /// <summary>
     /// Called by <c>Collect</c>. This function should block the current
@@ -243,15 +263,13 @@ public abstract partial class MetricReader : IDisposable
     {
         OpenTelemetrySdkEventSource.Log.MetricReaderEvent("MetricReader.OnCollect called.");
 
-        var sw = timeoutMilliseconds == Timeout.Infinite
-            ? null
-            : Stopwatch.StartNew();
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         this.CollectObservableInstruments();
 
         OpenTelemetrySdkEventSource.Log.MetricReaderEvent("Observable instruments collected.");
 
-        return this.ProcessMetricsCollection(sw, timeoutMilliseconds);
+        return this.ProcessMetricsCollection(timestamp, timeoutMilliseconds);
     }
 
     /// <summary>
@@ -389,50 +407,35 @@ public abstract partial class MetricReader : IDisposable
         return result;
     }
 
-    private bool ProcessMetricsCollection(Stopwatch? sw, int timeoutMilliseconds)
+    private bool ProcessMetricsCollection(long? startedAtTimestamp, int timeoutMilliseconds)
     {
         OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetricsCollection called.");
 
         var metrics = this.GetMetricsBatch();
 
-        bool result;
-        if (sw == null)
+        if (startedAtTimestamp is { } startedAt)
         {
-            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics called.");
-            result = this.ProcessMetrics(metrics, Timeout.Infinite);
-            if (result)
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics succeeded.");
-            }
-            else
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics failed.");
-            }
+            timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
 
-            return result;
-        }
-        else
-        {
-            var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
-
-            if (timeout <= 0)
+            if (timeoutMilliseconds <= 0)
             {
                 OpenTelemetrySdkEventSource.Log.MetricReaderEvent("OnCollect failed timeout period has elapsed.");
                 return false;
             }
-
-            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics called.");
-            result = this.ProcessMetrics(metrics, (int)timeout);
-            if (result)
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics succeeded.");
-            }
-            else
-            {
-                OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics failed.");
-            }
-
-            return result;
         }
+
+        OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics called.");
+
+        var result = this.ProcessMetrics(metrics, timeoutMilliseconds);
+        if (result)
+        {
+            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics succeeded.");
+        }
+        else
+        {
+            OpenTelemetrySdkEventSource.Log.MetricReaderEvent("ProcessMetrics failed.");
+        }
+
+        return result;
     }
 }

--- a/src/OpenTelemetry/Metrics/Reader/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/PeriodicExportingMetricReader.cs
@@ -52,36 +52,16 @@ public class PeriodicExportingMetricReader : BaseExportingMetricReader
     /// <inheritdoc />
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
-        Stopwatch? shutdownStopwatch = null;
-        if (timeoutMilliseconds > 0)
-        {
-            shutdownStopwatch = Stopwatch.StartNew();
-        }
+        long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         var result = this.worker.Shutdown(timeoutMilliseconds);
 
-        if (timeoutMilliseconds == Timeout.Infinite)
+        if (timestamp is { } startedAt)
         {
-            return this.exporter.Shutdown() && result;
+            timeoutMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt);
         }
 
-        if (timeoutMilliseconds == 0)
-        {
-            return this.exporter.Shutdown(0) && result;
-        }
-
-        int remainingTimeout = timeoutMilliseconds;
-        if (shutdownStopwatch != null)
-        {
-            shutdownStopwatch.Stop();
-            remainingTimeout -= (int)shutdownStopwatch.ElapsedMilliseconds;
-            if (remainingTimeout < 0)
-            {
-                remainingTimeout = 0;
-            }
-        }
-
-        return this.exporter.Shutdown(remainingTimeout) && result;
+        return this.exporter.Shutdown(timeoutMilliseconds) && result;
     }
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ThreadSafeRandom.cs" Link="Includes\ThreadSafeRandom.cs" />
   </ItemGroup>
 

--- a/src/Shared/StopwatchExtensions.cs
+++ b/src/Shared/StopwatchExtensions.cs
@@ -5,16 +5,18 @@ namespace System.Diagnostics;
 
 internal static class StopwatchExtensions
 {
+#if !NET
+    private static readonly double ToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+#endif
+
     extension(Stopwatch)
     {
 #if !NET
         public static TimeSpan GetElapsedTime(long begin)
         {
             var end = Stopwatch.GetTimestamp();
-
-            var timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
             var delta = end - begin;
-            var ticks = (long)(timestampToTicks * delta);
+            var ticks = (long)(ToTicks * delta);
 
             return new TimeSpan(ticks);
         }
@@ -22,8 +24,10 @@ internal static class StopwatchExtensions
 
         public static int Remaining(int durationMilliseconds, long begin)
         {
-            var elapsed = (int)Stopwatch.GetElapsedTime(begin).TotalMilliseconds;
-            return elapsed >= durationMilliseconds ? 0 : durationMilliseconds - elapsed;
+            var elapsedMilliseconds = Stopwatch.GetElapsedTime(begin).Ticks / TimeSpan.TicksPerMillisecond;
+            elapsedMilliseconds = elapsedMilliseconds < 0 ? 0 : elapsedMilliseconds > int.MaxValue ? int.MaxValue : elapsedMilliseconds;
+
+            return elapsedMilliseconds >= durationMilliseconds ? 0 : durationMilliseconds - (int)elapsedMilliseconds;
         }
     }
 }

--- a/src/Shared/StopwatchExtensions.cs
+++ b/src/Shared/StopwatchExtensions.cs
@@ -9,7 +9,9 @@ internal static class StopwatchExtensions
     private static readonly double ToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 #endif
 
+#pragma warning disable SA1201 // A <unknown> should not follow a field
     extension(Stopwatch)
+#pragma warning disable SA1201 // A <unknown> should not follow a field
     {
 #if !NET
         public static TimeSpan GetElapsedTime(long begin)

--- a/src/Shared/StopwatchExtensions.cs
+++ b/src/Shared/StopwatchExtensions.cs
@@ -1,16 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma warning disable SA1201 // A <unknown> should not follow a field
-
 namespace System.Diagnostics;
 
 internal static class StopwatchExtensions
 {
-#if !NET
-    private static readonly double ToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
-#endif
-
     extension(Stopwatch)
     {
 #if !NET
@@ -18,7 +12,7 @@ internal static class StopwatchExtensions
         {
             var end = Stopwatch.GetTimestamp();
             var delta = end - begin;
-            var ticks = (long)(ToTicks * delta);
+            var ticks = (long)(Conversion.ToTicks * delta);
 
             return new TimeSpan(ticks);
         }
@@ -32,4 +26,11 @@ internal static class StopwatchExtensions
             return elapsedMilliseconds >= durationMilliseconds ? 0 : durationMilliseconds - (int)elapsedMilliseconds;
         }
     }
+
+#if !NET
+    private static class Conversion
+    {
+        internal static readonly double ToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+    }
+#endif
 }

--- a/src/Shared/StopwatchExtensions.cs
+++ b/src/Shared/StopwatchExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma warning disable SA1201 // A <unknown> should not follow a field
+
 namespace System.Diagnostics;
 
 internal static class StopwatchExtensions
@@ -9,9 +11,7 @@ internal static class StopwatchExtensions
     private static readonly double ToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 #endif
 
-#pragma warning disable SA1201 // A <unknown> should not follow a field
     extension(Stopwatch)
-#pragma warning disable SA1201 // A <unknown> should not follow a field
     {
 #if !NET
         public static TimeSpan GetElapsedTime(long begin)

--- a/src/Shared/StopwatchExtensions.cs
+++ b/src/Shared/StopwatchExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace System.Diagnostics;
+
+internal static class StopwatchExtensions
+{
+    extension(Stopwatch)
+    {
+#if !NET
+        public static TimeSpan GetElapsedTime(long begin)
+        {
+            var end = Stopwatch.GetTimestamp();
+
+            var timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+            var delta = end - begin;
+            var ticks = (long)(timestampToTicks * delta);
+
+            return new TimeSpan(ticks);
+        }
+#endif
+
+        public static int Remaining(int durationMilliseconds, long begin)
+        {
+            var elapsed = (int)Stopwatch.GetElapsedTime(begin).TotalMilliseconds;
+            return elapsed >= durationMilliseconds ? 0 : durationMilliseconds - elapsed;
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
+++ b/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\OpenTelemetry.Exporter.Prometheus.HttpListener.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
+  </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
+++ b/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA1515</NoWarn>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
     <ReferenceSystemTextJsonPackages>true</ReferenceSystemTextJsonPackages>
@@ -15,10 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\OpenTelemetry.Exporter.Prometheus.HttpListener.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
+++ b/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <NoWarn>$(NoWarn);CA1515</NoWarn>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
     <ReferenceSystemTextJsonPackages>true</ReferenceSystemTextJsonPackages>

--- a/test/OpenTelemetry.Tests.Stress/StressTests.cs
+++ b/test/OpenTelemetry.Tests.Stress/StressTests.cs
@@ -76,7 +76,7 @@ public abstract class StressTests<T> : IDisposable
             .Build() : null;
 
         var statistics = new MeasurementData[options.Concurrency];
-        var startedTimestamp = Stopwatch.GetTimestamp();
+        var watchForTotal = Stopwatch.StartNew();
 
         TimeSpan? duration = options.DurationSeconds > 0
             ? TimeSpan.FromSeconds(options.DurationSeconds)
@@ -153,7 +153,7 @@ public abstract class StressTests<T> : IDisposable
                     dLoopsPerSecond = nLoops / (watch.ElapsedMilliseconds / 1000.0);
                     dCpuCyclesPerLoop = nLoops == 0 ? 0 : nCpuCycles / nLoops;
 
-                    var totalElapsedTime = Stopwatch.GetElapsedTime(startedTimestamp);
+                    var totalElapsedTime = watchForTotal.Elapsed;
 
                     if (duration.HasValue)
                     {
@@ -186,14 +186,13 @@ public abstract class StressTests<T> : IDisposable
                 });
             });
 
+        watchForTotal.Stop();
         cntLoopsTotal = (ulong)statistics.Sum(data => data.Count);
-
-        var totalElapsedTime = Stopwatch.GetElapsedTime(startedTimestamp);
-        var totalLoopsPerSecond = cntLoopsTotal / (totalElapsedTime.TotalMilliseconds / 1000.0);
+        var totalLoopsPerSecond = cntLoopsTotal / (watchForTotal.ElapsedMilliseconds / 1000.0);
         var cntCpuCyclesTotal = StressTestNativeMethods.GetCpuCycles();
         var cpuCyclesPerLoopTotal = cntLoopsTotal == 0 ? 0 : cntCpuCyclesTotal / cntLoopsTotal;
         Console.WriteLine("Stopping the stress test...");
-        Console.WriteLine($"* Total Running Time (Seconds) {totalElapsedTime.TotalSeconds:n0}");
+        Console.WriteLine($"* Total Running Time (Seconds) {watchForTotal.Elapsed.TotalSeconds:n0}");
         Console.WriteLine($"* Total Loops: {cntLoopsTotal:n0}");
         Console.WriteLine($"* Average Loops/Second: {totalLoopsPerSecond:n0}");
         Console.WriteLine($"* Average CPU Cycles/Loop: {cpuCyclesPerLoopTotal:n0}");

--- a/test/OpenTelemetry.Tests.Stress/StressTests.cs
+++ b/test/OpenTelemetry.Tests.Stress/StressTests.cs
@@ -76,7 +76,7 @@ public abstract class StressTests<T> : IDisposable
             .Build() : null;
 
         var statistics = new MeasurementData[options.Concurrency];
-        var watchForTotal = Stopwatch.StartNew();
+        var startedTimestamp = Stopwatch.GetTimestamp();
 
         TimeSpan? duration = options.DurationSeconds > 0
             ? TimeSpan.FromSeconds(options.DurationSeconds)
@@ -153,7 +153,7 @@ public abstract class StressTests<T> : IDisposable
                     dLoopsPerSecond = nLoops / (watch.ElapsedMilliseconds / 1000.0);
                     dCpuCyclesPerLoop = nLoops == 0 ? 0 : nCpuCycles / nLoops;
 
-                    var totalElapsedTime = watchForTotal.Elapsed;
+                    var totalElapsedTime = Stopwatch.GetElapsedTime(startedTimestamp);
 
                     if (duration.HasValue)
                     {
@@ -186,13 +186,14 @@ public abstract class StressTests<T> : IDisposable
                 });
             });
 
-        watchForTotal.Stop();
         cntLoopsTotal = (ulong)statistics.Sum(data => data.Count);
-        var totalLoopsPerSecond = cntLoopsTotal / (watchForTotal.ElapsedMilliseconds / 1000.0);
+
+        var totalElapsedTime = Stopwatch.GetElapsedTime(startedTimestamp);
+        var totalLoopsPerSecond = cntLoopsTotal / (totalElapsedTime.TotalMilliseconds / 1000.0);
         var cntCpuCyclesTotal = StressTestNativeMethods.GetCpuCycles();
         var cpuCyclesPerLoopTotal = cntLoopsTotal == 0 ? 0 : cntCpuCyclesTotal / cntLoopsTotal;
         Console.WriteLine("Stopping the stress test...");
-        Console.WriteLine($"* Total Running Time (Seconds) {watchForTotal.Elapsed.TotalSeconds:n0}");
+        Console.WriteLine($"* Total Running Time (Seconds) {totalElapsedTime.TotalSeconds:n0}");
         Console.WriteLine($"* Total Loops: {cntLoopsTotal:n0}");
         Console.WriteLine($"* Average Loops/Second: {totalLoopsPerSecond:n0}");
         Console.WriteLine($"* Average CPU Cycles/Loop: {cpuCyclesPerLoopTotal:n0}");

--- a/test/OpenTelemetry.Tests/Internal/StopwatchExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/StopwatchExtensionsTests.cs
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using Xunit;
+
+namespace OpenTelemetry.Internal.Tests;
+
+public static class StopwatchExtensionsTests
+{
+    [Fact]
+    public static void Remaining_ClampsElapsedMillisecondsPastIntMaxValue()
+    {
+        var elapsed = TimeSpan.FromDays(30);
+        var elapsedTimestampTicks = (long)(elapsed.Ticks * (Stopwatch.Frequency / (double)TimeSpan.TicksPerSecond));
+        var begin = Stopwatch.GetTimestamp() - elapsedTimestampTicks;
+
+        var remaining = Stopwatch.Remaining(1000, begin);
+
+        Assert.Equal(0, remaining);
+    }
+}

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
@@ -2487,7 +2487,7 @@ public class MetricApiTests : MetricTestsBase
         }
 
         argToThread.MreToEnsureAllThreadsStart.WaitOne();
-        var sw = Stopwatch.StartNew();
+        var startedTimestamp = Stopwatch.GetTimestamp();
         argToThread.MreToBlockUpdateThread.Set();
 
         for (var i = 0; i < NumberOfThreads; i++)
@@ -2495,7 +2495,8 @@ public class MetricApiTests : MetricTestsBase
             t[i].Join();
         }
 
-        this.output.WriteLine($"Took {sw.ElapsedMilliseconds} msecs. Total threads: {NumberOfThreads}, each thread doing {NumberOfMetricUpdateByEachThread} recordings.");
+        var elapsed = Stopwatch.GetElapsedTime(startedTimestamp);
+        this.output.WriteLine($"Took {elapsed.TotalMilliseconds} msecs. Total threads: {NumberOfThreads}, each thread doing {NumberOfMetricUpdateByEachThread} recordings.");
 
         meterProvider.ForceFlush();
 

--- a/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
@@ -303,6 +303,33 @@ public class MultipleReadersTests
         }
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CompositeMetricReader_PreservesOriginalTimeoutBudget(bool shutdown)
+    {
+        const int delayMilliseconds = 200;
+        const int timeoutMilliseconds = 1500;
+
+        using var first = new TimeoutCapturingMetricReader(delayMilliseconds);
+        using var second = new TimeoutCapturingMetricReader(delayMilliseconds);
+        using var third = new TimeoutCapturingMetricReader();
+
+        using var composite = new CompositeMetricReader([first, second, third]);
+
+        if (shutdown)
+        {
+            composite.Shutdown(timeoutMilliseconds);
+        }
+        else
+        {
+            composite.Collect(timeoutMilliseconds);
+        }
+
+        Assert.Equal(timeoutMilliseconds, shutdown ? first.LastShutdownTimeoutMilliseconds : first.LastCollectTimeoutMilliseconds);
+        Assert.InRange(shutdown ? third.LastShutdownTimeoutMilliseconds : third.LastCollectTimeoutMilliseconds, 1000, timeoutMilliseconds);
+    }
+
     private static void AssertLongSumValueForMetric(Metric metric, long value)
     {
         var metricPoints = metric.GetMetricPoints();
@@ -317,5 +344,33 @@ public class MultipleReadersTests
         {
             Assert.Equal(value, metricPointForFirstExport.GetGaugeLastValueLong());
         }
+    }
+
+#pragma warning disable CA2000 // BaseExportingMetricReader owns the exporter lifecycle
+    private sealed class TimeoutCapturingMetricReader(int delayMilliseconds = 0) : BaseExportingMetricReader(new TimeoutCapturingMetricExporter())
+#pragma warning restore CA2000
+    {
+        public int LastCollectTimeoutMilliseconds { get; private set; } = Timeout.Infinite;
+
+        public int LastShutdownTimeoutMilliseconds { get; private set; } = Timeout.Infinite;
+
+        protected override bool OnCollect(int timeoutMilliseconds)
+        {
+            this.LastCollectTimeoutMilliseconds = timeoutMilliseconds;
+            Thread.Sleep(delayMilliseconds);
+            return true;
+        }
+
+        protected override bool OnShutdown(int timeoutMilliseconds)
+        {
+            this.LastShutdownTimeoutMilliseconds = timeoutMilliseconds;
+            Thread.Sleep(delayMilliseconds);
+            return true;
+        }
+    }
+
+    private sealed class TimeoutCapturingMetricExporter : BaseExporter<Metric>
+    {
+        public override ExportResult Export(in Batch<Metric> batch) => ExportResult.Success;
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
@@ -106,7 +106,53 @@ public class CompositeActivityProcessorTests
         Assert.Equal(provider, p2.ParentProvider);
     }
 
-    private sealed class TestProvider : TracerProvider
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CompositeActivityProcessor_PreservesOriginalTimeoutBudget(bool shutdown)
     {
+        const int delayMilliseconds = 200;
+        const int timeoutMilliseconds = 1500;
+
+        using var first = new TimeoutCapturingActivityProcessor(delayMilliseconds);
+        using var second = new TimeoutCapturingActivityProcessor(delayMilliseconds);
+        using var third = new TimeoutCapturingActivityProcessor();
+
+        using var composite = new CompositeProcessor<Activity>([first, second, third]);
+
+        if (shutdown)
+        {
+            composite.Shutdown(timeoutMilliseconds);
+        }
+        else
+        {
+            composite.ForceFlush(timeoutMilliseconds);
+        }
+
+        Assert.Equal(timeoutMilliseconds, shutdown ? first.LastShutdownTimeoutMilliseconds : first.LastForceFlushTimeoutMilliseconds);
+        Assert.InRange(shutdown ? third.LastShutdownTimeoutMilliseconds : third.LastForceFlushTimeoutMilliseconds, 1000, timeoutMilliseconds);
+    }
+
+    private sealed class TestProvider : TracerProvider;
+
+    private sealed class TimeoutCapturingActivityProcessor(int delayMilliseconds = 0) : BaseProcessor<Activity>
+    {
+        public int LastForceFlushTimeoutMilliseconds { get; private set; } = Timeout.Infinite;
+
+        public int LastShutdownTimeoutMilliseconds { get; private set; } = Timeout.Infinite;
+
+        protected override bool OnForceFlush(int timeoutMilliseconds)
+        {
+            this.LastForceFlushTimeoutMilliseconds = timeoutMilliseconds;
+            Thread.Sleep(delayMilliseconds);
+            return true;
+        }
+
+        protected override bool OnShutdown(int timeoutMilliseconds)
+        {
+            this.LastShutdownTimeoutMilliseconds = timeoutMilliseconds;
+            Thread.Sleep(delayMilliseconds);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Refactoring opportunity I spotted while doing other work that relates to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4300.

## Changes

- Add a polyfill for `Stopwatch.GetElapsedTime()` for `netstandard2.0` and `net462` for use instead of allocating `Stopwatch`s.
- Simplify timeout computations and duplicative code.
- Rename `cur` to `current` for readability.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
