### PR TITLE
[Exporter.Console] Handle null attribute keys gracefully

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -89,7 +89,7 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
                     // Special casing {OriginalFormat}
                     // See https://github.com/open-telemetry/opentelemetry-dotnet/pull/3182
                     // for explanation.
-                    var valueToTransform = logRecord.Attributes[i].Key.Equals("{OriginalFormat}", StringComparison.Ordinal)
+                    var valueToTransform = string.Equals(logRecord.Attributes[i].Key, "{OriginalFormat}", StringComparison.Ordinal)
                         ? new KeyValuePair<string, object?>("OriginalFormat (a.k.a Body)", logRecord.Attributes[i].Value)
                         : logRecord.Attributes[i];
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTests.cs
@@ -215,6 +215,47 @@ public class ConsoleLogRecordExporterTests
     }
 
     [Fact]
+    public void Export_WithAttributesContainingNullKey_DoesNotThrow()
+    {
+        // Arrange
+        var logRecords = new List<LogRecord>();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddOpenTelemetry(options =>
+            {
+                options.ParseStateValues = true;
+                options.AddInMemoryExporter(logRecords);
+            });
+        });
+
+        var state = new List<KeyValuePair<string, object?>>
+        {
+            new(null!, "value"),
+            new("{OriginalFormat}", "Test log"),
+        };
+
+        var logger = loggerFactory.CreateLogger<ConsoleLogRecordExporterTests>();
+
+        // Act
+        logger.Log(
+            LogLevel.Information,
+            default,
+            state,
+            exception: null,
+            formatter: static (s, _) => s[1].Value?.ToString() ?? string.Empty);
+
+        // Assert
+        var logRecord = Assert.Single(logRecords);
+        Assert.NotNull(logRecord.Attributes);
+        Assert.Null(logRecord.Attributes[0].Key);
+
+        using var exporter = new ConsoleLogRecordExporter(new ConsoleExporterOptions());
+        var result = exporter.Export(new Batch<LogRecord>([.. logRecords], logRecords.Count));
+
+        Assert.Equal(ExportResult.Success, result);
+    }
+
+    [Fact]
     public void Export_AfterDispose_ReturnsFailure()
     {
         // Arrange


### PR DESCRIPTION
Found by Codex scanings.

Super defensive programming as it should never occur by the nullability contract.

## Changes

[Exporter.Console] Handle null attribute keys gracefully
Changelog intentionally omitted.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
