### PR TITLE
[Infra] Disallow instance string.Equals methods

### DIFF
--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -50,6 +50,8 @@ M:System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.SByte@); Use ove
 M:System.SByte.TryParse(System.String,System.SByte@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.String,System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
+M:System.String.Equals(System.String); Use the static string.Equals(string, string) method instead.
+M:System.String.Equals(System.String,System.StringComparison); Use the static string.Equals(string, string, StringComparison) method instead.
 M:System.TimeOnly.TryParse(System.ReadOnlySpan{System.Char},System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeOnly.TryParse(System.String,System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeSpan.TryParse(System.ReadOnlySpan{System.Char},System.TimeSpan@); Use overloads that specify CultureInfo.InvariantCulture.

--- a/build/BannedSymbols.txt
+++ b/build/BannedSymbols.txt
@@ -50,8 +50,8 @@ M:System.SByte.TryParse(System.ReadOnlySpan{System.Char},System.SByte@); Use ove
 M:System.SByte.TryParse(System.String,System.SByte@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.ReadOnlySpan{System.Char},System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.Single.TryParse(System.String,System.Single@); Use overloads that specify CultureInfo.InvariantCulture.
-M:System.String.Equals(System.String); Use the static string.Equals(string, string) method instead.
-M:System.String.Equals(System.String,System.StringComparison); Use the static string.Equals(string, string, StringComparison) method instead.
+M:System.String.Equals(System.String); Use the static string.Equals(string, string) method instead to avoid potential NullReferenceException.
+M:System.String.Equals(System.String,System.StringComparison); Use the static string.Equals(string, string, StringComparison) method instead to avoid potential NullReferenceException.
 M:System.TimeOnly.TryParse(System.ReadOnlySpan{System.Char},System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeOnly.TryParse(System.String,System.TimeOnly@); Use overloads that specify CultureInfo.InvariantCulture.
 M:System.TimeSpan.TryParse(System.ReadOnlySpan{System.Char},System.TimeSpan@); Use overloads that specify CultureInfo.InvariantCulture.

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -175,7 +175,7 @@ public sealed class B3Propagator : TextMapPropagator
             var traceOptions = ActivityTraceFlags.None;
             var xb3Sampled = getter(carrier, XB3Sampled)?.FirstOrDefault();
             if ((xb3Sampled != null && SampledValues.Contains(xb3Sampled))
-                || FlagsValue.Equals(getter(carrier, XB3Flags)?.FirstOrDefault(), StringComparison.Ordinal))
+                || string.Equals(FlagsValue, getter(carrier, XB3Flags)?.FirstOrDefault(), StringComparison.Ordinal))
             {
                 traceOptions |= ActivityTraceFlags.Recorded;
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -29,22 +29,18 @@ internal sealed class ExperimentalOptions
 
         if (configuration.TryGetStringValue(OtlpRetryEnvVar, out var retryPolicy))
         {
-            if (retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(retryPolicy, "in_memory", StringComparison.OrdinalIgnoreCase))
             {
                 this.EnableInMemoryRetry = true;
             }
-            else if (retryPolicy.Equals("disk", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(retryPolicy, "disk", StringComparison.OrdinalIgnoreCase))
             {
                 this.EnableDiskRetry = true;
-                if (configuration.TryGetStringValue(OtlpDiskRetryDirectoryPathEnvVar, out var path))
-                {
-                    this.DiskRetryDirectoryPath = path;
-                }
-                else
-                {
-                    throw new NotSupportedException(
+
+                this.DiskRetryDirectoryPath = configuration.TryGetStringValue(OtlpDiskRetryDirectoryPathEnvVar, out var path)
+                    ? path
+                    : throw new NotSupportedException(
                         $"Retry Policy '{retryPolicy}' requires '{OtlpDiskRetryDirectoryPathEnvVar}' to be configured.");
-                }
             }
             else
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
@@ -81,7 +81,7 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
             var trailingHeaders = httpResponse.TrailingHeaders();
             var status = GrpcProtocolHelpers.GetResponseStatus(httpResponse, trailingHeaders);
 
-            if (status.Detail.Equals(Status.NoReplyDetailMessage, StringComparison.Ordinal))
+            if (string.Equals(status.Detail, Status.NoReplyDetailMessage, StringComparison.Ordinal))
             {
 #if NET
                 using var responseStream = httpResponse.Content.ReadAsStream(cancellationToken);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -228,7 +228,7 @@ internal static class ProtobufOtlpLogSerializer
                 // Special casing {OriginalFormat}
                 // See https://github.com/open-telemetry/opentelemetry-dotnet/pull/3182
                 // for explanation.
-                if (attribute.Key.Equals("{OriginalFormat}", StringComparison.Ordinal) && !bodyPopulatedFromFormattedMessage)
+                if (string.Equals(attribute.Key, "{OriginalFormat}", StringComparison.Ordinal) && !bodyPopulatedFromFormattedMessage)
                 {
                     otlpTagWriterState.WritePosition = WriteLogRecordBody(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, (attribute.Value as string).AsSpan());
                     isLogRecordBodySet = true;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -304,13 +304,13 @@ internal static class ProtobufOtlpTraceSerializer
                     statusCode = tag.Value switch
                     {
                         /*
-                         * Note: Order here does matter for perf. Unset is
-                         * first because assumption is most spans will be
-                         * Unset, then Error. Ok is not set by the SDK.
+                         * Note: Order here matters for performance. Unset
+                         * is first because the assumption is most spans will
+                         * be Unset, then Error. Ok is not set by the SDK.
                          */
-                        not null when UnsetStatusCodeTagValue.Equals(tag.Value as string, StringComparison.OrdinalIgnoreCase) => StatusCode.Unset,
-                        not null when ErrorStatusCodeTagValue.Equals(tag.Value as string, StringComparison.OrdinalIgnoreCase) => StatusCode.Error,
-                        not null when OkStatusCodeTagValue.Equals(tag.Value as string, StringComparison.OrdinalIgnoreCase) => StatusCode.Ok,
+                        not null when string.Equals(UnsetStatusCodeTagValue, tag.Value as string, StringComparison.OrdinalIgnoreCase) => StatusCode.Unset,
+                        not null when string.Equals(ErrorStatusCodeTagValue, tag.Value as string, StringComparison.OrdinalIgnoreCase) => StatusCode.Error,
+                        not null when string.Equals(OkStatusCodeTagValue, tag.Value as string, StringComparison.OrdinalIgnoreCase) => StatusCode.Ok,
                         _ => null,
                     };
                     continue;

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -167,7 +167,7 @@ public sealed class B3Propagator : TextMapPropagator
             var traceOptions = ActivityTraceFlags.None;
             var xb3Sampled = getter(carrier, XB3Sampled)?.FirstOrDefault();
             if ((xb3Sampled != null && SampledValues.Contains(xb3Sampled))
-                || FlagsValue.Equals(getter(carrier, XB3Flags)?.FirstOrDefault(), StringComparison.Ordinal))
+                || string.Equals(FlagsValue, getter(carrier, XB3Flags)?.FirstOrDefault(), StringComparison.Ordinal))
             {
                 traceOptions |= ActivityTraceFlags.Recorded;
             }

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -175,7 +175,7 @@ public class JaegerPropagator : TextMapPropagator
 
         spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
 
-        if (SampledValue.Equals(traceFlagsStr, StringComparison.Ordinal))
+        if (string.Equals(SampledValue, traceFlagsStr, StringComparison.Ordinal))
         {
             traceOptions |= ActivityTraceFlags.Recorded;
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -178,7 +178,7 @@ internal sealed class SpanBuilderShim : ISpanBuilder
         }
 
         // see https://opentracing.io/specification/conventions/ for special key handling.
-        if (global::OpenTracing.Tag.Tags.SpanKind.Key.Equals(key, StringComparison.Ordinal))
+        if (string.Equals(global::OpenTracing.Tag.Tags.SpanKind.Key, key, StringComparison.Ordinal))
         {
             this.spanKind = value switch
             {
@@ -189,7 +189,7 @@ internal sealed class SpanBuilderShim : ISpanBuilder
                 _ => SpanKind.Internal,
             };
         }
-        else if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal) && bool.TryParse(value, out var booleanValue))
+        else if (string.Equals(global::OpenTracing.Tag.Tags.Error.Key, key, StringComparison.Ordinal) && bool.TryParse(value, out var booleanValue))
         {
             this.error = booleanValue;
         }
@@ -204,7 +204,7 @@ internal sealed class SpanBuilderShim : ISpanBuilder
     /// <inheritdoc/>
     public ISpanBuilder WithTag(string key, bool value)
     {
-        if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
+        if (string.Equals(global::OpenTracing.Tag.Tags.Error.Key, key, StringComparison.Ordinal))
         {
             this.error = value;
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -175,7 +175,7 @@ internal sealed class SpanShim : ISpan
 
         // Special case the OpenTracing Error Tag
         // see https://opentracing.io/specification/conventions/
-        if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
+        if (string.Equals(global::OpenTracing.Tag.Tags.Error.Key, key, StringComparison.Ordinal))
         {
             this.Span.SetStatus(value ? Status.Error : Status.Ok);
         }
@@ -263,7 +263,7 @@ internal sealed class SpanShim : ISpan
                 continue;
             }
 
-            if (eventName == null && field.Key.Equals(LogFields.Event, StringComparison.Ordinal) && field.Value is string value)
+            if (eventName == null && string.Equals(field.Key, LogFields.Event, StringComparison.Ordinal) && field.Value is string value)
             {
                 // This is meant to be the event name
                 eventName = value;

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -142,7 +142,7 @@ internal class SelfDiagnosticsConfigRefresher : IDisposable
         if (this.configParser.TryGetConfiguration(out var newLogDirectory, out var fileSizeInKB, out var newEventLevel, out var formatMessage))
         {
             var newFileSize = fileSizeInKB * 1024;
-            if (!newLogDirectory.Equals(this.logDirectory, StringComparison.Ordinal) || this.logFileSize != newFileSize)
+            if (!string.Equals(newLogDirectory, this.logDirectory, StringComparison.Ordinal) || this.logFileSize != newFileSize)
             {
                 this.CloseLogFile();
                 this.OpenLogFile(newLogDirectory, newFileSize);
@@ -150,11 +150,7 @@ internal class SelfDiagnosticsConfigRefresher : IDisposable
 
             if (!newEventLevel.Equals(this.logEventLevel) || this.formatMessage != formatMessage)
             {
-                if (this.eventListener != null)
-                {
-                    this.eventListener.Dispose();
-                }
-
+                this.eventListener?.Dispose();
                 this.eventListener = new SelfDiagnosticsEventListener(newEventLevel, this, formatMessage);
                 this.logEventLevel = newEventLevel;
             }
@@ -177,10 +173,7 @@ internal class SelfDiagnosticsConfigRefresher : IDisposable
             // properly.
             foreach (var stream in this.viewStream.Values)
             {
-                if (stream != null)
-                {
-                    stream.Dispose();
-                }
+                stream?.Dispose();
             }
 
             mmf.Dispose();

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -179,7 +179,7 @@ public static class MeterProviderBuilderExtensions
                 }
                 else
                 {
-                    meterProviderBuilderSdk.AddView(instrument => instrument.Name.Equals(instrumentName, StringComparison.OrdinalIgnoreCase) ? metricStreamConfiguration : null);
+                    meterProviderBuilderSdk.AddView(instrument => string.Equals(instrument.Name, instrumentName, StringComparison.OrdinalIgnoreCase) ? metricStreamConfiguration : null);
                 }
             }
         });
@@ -327,15 +327,10 @@ public static class MeterProviderBuilderExtensions
     /// </summary>
     /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
     /// <returns><see cref="MeterProvider"/>.</returns>
-    public static MeterProvider Build(this MeterProviderBuilder meterProviderBuilder)
-    {
-        if (meterProviderBuilder is MeterProviderBuilderBase meterProviderBuilderBase)
-        {
-            return meterProviderBuilderBase.InvokeBuild();
-        }
-
-        throw new NotSupportedException($"Build is not supported on '{meterProviderBuilder?.GetType().FullName ?? "null"}' instances.");
-    }
+    public static MeterProvider Build(this MeterProviderBuilder meterProviderBuilder) =>
+        meterProviderBuilder is MeterProviderBuilderBase meterProviderBuilderBase
+            ? meterProviderBuilderBase.InvokeBuild()
+            : throw new NotSupportedException($"Build is not supported on '{meterProviderBuilder?.GetType().FullName ?? "null"}' instances.");
 
     /// <summary>
     /// Sets the default <see cref="ExemplarFilterType"/> for the provider.

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -14,7 +14,7 @@ internal sealed class StringArrayEqualityComparer : IEqualityComparer<string[]>
             return true;
         }
 
-        if (ReferenceEquals(strings1, null) || ReferenceEquals(strings2, null))
+        if (strings1 is null || strings2 is null)
         {
             return false;
         }
@@ -28,7 +28,7 @@ internal sealed class StringArrayEqualityComparer : IEqualityComparer<string[]>
 
         for (var i = 0; i < len1; i++)
         {
-            if (!strings1[i].Equals(strings2[i], StringComparison.Ordinal))
+            if (!string.Equals(strings1[i], strings2[i], StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -28,9 +28,7 @@ internal readonly struct Tags : IEquatable<Tags>
     public static bool operator !=(Tags tag1, Tags tag2) => !tag1.Equals(tag2);
 
     public override readonly bool Equals(object? obj)
-    {
-        return obj is Tags other && this.Equals(other);
-    }
+        => obj is Tags other && this.Equals(other);
 
     public readonly bool Equals(Tags other)
     {
@@ -53,12 +51,12 @@ internal readonly struct Tags : IEquatable<Tags>
             ref var theirs = ref MemoryMarshal.GetArrayDataReference(theirKvps);
             while (true)
             {
-                if (!ours.Key.Equals(theirs.Key, StringComparison.Ordinal))
+                if (!string.Equals(ours.Key, theirs.Key, StringComparison.Ordinal))
                 {
                     return false;
                 }
 
-                if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
+                if (!ours.Value?.Equals(theirs.Value) ?? (theirs.Value != null))
                 {
                     return false;
                 }
@@ -80,12 +78,12 @@ internal readonly struct Tags : IEquatable<Tags>
             // Note: Bounds check happens here for theirKvps element access
             ref var theirs = ref theirKvps[i];
 
-            if (!ours.Key.Equals(theirs.Key, StringComparison.Ordinal))
+            if (!string.Equals(ours.Key, theirs.Key, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
+            if (!ours.Value?.Equals(theirs.Value) ?? (theirs.Value != null))
             {
                 return false;
             }

--- a/src/Shared/StatusHelper.cs
+++ b/src/Shared/StatusHelper.cs
@@ -13,38 +13,32 @@ internal static class StatusHelper
     public const string ErrorStatusCodeTagValue = "ERROR";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string? GetTagValueForStatusCode(StatusCode statusCode)
+    public static string? GetTagValueForStatusCode(StatusCode statusCode) => statusCode switch
     {
-        return statusCode switch
-        {
-            /*
-             * Note: Order here does matter for perf. Unset is
-             * first because assumption is most spans will be
-             * Unset, then Error. Ok is not set by the SDK.
-             */
-            StatusCode.Unset => UnsetStatusCodeTagValue,
-            StatusCode.Error => ErrorStatusCodeTagValue,
-            StatusCode.Ok => OkStatusCodeTagValue,
-            _ => null,
-        };
-    }
+        /*
+         * Note: Order here matters for performance. Unset
+         * is first because the assumption is most spans will
+         * be Unset, then Error. Ok is not set by the SDK.
+         */
+        StatusCode.Unset => UnsetStatusCodeTagValue,
+        StatusCode.Error => ErrorStatusCodeTagValue,
+        StatusCode.Ok => OkStatusCodeTagValue,
+        _ => null,
+    };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static StatusCode? GetStatusCodeForTagValue(string? statusCodeTagValue)
+    public static StatusCode? GetStatusCodeForTagValue(string? statusCodeTagValue) => statusCodeTagValue switch
     {
-        return statusCodeTagValue switch
-        {
-            /*
-             * Note: Order here does matter for perf. Unset is
-             * first because assumption is most spans will be
-             * Unset, then Error. Ok is not set by the SDK.
-             */
-            not null when UnsetStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Unset,
-            not null when ErrorStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Error,
-            not null when OkStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Ok,
-            _ => null,
-        };
-    }
+        /*
+         * Note: Order here matters for performance. Unset
+         * is first because the assumption is most spans will
+         * be Unset, then Error. Ok is not set by the SDK.
+         */
+        not null when string.Equals(UnsetStatusCodeTagValue, statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Unset,
+        not null when string.Equals(ErrorStatusCodeTagValue, statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Error,
+        not null when string.Equals(OkStatusCodeTagValue, statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Ok,
+        _ => null,
+    };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetStatusCodeForTagValue(string? statusCodeTagValue, out StatusCode statusCode)


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet/pull/7196#discussion_r3159656725

## Changes

- Disallow use of string instance `Equals()` methods and require the static versions be used instead.
- Apply minor refactoring suggested by Visual Studio in files touched.
- Make some comments clearer.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
