### PR TITLE
[OTLP] Clear rented arrays used for GZip compression

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/PooledBufferStream.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/PooledBufferStream.cs
@@ -275,7 +275,7 @@ internal sealed class PooledBufferStream : Stream
 
             if (rented is { Length: > 0 })
             {
-                this.pool.Return(rented);
+                this.pool.Return(rented, clearArray: true);
             }
         }
 
@@ -364,7 +364,7 @@ internal sealed class PooledBufferStream : Stream
         }
 
         this.buffer = replacement;
-        this.pool.Return(previous);
+        this.pool.Return(previous, clearArray: true);
     }
 
     private void ThrowIfDisposed()

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/PooledBufferStreamTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/PooledBufferStreamTests.cs
@@ -151,12 +151,28 @@ public class PooledBufferStreamTests
         Assert.Equal(2, pool.Returned.Count);
         Assert.Same(pool.Rented[0], pool.Returned[0]);
         Assert.Same(pool.Rented[1], pool.Returned[1]);
+        Assert.All(pool.Returned[0], (p) => Assert.Equal(0, p));
+        Assert.All(pool.Returned[1], (p) => Assert.Equal(0, p));
         Assert.Throws<ObjectDisposedException>(stream.Flush);
         Assert.Throws<ObjectDisposedException>(() => _ = stream.Length);
 
         stream.Dispose();
 
         Assert.Equal(2, pool.Returned.Count);
+    }
+
+    [Fact]
+    public void Grow_ClearsPreviousBufferBeforeReturn()
+    {
+        var pool = new TrackingArrayPool();
+
+        using var stream = new PooledBufferStream(initialCapacity: 1, pool);
+
+        stream.Write([1, 2]);
+
+        Assert.Equal(2, pool.Rented.Count);
+        var returned = Assert.Single(pool.Returned);
+        Assert.All(returned, (p) => Assert.Equal(0, p));
     }
 
     private sealed class TrackingArrayPool : ArrayPool<byte>


### PR DESCRIPTION
## Changes

Clear the rented arrays when exporting compressed OTLP data.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
