### PR TITLE
docs: add sanity check guidance to AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,15 @@ dotnet format OpenTelemetry.slnx
 markdownlint .
 ```
 
+**Check for non-ASCII characters and trailing whitespace** (requires `python3`):
+
+CI runs a sanity check that rejects non-ASCII characters (e.g. smart quotes,
+em dashes) and trailing whitespace. To check locally:
+
+```sh
+python3 ./build/scripts/sanitycheck.py
+```
+
 - The .NET SDK version specified in `global.json` (or newer) is required.
 - `TreatWarningsAsErrors` is active in Release builds; StyleCop and nullable
   violations fail the build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,14 @@ If you made changes to the Markdown documents (`*.md` files), install the latest
 markdownlint .
 ```
 
+CI also runs a sanity check that rejects non-ASCII characters (e.g. smart
+quotes, em dashes) and trailing whitespace in Markdown files. You can check
+locally if you have `python3` installed:
+
+```sh
+python3 ./build/scripts/sanitycheck.py
+```
+
 Check out a new branch, make modifications, and push the branch to your fork:
 
 ```sh


### PR DESCRIPTION
Documents the CI sanity check script (`python3 ./build/scripts/sanitycheck.py`) that rejects non-ASCII characters and trailing whitespace.

**Changes:**
- **AGENTS.md**: Added the sanity check command to the Build, Test, and Lint section
- **CONTRIBUTING.md**: Added guidance on running the sanity check locally near the existing markdownlint instructions, noting it requires `python3`