### PR TITLE
[Opentelemetry.Tests] Enable MultithreadedSingleCounterTest and refin…

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
@@ -1695,7 +1695,7 @@ public class MetricApiTests : MetricTestsBase
     public void MultithreadedLongCounterTest()
         => this.MultithreadedCounterTest(DeltaLongValueUpdatedByEachCall);
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/6803")]
+    [Fact]
     public void MultithreadedSingleCounterTest()
         => this.MultithreadedCounterTest((float)DeltaDoubleValueUpdatedByEachCall);
 
@@ -2505,7 +2505,13 @@ public class MetricApiTests : MetricTestsBase
             var expectedSum = DeltaLongValueUpdatedByEachCall * NumberOfMetricUpdateByEachThread * NumberOfThreads;
             Assert.Equal(expectedSum, sumReceived);
         }
-        else if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+        else if (typeof(T) == typeof(float))
+        {
+            var sumReceived = GetDoubleSum(metricItems);
+            var expectedSum = (double)(float)DeltaDoubleValueUpdatedByEachCall * NumberOfMetricUpdateByEachThread * NumberOfThreads;
+            Assert.Equal(expectedSum, sumReceived, 2);
+        }
+        else if (typeof(T) == typeof(double))
         {
             var sumReceived = GetDoubleSum(metricItems);
             var expectedSum = DeltaDoubleValueUpdatedByEachCall * NumberOfMetricUpdateByEachThread * NumberOfThreads;


### PR DESCRIPTION

Fixes #7214
Design discussion issue NA

## Changes

Check if type of `deltaValueUpdatedByEachCall` is float and refine the sum calculation accordingly. Need to use a float cast for `DeltaValueUpdatedByEachCall` when calculating the expected sum

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
