### PR TITLE
[Exporter.Prometheus] Emit OpenMetrics exemplars

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -24,6 +24,9 @@ Notes](../../RELEASENOTES.md).
   correctly during Prometheus serialization.
   ([#7184](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7184))
 
+* Emit OpenMetrics exemplars for counters and histogram buckets.
+  ([#7222](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7222))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -36,6 +36,9 @@ Notes](../../RELEASENOTES.md).
   response caching.
   ([#7189](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7189))
 
+* Emit OpenMetrics exemplars for counters and histogram buckets.
+  ([#7222](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7222))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -313,6 +313,66 @@ internal static partial class PrometheusSerializer
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int WriteExemplar(byte[] buffer, int cursor, in Exemplar exemplar, bool isLongValue)
+    {
+        buffer[cursor++] = unchecked((byte)' ');
+        buffer[cursor++] = unchecked((byte)'#');
+        buffer[cursor++] = unchecked((byte)' ');
+        buffer[cursor++] = unchecked((byte)'{');
+
+        var hasLabels = false;
+
+        if (exemplar.TraceId != default)
+        {
+            cursor = WriteLabel(buffer, cursor, "trace_id", exemplar.TraceId.ToHexString());
+            buffer[cursor++] = unchecked((byte)',');
+            hasLabels = true;
+        }
+
+        if (exemplar.SpanId != default)
+        {
+            cursor = WriteLabel(buffer, cursor, "span_id", exemplar.SpanId.ToHexString());
+            buffer[cursor++] = unchecked((byte)',');
+            hasLabels = true;
+        }
+
+        foreach (var tag in exemplar.FilteredTags)
+        {
+            if (tag.Key == "trace_id" || tag.Key == "span_id")
+            {
+                continue;
+            }
+
+            cursor = WriteLabel(buffer, cursor, tag.Key, tag.Value);
+            buffer[cursor++] = unchecked((byte)',');
+            hasLabels = true;
+        }
+
+        if (hasLabels)
+        {
+            buffer[cursor - 1] = unchecked((byte)'}');
+        }
+        else
+        {
+            buffer[cursor++] = unchecked((byte)'}');
+        }
+
+        buffer[cursor++] = unchecked((byte)' ');
+
+        cursor = isLongValue
+            ? WriteLong(buffer, cursor, exemplar.LongValue)
+            : WriteDouble(buffer, cursor, exemplar.DoubleValue);
+
+        if (exemplar.Timestamp != default)
+        {
+            buffer[cursor++] = unchecked((byte)' ');
+            cursor = WriteUnixTimeSeconds(buffer, cursor, exemplar.Timestamp);
+        }
+
+        return cursor;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteHelpMetadata(byte[] buffer, int cursor, PrometheusMetric metric, string metricDescription, bool openMetricsRequested)
     {
         if (string.IsNullOrEmpty(metricDescription))
@@ -497,6 +557,10 @@ internal static partial class PrometheusSerializer
 
         return WriteUnicodeNoEscape(buffer, cursor, 0xFFFD);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int WriteUnixTimeSeconds(byte[] buffer, int cursor, DateTimeOffset value)
+        => WriteDouble(buffer, cursor, value.ToUnixTimeMilliseconds() / 1000.0);
 
     private static string MapPrometheusType(PrometheusType type) => type switch
     {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
@@ -30,6 +30,8 @@ internal static partial class PrometheusSerializer
 
         if (!metric.MetricType.IsHistogram())
         {
+            var isLongValue = ((int)metric.MetricType & 0b_0000_1111) == 0x0a; // I8
+
             foreach (ref readonly var metricPoint in metric.GetMetricPoints())
             {
                 // Counter and Gauge
@@ -38,10 +40,7 @@ internal static partial class PrometheusSerializer
 
                 buffer[cursor++] = unchecked((byte)' ');
 
-                // TODO: MetricType is same for all MetricPoints
-                // within a given Metric, so this check can avoided
-                // for each MetricPoint
-                if (((int)metric.MetricType & 0b_0000_1111) == 0x0a /* I8 */)
+                if (isLongValue)
                 {
                     cursor = metric.MetricType.IsSum()
                         ? WriteLong(buffer, cursor, metricPoint.GetSumLong())
@@ -54,6 +53,13 @@ internal static partial class PrometheusSerializer
                         : WriteDouble(buffer, cursor, metricPoint.GetGaugeLastValueDouble());
                 }
 
+                if (openMetricsRequested &&
+                    prometheusMetric.Type == PrometheusType.Counter &&
+                    TryGetLatestExemplar(metricPoint, out var exemplar))
+                {
+                    cursor = WriteExemplar(buffer, cursor, in exemplar, isLongValue);
+                }
+
                 buffer[cursor++] = ASCII_LINEFEED;
             }
         }
@@ -62,6 +68,7 @@ internal static partial class PrometheusSerializer
             foreach (ref readonly var metricPoint in metric.GetMetricPoints())
             {
                 var tags = metricPoint.Tags;
+                var previousBound = double.NegativeInfinity;
 
                 long totalCount = 0;
                 foreach (var histogramMeasurement in metricPoint.GetHistogramBuckets())
@@ -82,7 +89,14 @@ internal static partial class PrometheusSerializer
 
                     cursor = WriteLong(buffer, cursor, totalCount);
 
+                    if (openMetricsRequested &&
+                        TryGetLatestHistogramBucketExemplar(metricPoint, previousBound, histogramMeasurement.ExplicitBound, out var exemplar))
+                    {
+                        cursor = WriteExemplar(buffer, cursor, in exemplar, isLongValue: false);
+                    }
+
                     buffer[cursor++] = ASCII_LINEFEED;
+                    previousBound = histogramMeasurement.ExplicitBound;
                 }
 
                 // Histogram sum
@@ -110,5 +124,65 @@ internal static partial class PrometheusSerializer
         }
 
         return cursor;
+    }
+
+    private static bool TryGetLatestExemplar(in MetricPoint metricPoint, out Exemplar exemplar)
+    {
+        exemplar = default;
+
+        if (!metricPoint.TryGetExemplars(out var exemplars))
+        {
+            return false;
+        }
+
+        var found = false;
+
+        foreach (var candidate in exemplars)
+        {
+            if (!found || exemplar.Timestamp < candidate.Timestamp)
+            {
+                exemplar = candidate;
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private static bool TryGetLatestHistogramBucketExemplar(
+        in MetricPoint metricPoint,
+        double lowerBoundExclusive,
+        double upperBoundInclusive,
+        out Exemplar exemplar)
+    {
+        exemplar = default;
+
+        if (!metricPoint.TryGetExemplars(out var exemplars))
+        {
+            return false;
+        }
+
+        var found = false;
+
+        foreach (var candidate in exemplars)
+        {
+            var exemplarValue = candidate.DoubleValue;
+
+            if (double.IsNaN(exemplarValue))
+            {
+                continue;
+            }
+
+            if (exemplarValue <= upperBoundInclusive && exemplarValue > lowerBoundExclusive)
+            {
+                if (!found || exemplar.Timestamp < candidate.Timestamp)
+                {
+                    exemplar = candidate;
+                    found = true;
+                }
+            }
+        }
+
+        return found;
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
@@ -126,20 +126,36 @@ internal static partial class PrometheusSerializer
         return cursor;
     }
 
-    private static bool TryGetLatestExemplar(in MetricPoint metricPoint, out Exemplar exemplar)
-    {
-        exemplar = default;
+    internal static bool ShouldPreferExemplar(DateTimeOffset currentTimestamp, DateTimeOffset candidateTimestamp)
+        => currentTimestamp <= candidateTimestamp;
 
-        if (!metricPoint.TryGetExemplars(out var exemplars))
+    internal static bool IsHistogramBucketExemplarMatch(
+        double exemplarValue,
+        double lowerBoundExclusive,
+        double upperBoundInclusive)
+    {
+        if (double.IsNaN(exemplarValue))
         {
             return false;
         }
+
+        var isAboveLowerBound =
+            exemplarValue > lowerBoundExclusive ||
+            (lowerBoundExclusive == double.NegativeInfinity &&
+             exemplarValue == double.NegativeInfinity);
+
+        return exemplarValue <= upperBoundInclusive && isAboveLowerBound;
+    }
+
+    internal static bool TryGetLatestExemplar(ReadOnlyExemplarCollection exemplars, out Exemplar exemplar)
+    {
+        exemplar = default;
 
         var found = false;
 
         foreach (var candidate in exemplars)
         {
-            if (!found || exemplar.Timestamp < candidate.Timestamp)
+            if (!found || ShouldPreferExemplar(exemplar.Timestamp, candidate.Timestamp))
             {
                 exemplar = candidate;
                 found = true;
@@ -149,6 +165,35 @@ internal static partial class PrometheusSerializer
         return found;
     }
 
+    internal static bool TryGetLatestHistogramBucketExemplar(
+        ReadOnlyExemplarCollection exemplars,
+        double lowerBoundExclusive,
+        double upperBoundInclusive,
+        out Exemplar exemplar)
+    {
+        exemplar = default;
+
+        var found = false;
+
+        foreach (var candidate in exemplars)
+        {
+            if (IsHistogramBucketExemplarMatch(candidate.DoubleValue, lowerBoundExclusive, upperBoundInclusive) &&
+                (!found || ShouldPreferExemplar(exemplar.Timestamp, candidate.Timestamp)))
+            {
+                exemplar = candidate;
+                found = true;
+            }
+        }
+
+        return found;
+    }
+
+    private static bool TryGetLatestExemplar(in MetricPoint metricPoint, out Exemplar exemplar)
+    {
+        exemplar = default;
+        return metricPoint.TryGetExemplars(out var exemplars) && TryGetLatestExemplar(exemplars, out exemplar);
+    }
+
     private static bool TryGetLatestHistogramBucketExemplar(
         in MetricPoint metricPoint,
         double lowerBoundExclusive,
@@ -156,33 +201,7 @@ internal static partial class PrometheusSerializer
         out Exemplar exemplar)
     {
         exemplar = default;
-
-        if (!metricPoint.TryGetExemplars(out var exemplars))
-        {
-            return false;
-        }
-
-        var found = false;
-
-        foreach (var candidate in exemplars)
-        {
-            var exemplarValue = candidate.DoubleValue;
-
-            if (double.IsNaN(exemplarValue))
-            {
-                continue;
-            }
-
-            if (exemplarValue <= upperBoundInclusive && exemplarValue > lowerBoundExclusive)
-            {
-                if (!found || exemplar.Timestamp < candidate.Timestamp)
-                {
-                    exemplar = candidate;
-                    found = true;
-                }
-            }
-        }
-
-        return found;
+        return metricPoint.TryGetExemplars(out var exemplars) &&
+               TryGetLatestHistogramBucketExemplar(exemplars, lowerBoundExclusive, upperBoundInclusive, out exemplar);
     }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Text;
@@ -670,6 +671,52 @@ public sealed class PrometheusSerializerTests
     }
 
     [Fact]
+    public void CounterWithOpenMetricsFormatEmitsLatestExemplar()
+    {
+        var buffer = new byte[85000];
+        var metrics = new List<Metric>();
+
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+        var counter = meter.CreateCounter<long>("test_counter");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .SetExemplarFilter(ExemplarFilterType.AlwaysOn)
+            .AddView(
+                counter.Name,
+                new MetricStreamConfiguration
+                {
+                    TagKeys = ["keep"],
+                    ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                })
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+        counter.Add(1, new("keep", "value"), new("filtered", "first"));
+
+        WaitForNextExemplarTimestamp();
+
+        using var activity = new Activity("test");
+        activity.Start();
+        counter.Add(2, new("keep", "value"), new("filtered", "second"), new("trace_id", "ignored-trace"), new("span_id", "ignored-span"));
+
+        provider.ForceFlush();
+
+        var cursor = WriteMetric(buffer, 0, metrics[0], true);
+        var output = Encoding.UTF8.GetString(buffer, 0, cursor);
+        var counterLine = output.Split(['\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Single(line => line.StartsWith("test_counter", StringComparison.Ordinal));
+
+        Assert.Contains(" 3 # ", counterLine, StringComparison.Ordinal);
+        Assert.Contains(
+            $"# {{trace_id=\"{activity.TraceId.ToHexString()}\",span_id=\"{activity.SpanId.ToHexString()}\",filtered=\"second\"}} 2 ",
+            counterLine,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("ignored-trace", counterLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("ignored-span", counterLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HistogramOneDimensionWithOpenMetricsFormat()
     {
         var buffer = new byte[85000];
@@ -712,6 +759,55 @@ public sealed class PrometheusSerializerTests
                 + $"test_histogram_count{{otel_scope_name='{Utils.GetCurrentMethodName()}',x='1'}} 2\n"
                 + "$").Replace('\'', '"');
         Assert.Matches(expected, output);
+    }
+
+    [Fact]
+    public void HistogramWithOpenMetricsFormatEmitsLatestBucketExemplar()
+    {
+        var buffer = new byte[85000];
+        var metrics = new List<Metric>();
+
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+        var histogram = meter.CreateHistogram<double>("test_histogram");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .SetExemplarFilter(ExemplarFilterType.AlwaysOn)
+            .AddView(
+                histogram.Name,
+                new ExplicitBucketHistogramConfiguration
+                {
+                    Boundaries = [5, 10],
+                    TagKeys = ["keep"],
+                    ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                })
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+        histogram.Record(4, new("keep", "value"), new("filtered", "older"));
+        histogram.Record(8, new("keep", "value"), new("filtered", "first"));
+
+        WaitForNextExemplarTimestamp();
+
+        using var activity = new Activity("test");
+        activity.Start();
+        histogram.Record(9, new("keep", "value"), new("filtered", "latest"), new("trace_id", "ignored-trace"), new("span_id", "ignored-span"));
+
+        provider.ForceFlush();
+
+        var cursor = WriteMetric(buffer, 0, metrics[0], true);
+        var output = Encoding.UTF8.GetString(buffer, 0, cursor);
+        var bucketLine = output.Split(['\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Single(line => line.Contains("test_histogram_bucket{", StringComparison.Ordinal)
+                && line.Contains("le=\"10\"", StringComparison.Ordinal));
+
+        Assert.Contains("} 3 # ", bucketLine, StringComparison.Ordinal);
+        Assert.Contains(
+            $"# {{trace_id=\"{activity.TraceId.ToHexString()}\",span_id=\"{activity.SpanId.ToHexString()}\",filtered=\"latest\"}} 9 ",
+            bucketLine,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("ignored-trace", bucketLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("ignored-span", bucketLine, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -974,6 +1070,16 @@ public sealed class PrometheusSerializerTests
 
     private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics = false)
         => PrometheusSerializer.WriteMetric(buffer, cursor, metric, PrometheusMetric.Create(metric, false), useOpenMetrics);
+
+    private static void WaitForNextExemplarTimestamp()
+    {
+        var timestamp = DateTimeOffset.UtcNow;
+
+        while (DateTimeOffset.UtcNow <= timestamp)
+        {
+            Thread.Sleep(1);
+        }
+    }
 
     private static string WriteGaugeMetricWithMeterTags(params KeyValuePair<string, object?>[] meterTags)
     {

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -753,6 +753,15 @@ public sealed class PrometheusSerializerTests
     }
 
     [Fact]
+    public void TryGetLatestExemplarPrefersLaterCandidateWhenTimestampsMatch()
+    {
+        var timestamp = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        Assert.True(PrometheusSerializer.ShouldPreferExemplar(timestamp, timestamp));
+        Assert.False(PrometheusSerializer.ShouldPreferExemplar(timestamp, timestamp.AddTicks(-1)));
+    }
+
+    [Fact]
     public void HistogramOneDimensionWithOpenMetricsFormat()
     {
         var buffer = new byte[85000];
@@ -844,6 +853,13 @@ public sealed class PrometheusSerializerTests
             StringComparison.Ordinal);
         Assert.DoesNotContain("ignored-trace", bucketLine, StringComparison.Ordinal);
         Assert.DoesNotContain("ignored-span", bucketLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryGetLatestHistogramBucketExemplarMatchesNegativeInfinityInFirstBucket()
+    {
+        Assert.True(PrometheusSerializer.IsHistogramBucketExemplarMatch(double.NegativeInfinity, double.NegativeInfinity, 5));
+        Assert.False(PrometheusSerializer.IsHistogramBucketExemplarMatch(double.NegativeInfinity, 5, 10));
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -717,6 +717,42 @@ public sealed class PrometheusSerializerTests
     }
 
     [Fact]
+    public void CounterWithOpenMetricsFormatEmitsExemplarWithoutLabelsWhenOnlyReservedTagNamesAreFiltered()
+    {
+        var buffer = new byte[85000];
+        var metrics = new List<Metric>();
+
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+        var counter = meter.CreateCounter<long>("test_counter");
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .SetExemplarFilter(ExemplarFilterType.AlwaysOn)
+            .AddView(
+                counter.Name,
+                new MetricStreamConfiguration
+                {
+                    TagKeys = ["keep"],
+                    ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                })
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+        counter.Add(2, new("keep", "value"), new("trace_id", "ignored-trace"), new("span_id", "ignored-span"));
+
+        provider.ForceFlush();
+
+        var cursor = WriteMetric(buffer, 0, metrics[0], true);
+        var output = Encoding.UTF8.GetString(buffer, 0, cursor);
+        var counterLine = output.Split(['\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Single(line => line.StartsWith("test_counter", StringComparison.Ordinal));
+
+        Assert.Contains(" 2 # {} 2 ", counterLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("ignored-trace", counterLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("ignored-span", counterLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HistogramOneDimensionWithOpenMetricsFormat()
     {
         var buffer = new byte[85000];


### PR DESCRIPTION
## Changes

Emit OpenMetrics exemplars for counters and histogram buckets using the latest applicable exemplar, including trace/span identifiers and filtered tags.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
