### PR TITLE
[Exporter.OTLP] Persist only valid part of the buffer

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -15,6 +15,10 @@ Notes](../../RELEASENOTES.md).
   or through the environment variables such as `OTEL_EXPORTER_OTLP_COMPRESSION=gzip`.
   ([#7055](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7055))
 
+* Fixed disk retry data being stored incorrectly when using persistent storage
+  retry.
+  ([#7228](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7228))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -48,7 +48,16 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
     }
 
     protected override bool OnSubmitRequestFailure(byte[] request, int contentLength, ExportClientResponse response)
-        => RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out _) && this.persistentBlobProvider.TryCreateBlob(request, out _);
+    {
+        Debug.Assert(contentLength >= 0 && contentLength <= request.Length, "contentLength was invalid");
+
+        if (!RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out _))
+        {
+            return false;
+        }
+
+        return this.persistentBlobProvider.TryCreateBlob(request.AsSpan(0, contentLength).ToArray(), out _);
+    }
 
     protected override void OnShutdown(int timeoutMilliseconds)
     {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OpenTelemetry.PersistentStorage.Abstractions;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission.Tests;
+
+public class OtlpExporterPersistentStorageTransmissionHandlerTests
+{
+    [Fact]
+    public void TrySubmitRequest_FailurePersistsOnlyContentLength()
+    {
+        var exportClient = new FailingExportClient();
+        var persistentBlobProvider = new CapturingBlobProvider();
+
+        using var transmissionHandler = new OtlpExporterPersistentStorageTransmissionHandler(persistentBlobProvider, exportClient, timeoutMilliseconds: 1000);
+
+        var request = new byte[] { 1, 2, 3, 4, 9, 9, 9 };
+        var result = transmissionHandler.TrySubmitRequest(request, contentLength: 4);
+
+        Assert.False(result);
+        Assert.NotNull(persistentBlobProvider.LastBuffer);
+        Assert.Equal([1, 2, 3, 4], persistentBlobProvider.LastBuffer);
+    }
+
+    private sealed class FailingExportClient : IExportClient
+    {
+        public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
+        {
+            return new ExportClientHttpResponse(
+                success: false,
+                deadlineUtc: deadlineUtc,
+                response: new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+                exception: null);
+        }
+
+        public bool Shutdown(int timeoutMilliseconds) => true;
+    }
+
+    private sealed class CapturingBlobProvider : PersistentBlobProvider
+    {
+        public byte[]? LastBuffer { get; private set; }
+
+        protected override IEnumerable<PersistentBlob> OnGetBlobs() => [];
+
+        protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out PersistentBlob blob)
+        {
+            this.LastBuffer = buffer;
+            blob = new NoopBlob();
+            return true;
+        }
+
+        protected override bool OnTryCreateBlob(byte[] buffer, out PersistentBlob blob)
+        {
+            this.LastBuffer = buffer;
+            blob = new NoopBlob();
+            return true;
+        }
+
+        protected override bool OnTryGetBlob(out PersistentBlob? blob)
+        {
+            blob = null;
+            return false;
+        }
+    }
+
+    private sealed class NoopBlob : PersistentBlob
+    {
+        protected override bool OnTryRead(out byte[] buffer)
+        {
+            buffer = [];
+            return false;
+        }
+
+        protected override bool OnTryWrite(byte[] buffer, int leasePeriodMilliseconds = 0) => true;
+
+        protected override bool OnTryLease(int leasePeriodMilliseconds) => false;
+
+        protected override bool OnTryDelete() => true;
+    }
+}

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Net;
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.PersistentStorage.Abstractions;
 
@@ -17,24 +20,24 @@ public class OtlpExporterPersistentStorageTransmissionHandlerTests
 
         using var transmissionHandler = new OtlpExporterPersistentStorageTransmissionHandler(persistentBlobProvider, exportClient, timeoutMilliseconds: 1000);
 
-        var request = new byte[] { 1, 2, 3, 4, 9, 9, 9 };
+        byte[] request = [1, 2, 3, 4, 9, 9, 9];
         var result = transmissionHandler.TrySubmitRequest(request, contentLength: 4);
 
-        Assert.False(result);
+        Assert.True(result);
         Assert.NotNull(persistentBlobProvider.LastBuffer);
         Assert.Equal([1, 2, 3, 4], persistentBlobProvider.LastBuffer);
     }
 
     private sealed class FailingExportClient : IExportClient
     {
-        public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
-        {
-            return new ExportClientHttpResponse(
+        public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default) =>
+            new ExportClientHttpResponse(
                 success: false,
                 deadlineUtc: deadlineUtc,
+#pragma warning disable CA2000 //  Dispose objects before losing scope
                 response: new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+#pragma warning restore CA2000 //  Dispose objects before losing scope
                 exception: null);
-        }
 
         public bool Shutdown(int timeoutMilliseconds) => true;
     }
@@ -59,9 +62,9 @@ public class OtlpExporterPersistentStorageTransmissionHandlerTests
             return true;
         }
 
-        protected override bool OnTryGetBlob(out PersistentBlob? blob)
+        protected override bool OnTryGetBlob(out PersistentBlob blob)
         {
-            blob = null;
+            blob = new NoopBlob();
             return false;
         }
     }


### PR DESCRIPTION
Fixes codex scanning findings.

## Changes

[Exporter.OTLP] Persistent only valid part of the buffer
It fixes issues without touches persistent storage mechanism. It can be improved by https://github.com/open-telemetry/opentelemetry-dotnet/pull/7101 when https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4128 is merged.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
