### PR TITLE
[OTLP] Disable HttpClientFactory integration for logs

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -19,6 +19,11 @@ Notes](../../RELEASENOTES.md).
   retry.
   ([#7228](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7228))
 
+* Reverts `OtlpLogExporter` from using `IHttpClientFactory` on .NET 8+ to fix
+  an issue with circular dependencies detected by some dependency injection
+  container implementations such as Autofac.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -22,7 +22,7 @@ Notes](../../RELEASENOTES.md).
 * Reverts `OtlpLogExporter` from using `IHttpClientFactory` on .NET 8+ to fix
   an issue with circular dependencies detected by some dependency injection
   container implementations such as Autofac.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7234))
 
 ## 1.15.3
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -19,7 +19,7 @@ Notes](../../RELEASENOTES.md).
   retry.
   ([#7228](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7228))
 
-* Reverts `OtlpLogExporter` from using `IHttpClientFactory` on .NET 8+ to fix
+* Reverted `OtlpLogExporter` from using `IHttpClientFactory` on .NET 8+ to fix
   an issue with circular dependencies detected by some dependency injection
   container implementations such as Autofac.
   ([#7234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7234))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -297,13 +297,19 @@ public static class OtlpLogExporterHelperExtensions
             serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        // IHttpClientFactory integration is only safe on .NET 8+. On earlier versions,
+        // TODO IHttpClientFactory integration should be safe on .NET 8+. On earlier versions,
         // DefaultHttpClientFactory took ILoggerFactory eagerly in its constructor, creating a
         // circular dependency: ILoggerFactory -> OpenTelemetryLoggerProvider -> OtlpLogExporter
         // -> IHttpClientFactory -> ILoggerFactory. This was fixed in .NET 8 (dotnet/runtime#89531).
+        // However, this doesn't appear to be true in all cases and can create circular dependencies
+        // when using Autofac and the .NET 11 IHttpClientFactory integration.
+        // Disabled until we can safely resolve this and have appropriate test coverage to ensure
+        // the circular dependency does not exist. See https://github.com/open-telemetry/opentelemetry-dotnet/issues/7233.
+        /*
 #if NET8_0_OR_GREATER
         exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter");
 #endif
+        */
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         BaseExporter<LogRecord> otlpExporter = new OtlpLogExporter(

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -109,9 +109,30 @@ public class OtlpLogExporterTests
     }
 
     [Fact]
+    public void ServiceProviderHttpClientFactoryNotInvoked()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHttpClient();
+
+        var invocations = 0;
+
+        services.AddHttpClient("OtlpLogExporter", configureClient: (client) => invocations++);
+
+        services.AddOpenTelemetry().WithLogging(builder => builder
+            .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.HttpProtobuf));
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var loggerProvider = serviceProvider.GetRequiredService<LoggerProvider>();
+
+        Assert.Equal(0, invocations);
+    }
+
+    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/7233")]
     public void ServiceProviderHttpClientFactoryInvoked()
     {
-        IServiceCollection services = new ServiceCollection();
+        var services = new ServiceCollection();
 
         services.AddHttpClient();
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -124,8 +124,7 @@ public class OtlpLogExporterTests
 
         using var serviceProvider = services.BuildServiceProvider();
 
-        var loggerProvider = serviceProvider.GetRequiredService<LoggerProvider>();
-
+        Assert.NotNull(serviceProvider);
         Assert.Equal(0, invocations);
     }
 


### PR DESCRIPTION
Relates to #7233

## Changes

Re-disable the HttpClientFactory integration for .NET 8+ as it is still causing circular dependencies.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
