### PR TITLE
[Exporter.Prometheus] Dedupe metadata

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -414,7 +414,8 @@ internal sealed class PrometheusCollectionManager
             if (!string.IsNullOrEmpty(prometheusMetric.Unit) &&
                 metadataState.Unit == null)
             {
-                metadataStates[metadataName] = new MetadataState(metadataState.Type, metadataState.Help, prometheusMetric.Unit);
+                metadataState = new MetadataState(metadataState.Type, metadataState.Help, prometheusMetric.Unit);
+                metadataStates[metadataName] = metadataState;
             }
             else if (!string.IsNullOrEmpty(prometheusMetric.Unit) &&
                      metadataState.Unit != null &&
@@ -426,7 +427,8 @@ internal sealed class PrometheusCollectionManager
             if (!string.IsNullOrEmpty(metric.Description) &&
                 metadataState.Help == null)
             {
-                metadataStates[metadataName] = new MetadataState(metadataState.Type, metric.Description, metadataState.Unit);
+                metadataState = new MetadataState(metadataState.Type, metric.Description, metadataState.Unit);
+                metadataStates[metadataName] = metadataState;
             }
             else if (!string.IsNullOrEmpty(metric.Description) &&
                      metadataState.Help != null &&

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -276,7 +276,9 @@ internal sealed class PrometheusCollectionManager
                             this.exporter.OpenMetricsRequested,
                             writeType: metricState.WriteType,
                             writeUnit: metricState.WriteUnit,
-                            writeHelp: metricState.WriteHelp);
+                            writeHelp: metricState.WriteHelp,
+                            unitOverride: metricState.Unit,
+                            helpOverride: metricState.Help);
 
                         break;
                     }
@@ -379,7 +381,7 @@ internal sealed class PrometheusCollectionManager
 
     private List<MetricState> GetMetricStates(in Batch<Metric> metrics, bool openMetricsRequested)
     {
-        var metricStates = new List<MetricState>();
+        var precomputedMetricStates = new List<PrecomputedMetricState>();
         var metadataStates = new Dictionary<string, MetadataState>(StringComparer.Ordinal);
         var droppedMetricNames = new HashSet<string>(StringComparer.Ordinal);
 
@@ -392,33 +394,27 @@ internal sealed class PrometheusCollectionManager
 
             var prometheusMetric = this.GetPrometheusMetric(metric);
             var metadataName = openMetricsRequested ? prometheusMetric.OpenMetricsMetadataName : prometheusMetric.Name;
+            precomputedMetricStates.Add(new PrecomputedMetricState(metric, prometheusMetric, metadataName));
 
             if (!metadataStates.TryGetValue(metadataName, out var metadataState))
             {
-                metadataStates[metadataName] = new MetadataState(prometheusMetric.Type, metric.Description, prometheusMetric.Unit);
-                metricStates.Add(
-                    new MetricState(
-                        metric,
-                        prometheusMetric,
-                        true,
-                        !string.IsNullOrEmpty(prometheusMetric.Unit),
-                        !string.IsNullOrEmpty(metric.Description)));
+                metadataStates[metadataName] = new MetadataState(
+                    prometheusMetric.Type,
+                    string.IsNullOrEmpty(metric.Description) ? null : metric.Description,
+                    string.IsNullOrEmpty(prometheusMetric.Unit) ? null : prometheusMetric.Unit);
                 continue;
             }
 
             if (metadataState.Type != prometheusMetric.Type)
             {
                 droppedMetricNames.Add(metadataName);
-                PrometheusExporterEventSource.Log.ConflictingType(metadataName, metadataState.Type.ToString(), prometheusMetric.Type.ToString());
+                PrometheusExporterEventSource.Log.ConflictingType(metadataName, metadataState.Type, prometheusMetric.Type);
             }
-
-            var writeUnit = false;
 
             if (!string.IsNullOrEmpty(prometheusMetric.Unit) &&
                 metadataState.Unit == null)
             {
                 metadataStates[metadataName] = new MetadataState(metadataState.Type, metadataState.Help, prometheusMetric.Unit);
-                writeUnit = true;
             }
             else if (!string.IsNullOrEmpty(prometheusMetric.Unit) &&
                      metadataState.Unit != null &&
@@ -427,13 +423,10 @@ internal sealed class PrometheusCollectionManager
                 PrometheusExporterEventSource.Log.ConflictingUnit(metadataName, metadataState.Unit, prometheusMetric.Unit!);
             }
 
-            var writeHelp = false;
-
             if (!string.IsNullOrEmpty(metric.Description) &&
                 metadataState.Help == null)
             {
                 metadataStates[metadataName] = new MetadataState(metadataState.Type, metric.Description, metadataState.Unit);
-                writeHelp = true;
             }
             else if (!string.IsNullOrEmpty(metric.Description) &&
                      metadataState.Help != null &&
@@ -441,26 +434,33 @@ internal sealed class PrometheusCollectionManager
             {
                 PrometheusExporterEventSource.Log.ConflictingHelp(metadataName, metadataState.Help, metric.Description);
             }
-
-            metricStates.Add(new MetricState(metric, prometheusMetric, false, writeUnit, writeHelp));
         }
 
-        if (droppedMetricNames.Count == 0)
-        {
-            return metricStates;
-        }
+        var metricStates = new List<MetricState>(precomputedMetricStates.Count);
+        var emittedMetricNames = new HashSet<string>(StringComparer.Ordinal);
 
-        var filteredMetricStates = new List<MetricState>(metricStates.Count);
-        foreach (var metricState in metricStates)
+        foreach (var metricState in precomputedMetricStates)
         {
-            var metadataName = openMetricsRequested ? metricState.PrometheusMetric.OpenMetricsMetadataName : metricState.PrometheusMetric.Name;
-            if (!droppedMetricNames.Contains(metadataName))
+            if (droppedMetricNames.Contains(metricState.MetadataName))
             {
-                filteredMetricStates.Add(metricState);
+                continue;
             }
+
+            var writeMetadata = emittedMetricNames.Add(metricState.MetadataName);
+            var metadataState = metadataStates[metricState.MetadataName];
+
+            metricStates.Add(
+                new MetricState(
+                    metricState.Metric,
+                    metricState.PrometheusMetric,
+                    writeMetadata,
+                    writeMetadata && metadataState.Unit != null,
+                    writeMetadata && metadataState.Help != null,
+                    metadataState.Unit,
+                    metadataState.Help));
         }
 
-        return filteredMetricStates;
+        return metricStates;
     }
 
     public readonly struct CollectionResponse
@@ -484,13 +484,22 @@ internal sealed class PrometheusCollectionManager
 
     private readonly struct MetricState
     {
-        public MetricState(Metric metric, PrometheusMetric prometheusMetric, bool writeType, bool writeUnit, bool writeHelp)
+        public MetricState(
+            Metric metric,
+            PrometheusMetric prometheusMetric,
+            bool writeType,
+            bool writeUnit,
+            bool writeHelp,
+            string? unit,
+            string? help)
         {
             this.Metric = metric;
             this.PrometheusMetric = prometheusMetric;
             this.WriteType = writeType;
             this.WriteUnit = writeUnit;
             this.WriteHelp = writeHelp;
+            this.Unit = unit;
+            this.Help = help;
         }
 
         public readonly Metric Metric { get; }
@@ -502,6 +511,26 @@ internal sealed class PrometheusCollectionManager
         public readonly bool WriteUnit { get; }
 
         public readonly bool WriteHelp { get; }
+
+        public readonly string? Unit { get; }
+
+        public readonly string? Help { get; }
+    }
+
+    private readonly struct PrecomputedMetricState
+    {
+        public PrecomputedMetricState(Metric metric, PrometheusMetric prometheusMetric, string metadataName)
+        {
+            this.Metric = metric;
+            this.PrometheusMetric = prometheusMetric;
+            this.MetadataName = metadataName;
+        }
+
+        public readonly Metric Metric { get; }
+
+        public readonly PrometheusMetric PrometheusMetric { get; }
+
+        public readonly string MetadataName { get; }
     }
 
     private readonly struct MetadataState

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -274,11 +274,11 @@ internal sealed class PrometheusCollectionManager
                             metricState.Metric,
                             metricState.PrometheusMetric,
                             this.exporter.OpenMetricsRequested,
-                            writeType: metricState.WriteType,
-                            writeUnit: metricState.WriteUnit,
-                            writeHelp: metricState.WriteHelp,
-                            unitOverride: metricState.Unit,
-                            helpOverride: metricState.Help);
+                            metricState.WriteType,
+                            metricState.WriteUnit,
+                            metricState.WriteHelp,
+                            metricState.Unit,
+                            metricState.Help);
 
                         break;
                     }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -260,13 +260,10 @@ internal sealed class PrometheusCollectionManager
                 }
             }
 
-            foreach (var metric in metrics)
-            {
-                if (!PrometheusSerializer.CanWriteMetric(metric))
-                {
-                    continue;
-                }
+            var metricStates = this.GetMetricStates(metrics, this.exporter.OpenMetricsRequested);
 
+            foreach (var metricState in metricStates)
+            {
                 while (true)
                 {
                     try
@@ -274,9 +271,12 @@ internal sealed class PrometheusCollectionManager
                         cursor = PrometheusSerializer.WriteMetric(
                             buffer,
                             cursor,
-                            metric,
-                            this.GetPrometheusMetric(metric),
-                            this.exporter.OpenMetricsRequested);
+                            metricState.Metric,
+                            metricState.PrometheusMetric,
+                            this.exporter.OpenMetricsRequested,
+                            writeType: metricState.WriteType,
+                            writeUnit: metricState.WriteUnit,
+                            writeHelp: metricState.WriteHelp);
 
                         break;
                     }
@@ -377,6 +377,92 @@ internal sealed class PrometheusCollectionManager
         return prometheusMetric;
     }
 
+    private List<MetricState> GetMetricStates(in Batch<Metric> metrics, bool openMetricsRequested)
+    {
+        var metricStates = new List<MetricState>();
+        var metadataStates = new Dictionary<string, MetadataState>(StringComparer.Ordinal);
+        var droppedMetricNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var metric in metrics)
+        {
+            if (!PrometheusSerializer.CanWriteMetric(metric))
+            {
+                continue;
+            }
+
+            var prometheusMetric = this.GetPrometheusMetric(metric);
+            var metadataName = openMetricsRequested ? prometheusMetric.OpenMetricsMetadataName : prometheusMetric.Name;
+
+            if (!metadataStates.TryGetValue(metadataName, out var metadataState))
+            {
+                metadataStates[metadataName] = new MetadataState(prometheusMetric.Type, metric.Description, prometheusMetric.Unit);
+                metricStates.Add(
+                    new MetricState(
+                        metric,
+                        prometheusMetric,
+                        true,
+                        !string.IsNullOrEmpty(prometheusMetric.Unit),
+                        !string.IsNullOrEmpty(metric.Description)));
+                continue;
+            }
+
+            if (metadataState.Type != prometheusMetric.Type)
+            {
+                droppedMetricNames.Add(metadataName);
+                PrometheusExporterEventSource.Log.ConflictingType(metadataName, metadataState.Type.ToString(), prometheusMetric.Type.ToString());
+            }
+
+            var writeUnit = false;
+
+            if (!string.IsNullOrEmpty(prometheusMetric.Unit) &&
+                metadataState.Unit == null)
+            {
+                metadataStates[metadataName] = new MetadataState(metadataState.Type, metadataState.Help, prometheusMetric.Unit);
+                writeUnit = true;
+            }
+            else if (!string.IsNullOrEmpty(prometheusMetric.Unit) &&
+                     metadataState.Unit != null &&
+                     metadataState.Unit != prometheusMetric.Unit)
+            {
+                PrometheusExporterEventSource.Log.ConflictingUnit(metadataName, metadataState.Unit, prometheusMetric.Unit!);
+            }
+
+            var writeHelp = false;
+
+            if (!string.IsNullOrEmpty(metric.Description) &&
+                metadataState.Help == null)
+            {
+                metadataStates[metadataName] = new MetadataState(metadataState.Type, metric.Description, metadataState.Unit);
+                writeHelp = true;
+            }
+            else if (!string.IsNullOrEmpty(metric.Description) &&
+                     metadataState.Help != null &&
+                     metadataState.Help != metric.Description)
+            {
+                PrometheusExporterEventSource.Log.ConflictingHelp(metadataName, metadataState.Help, metric.Description);
+            }
+
+            metricStates.Add(new MetricState(metric, prometheusMetric, false, writeUnit, writeHelp));
+        }
+
+        if (droppedMetricNames.Count == 0)
+        {
+            return metricStates;
+        }
+
+        var filteredMetricStates = new List<MetricState>(metricStates.Count);
+        foreach (var metricState in metricStates)
+        {
+            var metadataName = openMetricsRequested ? metricState.PrometheusMetric.OpenMetricsMetadataName : metricState.PrometheusMetric.Name;
+            if (!droppedMetricNames.Contains(metadataName))
+            {
+                filteredMetricStates.Add(metricState);
+            }
+        }
+
+        return filteredMetricStates;
+    }
+
     public readonly struct CollectionResponse
     {
         public CollectionResponse(ArraySegment<byte> openMetricsView, ArraySegment<byte> plainTextView, DateTime generatedAtUtc, bool fromCache)
@@ -387,12 +473,50 @@ internal sealed class PrometheusCollectionManager
             this.FromCache = fromCache;
         }
 
-        public ArraySegment<byte> OpenMetricsView { get; }
+        public readonly ArraySegment<byte> OpenMetricsView { get; }
 
-        public ArraySegment<byte> PlainTextView { get; }
+        public readonly ArraySegment<byte> PlainTextView { get; }
 
-        public DateTime GeneratedAtUtc { get; }
+        public readonly DateTime GeneratedAtUtc { get; }
 
-        public bool FromCache { get; }
+        public readonly bool FromCache { get; }
+    }
+
+    private readonly struct MetricState
+    {
+        public MetricState(Metric metric, PrometheusMetric prometheusMetric, bool writeType, bool writeUnit, bool writeHelp)
+        {
+            this.Metric = metric;
+            this.PrometheusMetric = prometheusMetric;
+            this.WriteType = writeType;
+            this.WriteUnit = writeUnit;
+            this.WriteHelp = writeHelp;
+        }
+
+        public readonly Metric Metric { get; }
+
+        public readonly PrometheusMetric PrometheusMetric { get; }
+
+        public readonly bool WriteType { get; }
+
+        public readonly bool WriteUnit { get; }
+
+        public readonly bool WriteHelp { get; }
+    }
+
+    private readonly struct MetadataState
+    {
+        public MetadataState(PrometheusType type, string? help, string? unit)
+        {
+            this.Type = type;
+            this.Help = help;
+            this.Unit = unit;
+        }
+
+        public readonly PrometheusType Type { get; }
+
+        public readonly string? Help { get; }
+
+        public readonly string? Unit { get; }
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
@@ -64,4 +64,22 @@ internal sealed class PrometheusExporterEventSource : EventSource
     {
         this.WriteEvent(4);
     }
+
+    [Event(5, Message = "Dropping metric family '{0}' due to conflicting TYPE metadata '{1}' and '{2}'.", Level = EventLevel.Warning)]
+    public void ConflictingType(string metricName, string firstType, string conflictingType)
+    {
+        this.WriteEvent(5, metricName, firstType, conflictingType);
+    }
+
+    [Event(6, Message = "Dropping duplicate HELP metadata for metric family '{0}' because values '{1}' and '{2}' conflict.", Level = EventLevel.Warning)]
+    public void ConflictingHelp(string metricName, string firstHelp, string conflictingHelp)
+    {
+        this.WriteEvent(6, metricName, firstHelp, conflictingHelp);
+    }
+
+    [Event(7, Message = "Dropping duplicate UNIT metadata for metric family '{0}' because values '{1}' and '{2}' conflict.", Level = EventLevel.Warning)]
+    public void ConflictingUnit(string metricName, string firstUnit, string conflictingUnit)
+    {
+        this.WriteEvent(7, metricName, firstUnit, conflictingUnit);
+    }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
@@ -41,6 +41,15 @@ internal sealed class PrometheusExporterEventSource : EventSource
         }
     }
 
+    [NonEvent]
+    public void ConflictingType(string metricName, PrometheusType firstType, PrometheusType conflictingType)
+    {
+        if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+        {
+            this.ConflictingType(metricName, firstType.ToString(), conflictingType.ToString());
+        }
+    }
+
     [Event(1, Message = "Failed to export metrics: '{0}'", Level = EventLevel.Error)]
     public void FailedExport(string exception)
     {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -404,9 +404,9 @@ internal static partial class PrometheusSerializer
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int WriteUnitMetadata(byte[] buffer, int cursor, PrometheusMetric metric, bool openMetricsRequested)
+    public static int WriteUnitMetadata(byte[] buffer, int cursor, PrometheusMetric metric, string? unit, bool openMetricsRequested)
     {
-        if (string.IsNullOrEmpty(metric.Unit))
+        if (string.IsNullOrEmpty(unit))
         {
             return cursor;
         }
@@ -418,10 +418,10 @@ internal static partial class PrometheusSerializer
 
         // Unit name has already been escaped.
 #pragma warning disable IDE0370 // Remove unnecessary suppression
-        for (var i = 0; i < metric.Unit!.Length; i++)
+        for (var i = 0; i < unit!.Length; i++)
 #pragma warning restore IDE0370 // Remove unnecessary suppression
         {
-            var ordinal = (ushort)metric.Unit[i];
+            var ordinal = (ushort)unit[i];
             buffer[cursor++] = unchecked((byte)ordinal);
         }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
@@ -30,7 +30,9 @@ internal static partial class PrometheusSerializer
         bool openMetricsRequested,
         bool writeType = true,
         bool writeUnit = true,
-        bool writeHelp = true)
+        bool writeHelp = true,
+        string? unitOverride = null,
+        string? helpOverride = null)
     {
         if (writeType)
         {
@@ -39,12 +41,12 @@ internal static partial class PrometheusSerializer
 
         if (writeUnit)
         {
-            cursor = WriteUnitMetadata(buffer, cursor, prometheusMetric, openMetricsRequested);
+            cursor = WriteUnitMetadata(buffer, cursor, prometheusMetric, unitOverride ?? prometheusMetric.Unit, openMetricsRequested);
         }
 
         if (writeHelp)
         {
-            cursor = WriteHelpMetadata(buffer, cursor, prometheusMetric, metric.Description, openMetricsRequested);
+            cursor = WriteHelpMetadata(buffer, cursor, prometheusMetric, helpOverride ?? metric.Description, openMetricsRequested);
         }
 
         if (!metric.MetricType.IsHistogram())

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
@@ -28,11 +28,11 @@ internal static partial class PrometheusSerializer
         Metric metric,
         PrometheusMetric prometheusMetric,
         bool openMetricsRequested,
-        bool writeType = true,
-        bool writeUnit = true,
-        bool writeHelp = true,
-        string? unitOverride = null,
-        string? helpOverride = null)
+        bool writeType,
+        bool writeUnit,
+        bool writeHelp,
+        string? unitOverride,
+        string? helpOverride)
     {
         if (writeType)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
@@ -22,11 +22,30 @@ internal static partial class PrometheusSerializer
         return true;
     }
 
-    public static int WriteMetric(byte[] buffer, int cursor, Metric metric, PrometheusMetric prometheusMetric, bool openMetricsRequested)
+    public static int WriteMetric(
+        byte[] buffer,
+        int cursor,
+        Metric metric,
+        PrometheusMetric prometheusMetric,
+        bool openMetricsRequested,
+        bool writeType = true,
+        bool writeUnit = true,
+        bool writeHelp = true)
     {
-        cursor = WriteTypeMetadata(buffer, cursor, prometheusMetric, openMetricsRequested);
-        cursor = WriteUnitMetadata(buffer, cursor, prometheusMetric, openMetricsRequested);
-        cursor = WriteHelpMetadata(buffer, cursor, prometheusMetric, metric.Description, openMetricsRequested);
+        if (writeType)
+        {
+            cursor = WriteTypeMetadata(buffer, cursor, prometheusMetric, openMetricsRequested);
+        }
+
+        if (writeUnit)
+        {
+            cursor = WriteUnitMetadata(buffer, cursor, prometheusMetric, openMetricsRequested);
+        }
+
+        if (writeHelp)
+        {
+            cursor = WriteHelpMetadata(buffer, cursor, prometheusMetric, metric.Description, openMetricsRequested);
+        }
 
         if (!metric.MetricType.IsHistogram())
         {

--- a/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
@@ -66,7 +66,17 @@ public class PrometheusSerializerBenchmarks
             var cursor = 0;
             foreach (var metric in this.metrics)
             {
-                cursor = PrometheusSerializer.WriteMetric(this.buffer, cursor, metric, this.GetPrometheusMetric(metric), openMetricsRequested: false);
+                cursor = PrometheusSerializer.WriteMetric(
+                    this.buffer,
+                    cursor,
+                    metric,
+                    this.GetPrometheusMetric(metric),
+                    openMetricsRequested: false,
+                    writeType: true,
+                    writeUnit: true,
+                    writeHelp: true,
+                    unitOverride: null,
+                    helpOverride: null);
             }
         }
     }
@@ -76,7 +86,17 @@ public class PrometheusSerializerBenchmarks
     {
         for (var i = 0; i < this.NumberOfSerializeCalls; i++)
         {
-            _ = PrometheusSerializer.WriteMetric(this.buffer, 0, this.histogramMetric!, this.GetPrometheusMetric(this.histogramMetric!), openMetricsRequested: false);
+            _ = PrometheusSerializer.WriteMetric(
+                this.buffer,
+                0,
+                this.histogramMetric!,
+                this.GetPrometheusMetric(this.histogramMetric!),
+                openMetricsRequested: false,
+                writeType: true,
+                writeUnit: true,
+                writeHelp: true,
+                unitOverride: null,
+                helpOverride: null);
         }
     }
 
@@ -85,7 +105,17 @@ public class PrometheusSerializerBenchmarks
     {
         for (var i = 0; i < this.NumberOfSerializeCalls; i++)
         {
-            _ = PrometheusSerializer.WriteMetric(this.buffer, 0, this.typedLabelsMetric!, this.GetPrometheusMetric(this.typedLabelsMetric!), openMetricsRequested: false);
+            _ = PrometheusSerializer.WriteMetric(
+                this.buffer,
+                0,
+                this.typedLabelsMetric!,
+                this.GetPrometheusMetric(this.typedLabelsMetric!),
+                openMetricsRequested: false,
+                writeType: true,
+                writeUnit: true,
+                writeHelp: true,
+                unitOverride: null,
+                helpOverride: null);
         }
     }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests;
 [Collection(PromToolCollection.Name)]
 public class PrometheusIntegrationTests(PromToolFixture fixture, ITestOutputHelper outputHelper)
 {
-    [EnabledOnDockerPlatformTheory(DockerPlatform.Linux, Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/pull/7240")]
+    [EnabledOnDockerPlatformTheory(DockerPlatform.Linux)]
     [InlineData("")]
     [InlineData("text/plain")]
     [InlineData("text/plain;version=0.0.4")]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -436,6 +436,60 @@ public sealed class PrometheusCollectionManagerTests
     }
 
     [Fact]
+    public async Task MetricHelpAndUnitDiscoveredTogetherLaterAreBothWrittenBeforeSamples()
+    {
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+#if PROMETHEUS_HTTP_LISTENER
+            .AddPrometheusHttpListener()
+#elif PROMETHEUS_ASPNETCORE
+            .AddPrometheusExporter()
+#endif
+            .Build();
+
+#pragma warning disable CA2000
+        Assert.True(provider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000
+
+        var counter1 = meter.CreateCounter<int>("test.metric.bytes");
+        var counter2 = meter.CreateCounter<int>("test-metric-bytes", unit: "By", description: "Test help");
+
+        counter1.Add(1, [new("source", "a")]);
+        counter2.Add(2, [new("source", "b")]);
+
+        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        try
+        {
+            var view = response.PlainTextView;
+            var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
+
+            var typeIndex = output.IndexOf("# TYPE test_metric_bytes_total counter", StringComparison.Ordinal);
+            var unitIndex = output.IndexOf("# UNIT test_metric_bytes_total bytes", StringComparison.Ordinal);
+            var helpIndex = output.IndexOf("# HELP test_metric_bytes_total Test help", StringComparison.Ordinal);
+            var sampleAIndex = output.IndexOf("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"a\"} 1", StringComparison.Ordinal);
+            var sampleBIndex = output.IndexOf("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"b\"} 2", StringComparison.Ordinal);
+
+            Assert.True(typeIndex >= 0, "No TYPE found.");
+            Assert.True(unitIndex >= 0, "No UNIT found.");
+            Assert.True(helpIndex >= 0, "No HELP found.");
+            Assert.True(sampleAIndex >= 0, "No sample A found.");
+            Assert.True(sampleBIndex >= 0, "No sample B found.");
+            Assert.True(typeIndex < sampleAIndex, "TYPE appears after sample A.");
+            Assert.True(typeIndex < sampleBIndex, "TYPE appears after sample B.");
+            Assert.True(unitIndex < sampleAIndex, "UNIT appears after sample A.");
+            Assert.True(unitIndex < sampleBIndex, "UNIT appears after sample B.");
+            Assert.True(helpIndex < sampleAIndex, "HELP appears after sample A.");
+            Assert.True(helpIndex < sampleBIndex, "HELP appears after sample B.");
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect();
+        }
+    }
+
+    [Fact]
     public async Task ConflictingMetricTypesAreDroppedFromAScrape()
     {
         using var meter = new Meter(Utils.GetCurrentMethodName());

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -336,6 +336,56 @@ public sealed class PrometheusCollectionManagerTests
     }
 
     [Fact]
+    public async Task MetricMetadataDiscoveredLaterIsWrittenBeforeSamples()
+    {
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+#if PROMETHEUS_HTTP_LISTENER
+            .AddPrometheusHttpListener()
+#elif PROMETHEUS_ASPNETCORE
+            .AddPrometheusExporter()
+#endif
+            .Build();
+
+#pragma warning disable CA2000
+        Assert.True(provider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000
+
+        var counter1 = meter.CreateCounter<int>("test.metric");
+        var counter2 = meter.CreateCounter<int>("test-metric", description: "Test help");
+
+        counter1.Add(1, [new("source", "a")]);
+        counter2.Add(2, [new("source", "b")]);
+
+        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        try
+        {
+            var view = response.PlainTextView;
+            var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
+
+            var typeIndex = output.IndexOf("# TYPE test_metric_total counter", StringComparison.Ordinal);
+            var helpIndex = output.IndexOf("# HELP test_metric_total Test help", StringComparison.Ordinal);
+            var sampleAIndex = output.IndexOf("test_metric_total{otel_scope_name=\"" + meter.Name + "\",source=\"a\"} 1", StringComparison.Ordinal);
+            var sampleBIndex = output.IndexOf("test_metric_total{otel_scope_name=\"" + meter.Name + "\",source=\"b\"} 2", StringComparison.Ordinal);
+
+            Assert.True(typeIndex >= 0, "No TYPE found.");
+            Assert.True(helpIndex >= 0, "No HELP found.");
+            Assert.True(sampleAIndex >= 0, "No sample A found.");
+            Assert.True(sampleBIndex >= 0, "No sample B found.");
+            Assert.True(typeIndex < sampleAIndex, "TYPE appears after sample A.");
+            Assert.True(typeIndex < sampleBIndex, "TYPE appears after sample B.");
+            Assert.True(helpIndex < sampleAIndex, "HELP appears after sample A.");
+            Assert.True(helpIndex < sampleBIndex, "HELP appears after sample B.");
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect();
+        }
+    }
+
+    [Fact]
     public async Task ConflictingMetricTypesAreDroppedFromAScrape()
     {
         using var meter = new Meter(Utils.GetCurrentMethodName());

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
+using System.Text;
+using System.Text.RegularExpressions;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using Xunit;
@@ -288,6 +290,86 @@ public sealed class PrometheusCollectionManagerTests
             {
                 exporter.CollectionManager.ExitCollect();
             }
+        }
+    }
+
+    [Fact]
+    public async Task DuplicateMetricMetadataIsWrittenOncePerScrape()
+    {
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+#if PROMETHEUS_HTTP_LISTENER
+            .AddPrometheusHttpListener()
+#elif PROMETHEUS_ASPNETCORE
+            .AddPrometheusExporter()
+#endif
+            .Build();
+
+#pragma warning disable CA2000
+        Assert.True(provider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000
+
+        var counter1 = meter.CreateCounter<int>("test.metric", unit: "By", description: "Test help");
+        var counter2 = meter.CreateCounter<int>("test-metric", unit: "By", description: "Test help");
+
+        counter1.Add(1, [new("source", "a")]);
+        counter2.Add(2, [new("source", "b")]);
+
+        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        try
+        {
+            var view = response.PlainTextView;
+            var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
+
+            Assert.Single(Regex.Matches(output, "^# TYPE test_metric_bytes_total counter$", RegexOptions.Multiline).Cast<Match>());
+            Assert.Single(Regex.Matches(output, "^# UNIT test_metric_bytes_total bytes$", RegexOptions.Multiline).Cast<Match>());
+            Assert.Single(Regex.Matches(output, "^# HELP test_metric_bytes_total Test help$", RegexOptions.Multiline).Cast<Match>());
+            Assert.Contains("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"a\"} 1", output, StringComparison.Ordinal);
+            Assert.Contains("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"b\"} 2", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect();
+        }
+    }
+
+    [Fact]
+    public async Task ConflictingMetricTypesAreDroppedFromAScrape()
+    {
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+#if PROMETHEUS_HTTP_LISTENER
+            .AddPrometheusHttpListener()
+#elif PROMETHEUS_ASPNETCORE
+            .AddPrometheusExporter()
+#endif
+            .Build();
+
+#pragma warning disable CA2000
+        Assert.True(provider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000
+
+        var counter = meter.CreateCounter<int>("test.metric");
+        meter.CreateObservableGauge("test-metric", () => 1);
+        counter.Add(1);
+
+        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: true);
+        try
+        {
+            var view = response.OpenMetricsView;
+            var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
+
+            Assert.DoesNotContain("# TYPE test_metric", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("test_metric_total", output, StringComparison.Ordinal);
+            Assert.Contains("# EOF", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect();
         }
     }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -386,6 +386,56 @@ public sealed class PrometheusCollectionManagerTests
     }
 
     [Fact]
+    public async Task MetricUnitDiscoveredLaterIsWrittenBeforeSamples()
+    {
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+#if PROMETHEUS_HTTP_LISTENER
+            .AddPrometheusHttpListener()
+#elif PROMETHEUS_ASPNETCORE
+            .AddPrometheusExporter()
+#endif
+            .Build();
+
+#pragma warning disable CA2000
+        Assert.True(provider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000
+
+        var counter1 = meter.CreateCounter<int>("test.metric.bytes");
+        var counter2 = meter.CreateCounter<int>("test-metric-bytes", unit: "By");
+
+        counter1.Add(1, [new("source", "a")]);
+        counter2.Add(2, [new("source", "b")]);
+
+        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        try
+        {
+            var view = response.PlainTextView;
+            var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
+
+            var typeIndex = output.IndexOf("# TYPE test_metric_bytes_total counter", StringComparison.Ordinal);
+            var unitIndex = output.IndexOf("# UNIT test_metric_bytes_total bytes", StringComparison.Ordinal);
+            var sampleAIndex = output.IndexOf("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"a\"} 1", StringComparison.Ordinal);
+            var sampleBIndex = output.IndexOf("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"b\"} 2", StringComparison.Ordinal);
+
+            Assert.True(typeIndex >= 0, "No TYPE found.");
+            Assert.True(unitIndex >= 0, "No UNIT found.");
+            Assert.True(sampleAIndex >= 0, "No sample A found.");
+            Assert.True(sampleBIndex >= 0, "No sample B found.");
+            Assert.True(typeIndex < sampleAIndex, "TYPE appears after sample A.");
+            Assert.True(typeIndex < sampleBIndex, "TYPE appears after sample B.");
+            Assert.True(unitIndex < sampleAIndex, "UNIT appears after sample A.");
+            Assert.True(unitIndex < sampleBIndex, "UNIT appears after sample B.");
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect();
+        }
+    }
+
+    [Fact]
     public async Task ConflictingMetricTypesAreDroppedFromAScrape()
     {
         using var meter = new Meter(Utils.GetCurrentMethodName());

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace OpenTelemetry.Exporter.Prometheus.HttpListener.Tests;
 [Collection(PromToolCollection.Name)]
 public class PrometheusIntegrationTests(PromToolFixture fixture, ITestOutputHelper outputHelper)
 {
-    [EnabledOnDockerPlatformTheory(DockerPlatform.Linux, Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/pull/7240")]
+    [EnabledOnDockerPlatformTheory(DockerPlatform.Linux)]
     [InlineData("")]
     [InlineData("text/plain")]
     [InlineData("text/plain;version=0.0.4")]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -104,7 +104,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_gauge gauge\n"
@@ -130,7 +130,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_gauge_seconds gauge\n"
@@ -156,7 +156,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_gauge_seconds gauge\n"
@@ -185,7 +185,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_gauge gauge\n"
@@ -212,7 +212,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_gauge gauge\n"
@@ -239,7 +239,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_gauge gauge\n"
@@ -303,7 +303,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_gauge gauge\n"
@@ -332,7 +332,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_counter_total counter\n"
@@ -361,7 +361,7 @@ public sealed class PrometheusSerializerTests
             provider.ForceFlush();
         }
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_counter_total counter\n"
@@ -388,7 +388,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_updown_counter gauge\n"
@@ -460,7 +460,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_histogram histogram\n"
@@ -504,7 +504,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_histogram histogram\n"
@@ -549,7 +549,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_histogram histogram\n"
@@ -594,7 +594,7 @@ public sealed class PrometheusSerializerTests
 
         provider.ForceFlush();
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         Assert.Matches(
             ("^"
                 + "# TYPE test_histogram histogram\n"
@@ -1076,7 +1076,18 @@ public sealed class PrometheusSerializerTests
 
         var prometheusMetric = new PrometheusMetric(metric.Name, metric.Unit, PrometheusType.Histogram, disableTotalNameSuffixForCounters: false);
 
-        var cursor = PrometheusSerializer.WriteMetric(buffer, 0, metric, prometheusMetric, openMetricsRequested: false);
+        var cursor = PrometheusSerializer.WriteMetric(
+            buffer,
+            0,
+            metric,
+            prometheusMetric,
+            openMetricsRequested: false,
+            writeType: true,
+            writeUnit: true,
+            writeHelp: true,
+            unitOverride: null,
+            helpOverride: null);
+
         var output = Encoding.UTF8.GetString(buffer, 0, cursor);
 
         Assert.Contains("test_histogram_bucket{otel_scope_name=\"\u65e5\u672c\",_=\"meterTagValue\",le=\"0\"} 0\n", output, StringComparison.Ordinal);
@@ -1120,8 +1131,18 @@ public sealed class PrometheusSerializerTests
         static char GetHexValue(int value) => (char)(value < 10 ? '0' + value : 'A' + (value - 10));
     }
 
-    private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics = false)
-        => PrometheusSerializer.WriteMetric(buffer, cursor, metric, PrometheusMetric.Create(metric, false), useOpenMetrics);
+    private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics) =>
+        PrometheusSerializer.WriteMetric(
+            buffer,
+            cursor,
+            metric,
+            PrometheusMetric.Create(metric, false),
+            useOpenMetrics,
+            writeType: true,
+            writeUnit: true,
+            writeHelp: true,
+            unitOverride: null,
+            helpOverride: null);
 
     private static void WaitForNextExemplarTimestamp()
     {
@@ -1148,7 +1169,7 @@ public sealed class PrometheusSerializerTests
             provider.ForceFlush();
         }
 
-        var cursor = WriteMetric(buffer, 0, metrics[0]);
+        var cursor = WriteMetric(buffer, 0, metrics[0], useOpenMetrics: false);
         return Encoding.UTF8.GetString(buffer, 0, cursor);
     }
 }


### PR DESCRIPTION
## Changes

Deduplicate HELP/UNIT/TYPE metadata within a scrape, and drop entire metric families when TYPE metadata conflicts would make the output invalid.

Enable Prometheus integration tests with promtool added by #7241 that now pass.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
