### PR TITLE
[Prometheus.HttpListener] disposal/shutdown lifecycle hardening

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -13,6 +13,8 @@ internal sealed class PrometheusHttpListener : IDisposable
     private readonly HttpListener httpListener = new();
     private readonly Lock syncObject = new();
 
+    private volatile bool disposed;
+    private int activeRequestCount;
     private CancellationTokenSource? tokenSource;
     private Task? workerThread;
 
@@ -77,6 +79,15 @@ internal sealed class PrometheusHttpListener : IDisposable
     {
         lock (this.syncObject)
         {
+#if NET
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+#else
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(nameof(PrometheusHttpListener));
+            }
+#endif
+
             if (this.tokenSource != null)
             {
                 return;
@@ -85,18 +96,56 @@ internal sealed class PrometheusHttpListener : IDisposable
             this.httpListener.Start();
 
             // link the passed in token if not null
-            this.tokenSource = token == default ?
+            this.tokenSource = token == CancellationToken.None ?
                 new CancellationTokenSource() :
                 CancellationTokenSource.CreateLinkedTokenSource(token);
 
-            this.workerThread = Task.Factory.StartNew(this.WorkerProc, default, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            var workerToken = this.tokenSource.Token;
+            this.workerThread = Task.Factory.StartNew(paramToken => this.WorkerProc((CancellationToken)paramToken!), workerToken, workerToken, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        lock (this.syncObject)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+        }
+
+        this.Stop();
+
+        // Wait for in-flight requests to finish (they will observe the
+        // cancelled token and return 503 quickly). Use a timeout to avoid
+        // blocking indefinitely if a request is unexpectedly stuck.
+        SpinWait.SpinUntil(() => Volatile.Read(ref this.activeRequestCount) == 0, TimeSpan.FromSeconds(5));
+
+        try
+        {
+            this.httpListener.Stop();
+            this.httpListener.Close();
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException or HttpListenerException)
+        {
+        }
+    }
+
+    private static bool AcceptsOpenMetrics(HttpListenerRequest request)
+    {
+        var acceptHeader = request.Headers["Accept"];
+
+        return !string.IsNullOrEmpty(acceptHeader) && PrometheusHeadersParser.AcceptsOpenMetrics(acceptHeader);
     }
 
     /// <summary>
     /// Gracefully stop the PrometheusHttpListener.
     /// </summary>
-    public void Stop()
+    private void Stop()
     {
         CancellationTokenSource? tokenSource;
         Task? workerThread;
@@ -126,28 +175,8 @@ internal sealed class PrometheusHttpListener : IDisposable
         }
     }
 
-    /// <inheritdoc/>
-    public void Dispose()
+    private void WorkerProc(CancellationToken cancellationToken)
     {
-        this.Stop();
-
-        if (this.httpListener.IsListening)
-        {
-            this.httpListener.Close();
-        }
-    }
-
-    private static bool AcceptsOpenMetrics(HttpListenerRequest request)
-    {
-        var acceptHeader = request.Headers["Accept"];
-
-        return !string.IsNullOrEmpty(acceptHeader) && PrometheusHeadersParser.AcceptsOpenMetrics(acceptHeader);
-    }
-
-    private void WorkerProc()
-    {
-        var cancellationToken = this.tokenSource!.Token;
-
         try
         {
             using var scope = SuppressInstrumentationScope.Begin();
@@ -157,7 +186,20 @@ internal sealed class PrometheusHttpListener : IDisposable
                 ctxTask.Wait(cancellationToken);
                 var ctx = ctxTask.Result;
 
-                Task.Run(() => this.ProcessRequestAsync(ctx));
+                Interlocked.Increment(ref this.activeRequestCount);
+                Task.Run(
+                    async () =>
+                    {
+                        try
+                        {
+                            await this.ProcessRequestAsync(ctx, cancellationToken).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            Interlocked.Decrement(ref this.activeRequestCount);
+                        }
+                    },
+                    CancellationToken.None);
             }
         }
         catch (OperationCanceledException ex)
@@ -166,20 +208,41 @@ internal sealed class PrometheusHttpListener : IDisposable
         }
         finally
         {
-            try
+            // If the worker exited due to an external token cancellation (not
+            // Dispose), clean up the listener here. When Dispose() is the caller
+            // it will handle stop/close itself after draining in-flight requests.
+            if (!this.disposed)
             {
-                this.httpListener.Stop();
-                this.httpListener.Close();
-            }
-            catch (Exception exFromFinally)
-            {
-                PrometheusExporterEventSource.Log.FailedShutdown(exFromFinally);
+                try
+                {
+                    this.httpListener.Stop();
+                    this.httpListener.Close();
+                }
+                catch (Exception exFromFinally)
+                {
+                    PrometheusExporterEventSource.Log.FailedShutdown(exFromFinally);
+                }
             }
         }
     }
 
-    private async Task ProcessRequestAsync(HttpListenerContext context)
+    private async Task ProcessRequestAsync(HttpListenerContext context, CancellationToken cancellationToken)
     {
+        if (this.disposed || cancellationToken.IsCancellationRequested)
+        {
+            context.Response.StatusCode = 503;
+
+            try
+            {
+                context.Response.Close();
+            }
+            catch
+            {
+            }
+
+            return;
+        }
+
         try
         {
             var openMetricsRequested = AcceptsOpenMetrics(context.Request);
@@ -187,6 +250,8 @@ internal sealed class PrometheusHttpListener : IDisposable
 
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 context.Response.Headers.Add("Server", string.Empty);
 
                 var dataView = openMetricsRequested ? collectionResponse.OpenMetricsView : collectionResponse.PlainTextView;
@@ -200,9 +265,9 @@ internal sealed class PrometheusHttpListener : IDisposable
                         : "text/plain; charset=utf-8; version=0.0.4";
 
 #if NET
-                    await context.Response.OutputStream.WriteAsync(dataView.Array.AsMemory(0, dataView.Count)).ConfigureAwait(false);
+                    await context.Response.OutputStream.WriteAsync(dataView.Array.AsMemory(0, dataView.Count), cancellationToken).ConfigureAwait(false);
 #else
-                    await context.Response.OutputStream.WriteAsync(dataView.Array, 0, dataView.Count).ConfigureAwait(false);
+                    await context.Response.OutputStream.WriteAsync(dataView.Array, 0, dataView.Count, cancellationToken).ConfigureAwait(false);
 #endif
                 }
                 else
@@ -216,6 +281,10 @@ internal sealed class PrometheusHttpListener : IDisposable
             {
                 this.exporter.CollectionManager.ExitCollect();
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            context.Response.StatusCode = 503;
         }
         catch (Exception ex)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -104,7 +104,7 @@ internal sealed class PrometheusHttpListener : IDisposable
             this.workerThread = Task.Factory.StartNew(
                 (paramToken) => this.ProcessingLoopAsync((CancellationToken)paramToken!),
                 workerToken,
-                workerToken,
+                CancellationToken.None,
                 TaskCreationOptions.LongRunning,
                 TaskScheduler.Default).Unwrap();
         }
@@ -140,6 +140,13 @@ internal sealed class PrometheusHttpListener : IDisposable
         }
     }
 
+    private static bool AcceptsOpenMetrics(HttpListenerRequest request)
+    {
+        var acceptHeader = request.Headers["Accept"];
+
+        return !string.IsNullOrEmpty(acceptHeader) && PrometheusHeadersParser.AcceptsOpenMetrics(acceptHeader);
+    }
+
     /// <summary>
     /// Gracefully stop the PrometheusHttpListener.
     /// </summary>
@@ -171,13 +178,6 @@ internal sealed class PrometheusHttpListener : IDisposable
         {
             tokenSource.Dispose();
         }
-    }
-
-    private static bool AcceptsOpenMetrics(HttpListenerRequest request)
-    {
-        var acceptHeader = request.Headers["Accept"];
-
-        return !string.IsNullOrEmpty(acceptHeader) && PrometheusHeadersParser.AcceptsOpenMetrics(acceptHeader);
     }
 
     private async Task ProcessingLoopAsync(CancellationToken cancellationToken)

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -365,57 +365,20 @@ public class PrometheusHttpListenerTests
         => Assert.Equal(9464, new PrometheusHttpListenerOptions().Port);
 
     [Fact]
-    public async Task PrometheusHttpListenerStopDoesNotWaitForInFlightRequest()
+    public void PrometheusHttpListenerDisposeImmediatelyAfterStartDoesNotThrow()
     {
-        var timeout = TimeSpan.FromSeconds(5);
-
-        using var collectStarted = new ManualResetEventSlim();
-        using var allowCollectToComplete = new ManualResetEventSlim();
-
         using var context = CreateListener();
+        context.Listener.Dispose();
+    }
 
-        context.Exporter.Collect = _ =>
-        {
-            collectStarted.Set();
+    [Fact]
+    public void PrometheusHttpListenerDisposeAfterStartWithCanceledTokenDoesNotThrow()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
 
-            return
-                allowCollectToComplete.Wait(timeout) ?
-                true :
-                throw new TimeoutException("Timed out waiting for the test to release the scrape.");
-        };
-
-        using var client = new HttpClient() { BaseAddress = context.BaseAddress };
-
-        var requestTask = client.GetAsync(new Uri("metrics", UriKind.Relative));
-
-        Assert.True(collectStarted.Wait(timeout));
-
-        var stopTask = Task.Run(context.Listener.Stop);
-
-        try
-        {
-            using var cts = new CancellationTokenSource(timeout);
-            var completedTask = await Task.WhenAny(stopTask, Task.Delay(timeout, cts.Token));
-
-            Assert.Same(stopTask, completedTask);
-
-            await stopTask;
-        }
-        finally
-        {
-            allowCollectToComplete.Set();
-
-            try
-            {
-                using var response = await requestTask;
-            }
-            catch (HttpRequestException)
-            {
-            }
-            catch (TaskCanceledException)
-            {
-            }
-        }
+        using var context = CreateListener(startToken: cancellationTokenSource.Token);
+        context.Listener.Dispose();
     }
 
     [Fact]
@@ -640,7 +603,8 @@ public class PrometheusHttpListenerTests
 
     private static PrometheusTestContext CreateListener(
         Action<PrometheusExporterOptions>? configureExporter = null,
-        Action<PrometheusHttpListenerOptions>? configureListener = null)
+        Action<PrometheusHttpListenerOptions>? configureListener = null,
+        CancellationToken startToken = default)
     {
         var maximumAttempts = 5;
         var attemptsLeft = maximumAttempts;
@@ -675,7 +639,7 @@ public class PrometheusHttpListenerTests
 
                 try
                 {
-                    listener.Start();
+                    listener.Start(startToken);
                     boundPort = port;
 
                     return new(exporter, listener, boundPort);

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -142,7 +142,7 @@ public class PrometheusHttpListenerTests
             counter.Add(1);
         }
 
-        using var client = new HttpClient()
+        using var client = new HttpClient
         {
             BaseAddress = context.BaseAddress,
         };
@@ -181,7 +181,7 @@ public class PrometheusHttpListenerTests
         Assert.Equal(host, context.BaseAddress.Host);
         Assert.Equal(port, context.Port);
 
-        using var client = new HttpClient() { BaseAddress = context.BaseAddress };
+        using var client = new HttpClient { BaseAddress = context.BaseAddress };
         using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -203,7 +203,7 @@ public class PrometheusHttpListenerTests
         Assert.Equal("localhost", context.BaseAddress.Host);
         Assert.Equal(port, context.Port);
 
-        using var client = new HttpClient() { BaseAddress = context.BaseAddress };
+        using var client = new HttpClient { BaseAddress = context.BaseAddress };
         using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -232,7 +232,7 @@ public class PrometheusHttpListenerTests
 
         Assert.Equal(9464, context.Port);
 
-        using var client = new HttpClient() { BaseAddress = context.BaseAddress };
+        using var client = new HttpClient { BaseAddress = context.BaseAddress };
         using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -261,10 +261,99 @@ public class PrometheusHttpListenerTests
         Assert.Equal(port, context.Port);
         Assert.Equal($"http://localhost:{port}/", context.BaseAddress.ToString());
 
-        using var client = new HttpClient() { BaseAddress = context.BaseAddress };
+        using var client = new HttpClient { BaseAddress = context.BaseAddress };
         using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public void Start_ThrowsObjectDisposedException_AfterDisposal()
+    {
+        using var exporter = new PrometheusExporter(new());
+        var listener = new PrometheusHttpListener(
+            exporter,
+            new()
+            {
+                Host = "localhost",
+                Port = GetRandomPort(),
+            });
+
+        listener.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => listener.Start());
+    }
+
+    [Fact]
+    public async Task ProcessRequest_Returns503_AfterDisposal()
+    {
+        using var meter = new Meter(MeterName, MeterVersion);
+
+        var port = GetRandomPort();
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddPrometheusHttpListener(options =>
+            {
+                options.Host = "localhost";
+                options.Port = port;
+            })
+            .Build();
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        if (!provider.TryFindExporter(out PrometheusExporter? exporter))
+#pragma warning restore CA2000 // Dispose objects before losing scope
+        {
+            throw new InvalidOperationException("PrometheusExporter could not be found on MeterProvider.");
+        }
+
+        // Create a counter and record a value so that collection has something to export.
+        var counter = meter.CreateCounter<int>("test_counter");
+        counter.Add(1);
+
+        // Replace the Collect delegate with one that blocks until we release it.
+        // This lets us hold a request inside ProcessRequestAsync (in EnterCollect)
+        // while we trigger disposal.
+        using var collectBlocker = new ManualResetEventSlim(false);
+        using var collectEntered = new ManualResetEventSlim(false);
+        var originalCollect = exporter.Collect;
+        exporter.Collect = (timeout) =>
+        {
+            collectEntered.Set();
+            collectBlocker.Wait(TimeSpan.FromSeconds(10));
+            return originalCollect!(timeout);
+        };
+
+        var baseAddress = new UriBuilder(Uri.UriSchemeHttp, "localhost", port).Uri;
+        using var client = new HttpClient { BaseAddress = baseAddress };
+
+        // Send a scrape request; it will block inside EnterCollect.
+        var scrapeTask = client.GetAsync(new Uri("metrics", UriKind.Relative));
+
+        // Wait until the request is actually inside the Collect delegate.
+        Assert.True(collectEntered.Wait(TimeSpan.FromSeconds(10)), "Request did not enter Collect in time.");
+
+        // Dispose the provider on a background thread. This sets disposed = true,
+        // cancels the CancellationToken, and then blocks on SpinWait waiting for
+        // the in-flight request to drain.
+        var disposeTask = Task.Run(() => provider.Dispose());
+
+        // Confirm Dispose() is actually blocked (meaning it has cancelled the
+        // token and is now waiting for activeRequestCount to reach 0). If
+        // disposeTask completes within 500ms it means the request wasn't held.
+        var completed = await Task.WhenAny(disposeTask, Task.Delay(500));
+        Assert.NotSame(disposeTask, completed);
+
+        // Release the blocker so EnterCollect can finish.
+        // After EnterCollect completes, ProcessRequestAsync will hit
+        // cancellationToken.ThrowIfCancellationRequested() and return 503.
+        collectBlocker.Set();
+
+        // Wait for both the scrape response and disposal to complete.
+        using var response = await scrapeTask;
+        await disposeTask;
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
     }
 
     [Fact]
@@ -344,7 +433,7 @@ public class PrometheusHttpListenerTests
             counter.Add(0.99D, counterTags);
         }
 
-        using var client = new HttpClient()
+        using var client = new HttpClient
         {
             BaseAddress = context.BaseAddress,
         };
@@ -418,7 +507,7 @@ public class PrometheusHttpListenerTests
         var attemptsLeft = maximumAttempts;
         int boundPort = 0;
 
-        var options = new PrometheusHttpListenerOptions()
+        var options = new PrometheusHttpListenerOptions
         {
             Host = "localhost",
         };
@@ -464,7 +553,7 @@ public class PrometheusHttpListenerTests
     [Obsolete("Supports tests for the obsolete UriPrefixes property.")]
     private static PrometheusHttpListenerOptions TestPrometheusHttpListenerUriPrefixOptions(string[] uriPrefixes)
     {
-        var options = new PrometheusHttpListenerOptions()
+        var options = new PrometheusHttpListenerOptions
         {
             UriPrefixes = uriPrefixes,
         };


### PR DESCRIPTION
Fixes some Codex fidings

## Changes

`PrometheusHttpListener` runs request handling on background tasks while lifecycle operations (`Start`, `Stop`, `Dispose`) may happen concurrently. Without explicit disposal-state handling and lifecycle ownership boundaries:

- caller code can accidentally try to restart a disposed listener,
- request processing can continue while shutdown is in progress,
- shutdown behavior becomes non-deterministic and harder to reason about.

Even when this is not externally exploitable, it is reliability-critical for telemetry availability and clean host shutdown behavior.

### What changed

- Listener tracks disposal state (`disposed`) and rejects `Start()` after disposal.
- `Stop()` remains private to keep lifecycle control internal.
- Request handling short-circuits with `503` after disposal, avoiding further processing during teardown.

### Impact

- Reduces lifecycle race-related failures.
- Makes shutdown semantics explicit and predictable.
- Improves operational safety for hosts embedding Prometheus scraping endpoint support.


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~ Intentionally skipped
* ~~[ ] Changes in public API reviewed (if applicable)~~
