### PR TITLE
[Repo] Exclude opentelemetrybot from survey

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -13,10 +13,11 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
-    # Only run for merged pull requests by non-members users (i.e. not bots)
+    # Only run for merged pull requests by non-members users (i.e. not bots or opentelemetrybot)
     if: |
       github.event.pull_request.merged &&
       github.event.pull_request.user.type == 'User' &&
+      github.event.pull_request.user.id != 107717825 &&
       contains(fromJson('["CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"]'), github.event.pull_request.author_association)
     steps:
       - name: Add comment


### PR DESCRIPTION
## Changes

Do not ask `opentelemetrybot` to fill in a survey if it has a PR merged (e.g. https://github.com/open-telemetry/opentelemetry-dotnet/pull/7230#issuecomment-4376704270).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
