### PR TITLE
[Prometheus.HttpListener] Harden env. var. port parsing

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -52,7 +52,8 @@ Notes](../../RELEASENOTES.md).
 * Add support for configuring the HTTP listener endpoint host and port using
   the `OTEL_EXPORTER_PROMETHEUS_HOST` and `OTEL_EXPORTER_PROMETHEUS_PORT`
   environment variables.
-  ([#7167](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7167))
+  ([#7167](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7167),
+  [#7255](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7255))
 
 * Fix Prometheus/OpenMetrics serialization to emit metric and label names
   containing and `_` instead of dropping them and prefixing leading digits.

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
@@ -71,7 +71,7 @@ internal sealed class PrometheusExporterEventSource : EventSource, IConfiguratio
     public void InvalidConfigurationValue(string key, string value)
         => this.WriteEvent(5, key, value);
 
-    void IConfigurationExtensionsLogger.LogInvalidConfigurationValue(string key, string value)
+    public void LogInvalidConfigurationValue(string key, string value)
         => this.InvalidConfigurationValue(key, value);
 
     [Event(6, Message = "Dropping metric family '{0}' due to conflicting TYPE metadata '{1}' and '{2}'.", Level = EventLevel.Warning)]

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Globalization;
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter.Prometheus;
 using OpenTelemetry.Internal;
@@ -37,6 +38,11 @@ public class PrometheusHttpListenerOptions
 
         if (!configuration.TryGetIntValue(PrometheusExporterEventSource.Log, PrometheusPortEnvVar, out var port))
         {
+            port = 9464;
+        }
+        else if (port is <= 0 or > 65535)
+        {
+            PrometheusExporterEventSource.Log.LogInvalidConfigurationValue(PrometheusPortEnvVar, port.ToString(CultureInfo.InvariantCulture));
             port = 9464;
         }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -40,7 +40,7 @@ public class PrometheusHttpListenerOptions
         {
             port = 9464;
         }
-        else if (port is <= 0 or > 65535)
+        else if (port is <= 0 or > ushort.MaxValue)
         {
             PrometheusExporterEventSource.Log.LogInvalidConfigurationValue(PrometheusPortEnvVar, port.ToString(CultureInfo.InvariantCulture));
             port = 9464;

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
@@ -108,6 +108,34 @@ public sealed class PrometheusHttpListenerMeterProviderBuilderExtensionsTests
         }
     }
 
+    [Theory]
+    [InlineData("65536")]
+    [InlineData("0")]
+    [InlineData("-1")]
+    public void TestAddPrometheusHttpListener_Configuration_From_Environment_Variables_Ignores_OutOfRange_Port(string port)
+    {
+        using (EnvironmentVariableScope.Create(
+            [
+                ("OTEL_EXPORTER_PROMETHEUS_PORT", port),
+            ]))
+        {
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddPrometheusHttpListener()
+                .Build();
+
+            var serviceProvider = meterProvider.GetServiceProvider();
+
+            Assert.NotNull(serviceProvider);
+
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<PrometheusHttpListenerOptions>>();
+
+            Assert.NotNull(options);
+            Assert.NotNull(options.CurrentValue);
+
+            Assert.Equal(9464, options.CurrentValue.Port);
+        }
+    }
+
     [Fact]
     public void TestAddPrometheusHttpListener_Manual_Configuration_Overrides_Environment_Variables()
     {


### PR DESCRIPTION
Fixes Codex scna findins
Follow up to #7255

## Changes

[Promehteus.HttpListener] Harden env. var. port parsing
Ignores port values from invalid ranges.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
