### PR TITLE
[Exporter.Prometheus] Add security note to READMEs

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md
@@ -18,6 +18,19 @@ to scrape.
   Grafana](../../docs/metrics/getting-started-prometheus-grafana/README.md)
   tutorial for more information.
 
+<!-- Comment to separate the notes -->
+
+> [!IMPORTANT]
+> The Prometheus scraping endpoint is not secured by default, so it is important
+> to consider the security implications of exposing this endpoint in your application.
+>
+> Refer to the
+> [Prometheus Security model](https://prometheus.io/docs/operating/security/) and
+> [ASP.NET Core security](https://learn.microsoft.com/en-us/aspnet/core/security/)
+> documentation for more information and guidance on securing the Prometheus
+> scraping endpoint to ensure only authorized users can access the information
+> exposed by it.
+
 ## Prerequisite
 
 * [Get Prometheus](https://prometheus.io/docs/introduction/first_steps/)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md
@@ -15,6 +15,19 @@ instance for Prometheus to scrape.
   Grafana](../../docs/metrics/getting-started-prometheus-grafana/README.md)
   tutorial for more information.
 
+<!-- Comment to separate the notes -->
+
+> [!IMPORTANT]
+> The Prometheus scraping endpoint is not secured by default, so it is important
+> to consider the security implications of exposing this endpoint in your application.
+>
+> Refer to the
+> [Prometheus Security model](https://prometheus.io/docs/operating/security/) and
+> the [HttpListener class](https://learn.microsoft.com/dotnet/fundamentals/runtime-libraries/system-net-httplistener)
+> documentation for more information and guidance on securing the Prometheus
+> scraping endpoint to ensure only authorized users can access the information
+> exposed by it.
+
 ## Prerequisite
 
 * [Get Prometheus](https://prometheus.io/docs/introduction/first_steps/)


### PR DESCRIPTION
Relates to #7264.

## Changes

Add a note to users about ensuring that Prometheus scrape endpoints are secure.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
