### PR TITLE
docs: Warn that View-dropped attributes still appear on Exemplars

### DIFF
--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -191,7 +191,7 @@ with the metric are of interest to you.
 > drops them from the **aggregated metric** stream, but does **not**
 > drop them from any [Exemplars](#exemplars) recorded for the same
 > instrument. Dropped attributes are preserved on Exemplars as
-> *filtered tags* — see the [Exemplars](#exemplars) section below for
+> *filtered tags* - see the [Exemplars](#exemplars) section below for
 > details.
 >
 > If the goal of dropping the attribute is **data redaction** (for

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -186,6 +186,25 @@ with the metric are of interest to you.
     ...
 ```
 
+> [!IMPORTANT]
+> Restricting `TagKeys` (or otherwise dropping attributes via a `View`)
+> drops them from the **aggregated metric** stream, but does **not**
+> drop them from any [Exemplars](#exemplars) recorded for the same
+> instrument. Dropped attributes are preserved on Exemplars as
+> *filtered tags* — see the [Exemplars](#exemplars) section below for
+> details.
+>
+> If the goal of dropping the attribute is **data redaction** (for
+> example, removing an attribute containing sensitive data), the View
+> alone is **not** sufficient when Exemplars are enabled. Either keep
+> the default `ExemplarFilterType.AlwaysOff` to disable Exemplars
+> entirely, or configure a custom `ExemplarFilter` /
+> `ExemplarReservoir` to control which measurements are sampled. See
+> [opentelemetry-specification#5073][spec-pr-5073] for the
+> corresponding spec clarification.
+
+[spec-pr-5073]: https://github.com/open-telemetry/opentelemetry-specification/pull/5073
+
 #### Configuring the aggregation of a Histogram
 
 There are two types of


### PR DESCRIPTION
Fixes #
Design discussion issue # — companion to [open-telemetry/opentelemetry-specification#5073](https://github.com/open-telemetry/opentelemetry-specification/pull/5073)

## Changes

Adds an `IMPORTANT` callout to the **Select specific tags** subsection of `docs/metrics/customizing-the-sdk/README.md` clarifying that restricting `TagKeys` (or otherwise dropping attributes via a `View`) drops them from the aggregated metric stream but does **not** drop them from any Exemplars recorded for the same instrument.

The existing Exemplars section already mentions *Filtered Tags* in passing — but users who drop attributes for **data-redaction** purposes (e.g. removing an attribute containing sensitive data) currently have no in-place warning that the View alone is insufficient when Exemplars are enabled.

This PR adds the explicit warning along with the recommended mitigations:
- Keep the current .NET default (`ExemplarFilterType.AlwaysOff`) to disable Exemplars entirely, **or**
- Configure a custom `ExemplarFilter` / `ExemplarReservoir` to control which measurements are sampled.

Companion to [open-telemetry/opentelemetry-specification#5073](https://github.com/open-telemetry/opentelemetry-specification/pull/5073), which adds the same clarification to the spec.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated — N/A (docs-only change)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes — N/A (docs-only change)
* [ ] Changes in public API reviewed (if applicable) — N/A (docs-only change)