### PR TITLE
[Prometheus.HttpListener] Fix event log

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterEventSource.cs
@@ -71,6 +71,7 @@ internal sealed class PrometheusExporterEventSource : EventSource, IConfiguratio
     public void InvalidConfigurationValue(string key, string value)
         => this.WriteEvent(5, key, value);
 
+    [NonEvent]
     public void LogInvalidConfigurationValue(string key, string value)
         => this.InvalidConfigurationValue(key, value);
 


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/pull/7255

## Changes

Codex finding:

The intended out-of-range port fallback is a bug fix, but the commit introduces a reliability regression in PrometheusExporterEventSource by exposing a helper as a public EventSource method without [NonEvent]. No direct exploitable security issue was found.

PrometheusExporterEventSource.LogInvalidConfigurationValue was changed from an explicit interface implementation to a public method so PrometheusHttpListenerOptions can call it directly when rejecting out-of-range ports. In EventSource-derived types, public void instance methods are treated as event methods unless they are annotated with [NonEvent] or [Event]. This helper is not intended to be an event method; it delegates to InvalidConfigurationValue instead. Leaving it public and unannotated can make EventSource manifest generation/runtime validation treat it as an implicit event, potentially conflicting with existing event IDs or causing EventSource validation failures. The safe fix is to either keep the explicit interface implementation and invoke through the interface, or add [NonEvent] to the public helper.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
