### PR TITLE
[Prometheus.AspNetCore] Add scrape benchmark

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <PackageReference Include="Grpc.AspNetCore.Server" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
@@ -25,9 +26,14 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.InMemory\OpenTelemetry.Exporter.InMemory.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" Aliases="OpenTelemetryProtocol" />
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj" Aliases="Zipkin" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\OpenTelemetry.Exporter.Prometheus.HttpListener.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj" Aliases="Zipkin" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Propagators\OpenTelemetry.Extensions.Propagators.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.AspNetCore\OpenTelemetry.Exporter.Prometheus.AspNetCore.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Benchmarks/Exporter/PrometheusAspNetCoreScrapeEndpointBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusAspNetCoreScrapeEndpointBenchmarks.cs
@@ -1,0 +1,110 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Diagnostics.Metrics;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Metrics;
+
+namespace Benchmarks.Exporter;
+
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
+public class PrometheusAspNetCoreScrapeEndpointBenchmarks
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
+{
+    private const string MeterName = "Benchmarks.Exporter.PrometheusAspNetCoreScrapeEndpoint";
+
+    private static readonly Uri MetricsEndpoint = new("/metrics", UriKind.Relative);
+
+    private WebApplication? app;
+    private HttpClient? client;
+    private Meter? meter;
+    private int queueDepth = 3;
+
+    [Params("text/plain", "application/openmetrics-text; version=1.0.0")]
+    public string Accept { get; set; } = string.Empty;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddOpenTelemetry().WithMetrics((metrics) =>
+        {
+            metrics
+                .AddMeter(MeterName)
+                .AddPrometheusExporter((options) => options.ScrapeResponseCacheDurationMilliseconds = 0);
+        });
+
+        this.app = builder.Build();
+
+        this.app.MapPrometheusScrapingEndpoint();
+
+        await this.app.StartAsync().ConfigureAwait(false);
+
+        this.client = this.app.GetTestClient();
+        this.client.DefaultRequestHeaders.TryAddWithoutValidation("Accept", this.Accept);
+
+        this.meter = new Meter(MeterName);
+
+        var requestCounter = this.meter.CreateCounter<long>("http.server.request.count", unit: "{request}");
+        var activeRequests = this.meter.CreateUpDownCounter<long>("http.server.active_requests", unit: "{request}");
+        var requestDuration = this.meter.CreateHistogram<double>("http.server.request.duration", unit: "s");
+        _ = this.meter.CreateObservableGauge("worker.queue.depth", () => this.queueDepth, unit: "{item}");
+
+        for (var i = 0; i < 50; i++)
+        {
+            var route = $"/resource/{i % 10}";
+            var statusCode = 200 + (i % 5);
+            var method = i % 2 == 0 ? "GET" : "POST";
+
+            requestCounter.Add(
+                i + 1,
+                new("http.request.method", method),
+                new("http.route", route),
+                new("http.response.status_code", statusCode));
+
+            activeRequests.Add(1, new("http.request.method", method), new("http.route", route));
+            activeRequests.Add(-1, new("http.request.method", method), new("http.route", route));
+
+            requestDuration.Record(
+                0.005 * (i + 1),
+                new("http.request.method", method),
+                new("http.route", route),
+                new("http.response.status_code", statusCode));
+        }
+
+        this.queueDepth = 7;
+
+        var responseBytes = await this.client.GetByteArrayAsync(MetricsEndpoint).ConfigureAwait(false);
+        if (responseBytes.Length == 0)
+        {
+            throw new InvalidOperationException("The Prometheus scrape endpoint returned an empty payload.");
+        }
+    }
+
+    [GlobalCleanup]
+    public async Task GlobalCleanup()
+    {
+        this.client?.Dispose();
+
+        if (this.app != null)
+        {
+            await this.app.DisposeAsync().ConfigureAwait(false);
+        }
+
+        this.meter?.Dispose();
+    }
+
+    [Benchmark]
+    public async Task<byte[]> ScrapeEndpoint()
+        => await this.client!.GetByteArrayAsync(MetricsEndpoint).ConfigureAwait(false);
+}
+#endif


### PR DESCRIPTION
## Changes

Add a benchmark for the ASP.NET Core Prometheus scrape endpoint.

### Benchmark Results

```text
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8246/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 10.0.203
  [Host]    : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
  .NET 10.0 : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3

Job=.NET 10.0  Runtime=.NET 10.0  Toolchain=net10.0  
```

| Method         | Accept               | Mean     | Error   | StdDev  | Gen0   | Gen1   | Allocated |
|--------------- |--------------------- |---------:|--------:|--------:|-------:|-------:|----------:|
| **ScrapeEndpoint** | **appli(...)1.0.0 [43]** | **114.9 μs** | **2.29 μs** | **2.64 μs** | **4.1504** | **0.4883** |  **53.31 KB** |
| **ScrapeEndpoint** | **text/plain**           | **110.9 μs** | **2.18 μs** | **3.87 μs** | **4.1504** | **0.4883** |  **52.28 KB** |


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
