### PR TITLE
[Infra] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/PooledBufferStream.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/PooledBufferStream.cs
@@ -83,13 +83,13 @@ internal sealed class PooledBufferStream : Stream
 
         this.ThrowIfDisposed();
 
-        int available = this.length - this.position;
+        var available = this.length - this.position;
         if (available <= 0)
         {
             return 0;
         }
 
-        int toCopy = Math.Min(available, count);
+        var toCopy = Math.Min(available, count);
         Buffer.BlockCopy(this.buffer, this.position, buffer, offset, toCopy);
         this.position += toCopy;
 
@@ -101,13 +101,13 @@ internal sealed class PooledBufferStream : Stream
     {
         this.ThrowIfDisposed();
 
-        int available = this.length - this.position;
+        var available = this.length - this.position;
         if (available <= 0)
         {
             return 0;
         }
 
-        int toCopy = Math.Min(available, destination.Length);
+        var toCopy = Math.Min(available, destination.Length);
         this.buffer.AsSpan(this.position, toCopy).CopyTo(destination);
         this.position += toCopy;
 
@@ -124,7 +124,7 @@ internal sealed class PooledBufferStream : Stream
 
         try
         {
-            int bytesRead = this.Read(buffer.Span);
+            var bytesRead = this.Read(buffer.Span);
             return ValueTask.FromResult(bytesRead);
         }
         catch (Exception ex)
@@ -138,7 +138,7 @@ internal sealed class PooledBufferStream : Stream
     {
         this.ThrowIfDisposed();
 
-        long newOffset = origin switch
+        var newOffset = origin switch
         {
             SeekOrigin.Begin => offset,
             SeekOrigin.Current => this.position + offset,
@@ -146,7 +146,7 @@ internal sealed class PooledBufferStream : Stream
             _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, "Invalid seek origin."),
         };
 
-        if (newOffset < 0 || newOffset > int.MaxValue)
+        if (newOffset is < 0 or > int.MaxValue)
         {
             throw new IOException("Attempted to seek outside the bounds of the stream.");
         }
@@ -163,7 +163,7 @@ internal sealed class PooledBufferStream : Stream
         ArgumentOutOfRangeException.ThrowIfNegative(value, nameof(value));
         ArgumentOutOfRangeException.ThrowIfGreaterThan(value, int.MaxValue, nameof(value));
 
-        int newLength = (int)value;
+        var newLength = (int)value;
         this.EnsureCapacity(newLength);
 
         // If we grew length, zero the gap to preserve typical MemoryStream behavior.
@@ -285,7 +285,7 @@ internal sealed class PooledBufferStream : Stream
     private static int ComputeNewCapacity(int minCapacity, int currentCapacity)
     {
         // Growth heuristic: double, with a small starting point.
-        int newCapacity = currentCapacity switch
+        var newCapacity = currentCapacity switch
         {
             <= 0 => 256,
             < 1024 * 1024 => currentCapacity * 2,
@@ -329,7 +329,7 @@ internal sealed class PooledBufferStream : Stream
     {
         Debug.Assert(additionalCount >= 0, $"{nameof(additionalCount)} is negative.");
 
-        long required = (long)this.position + additionalCount;
+        var required = (long)this.position + additionalCount;
         if (required > int.MaxValue)
         {
             throw new IOException($"The stream's buffer cannot be greater than {int.MaxValue} bytes in length.");
@@ -352,11 +352,11 @@ internal sealed class PooledBufferStream : Stream
     {
         this.ThrowIfDisposed();
 
-        byte[] previous = this.buffer;
+        var previous = this.buffer;
 
-        int newCapacity = ComputeNewCapacity(minCapacity, previous.Length);
+        var newCapacity = ComputeNewCapacity(minCapacity, previous.Length);
 
-        byte[] replacement = this.pool.Rent(newCapacity);
+        var replacement = this.pool.Rent(newCapacity);
 
         if (this.length != 0)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -429,11 +429,11 @@ internal sealed class PrometheusCollectionManager
                 metadataState = new MetadataState(metadataState.Type, metadataState.Help, prometheusMetric.Unit);
                 metadataStates[metadataName] = metadataState;
             }
-            else if (!string.IsNullOrEmpty(prometheusMetric.Unit) &&
+            else if (prometheusMetric.Unit is { Length: > 0 } &&
                      metadataState.Unit != null &&
                      metadataState.Unit != prometheusMetric.Unit)
             {
-                PrometheusExporterEventSource.Log.ConflictingUnit(metadataName, metadataState.Unit, prometheusMetric.Unit!);
+                PrometheusExporterEventSource.Log.ConflictingUnit(metadataName, metadataState.Unit, prometheusMetric.Unit);
             }
 
             if (!string.IsNullOrEmpty(metric.Description) &&

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterOptions.cs
@@ -23,7 +23,7 @@ internal sealed class PrometheusExporterOptions
     /// </remarks>
     public int ScrapeResponseCacheDurationMilliseconds
     {
-        get => field;
+        get;
         set
         {
             Guard.ThrowIfOutOfRange(value, min: 0);

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -321,7 +321,7 @@ internal static partial class PrometheusSerializer
 
         foreach (var tag in exemplar.FilteredTags)
         {
-            if (tag.Key == "trace_id" || tag.Key == "span_id")
+            if (tag.Key is "trace_id" or "span_id")
             {
                 continue;
             }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -102,8 +102,7 @@ internal sealed class PrometheusHttpListener : IDisposable
 
             var workerToken = this.tokenSource.Token;
             this.workerThread = Task.Factory.StartNew(
-                (paramToken) => this.ProcessingLoopAsync((CancellationToken)paramToken!),
-                workerToken,
+                () => this.ProcessingLoopAsync(workerToken),
                 CancellationToken.None,
                 TaskCreationOptions.LongRunning,
                 TaskScheduler.Default).Unwrap();

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -79,7 +79,7 @@ public class PrometheusHttpListenerOptions
     /// </remarks>
     public int ScrapeResponseCacheDurationMilliseconds
     {
-        get => field;
+        get;
         set
         {
             Guard.ThrowIfOutOfRange(value, min: 0);

--- a/src/Shared/CharExtensions.cs
+++ b/src/Shared/CharExtensions.cs
@@ -25,7 +25,7 @@ internal static class CharExtensions
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsAsciiLetterUpper(char value) =>
-            value >= 'A' && value <= 'Z';
+            value is >= 'A' and <= 'Z';
     }
 }
 

--- a/test/Benchmarks/Context/BaggageBenchmarks.cs
+++ b/test/Benchmarks/Context/BaggageBenchmarks.cs
@@ -21,15 +21,14 @@ public class BaggageBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        this.sameItems = Enumerable.Range(0, this.ItemCount)
-            .Select(i => new KeyValuePair<string, string?>($"key{i}", $"value{i}"))
-            .ToArray();
+        this.sameItems = [.. Enumerable
+            .Range(0, this.ItemCount)
+            .Select(i => new KeyValuePair<string, string?>($"key{i}", $"value{i}"))];
 
-        this.changedItems = this.sameItems
+        this.changedItems = [.. this.sameItems
             .Select((item, index) => index == this.sameItems.Length - 1
                 ? new KeyValuePair<string, string?>(item.Key, $"{item.Value}-updated")
-                : item)
-            .ToArray();
+                : item)];
 
         var baggageItems = this.sameItems.ToDictionary(item => item.Key, item => item.Value!);
 

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/EnvironmentVariableCarrierFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/EnvironmentVariableCarrierFuzzTests.cs
@@ -107,9 +107,7 @@ public class EnvironmentVariableCarrierFuzzTests
         expected.All(pair => actual.TryGetValue(pair.Key, out var value) && value == pair.Value);
 
     private static bool IsValidEnvironmentCharacter(char value) =>
-        (value >= 'A' && value <= 'Z') ||
-        (value >= '0' && value <= '9') ||
-        value == '_';
+        value is (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '_';
 
-    private static bool IsAsciiDigit(char value) => value >= '0' && value <= '9';
+    private static bool IsAsciiDigit(char value) => value is >= '0' and <= '9';
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
@@ -102,10 +102,10 @@ public class PrometheusSerializerFuzzTests
         {
             var c = value[i];
             var isAllowed =
-                (c is >= 'A' and <= 'Z') ||
-                (c is >= 'a' and <= 'z') ||
-                (c is >= '0' and <= '9') ||
-                c == '_';
+                c is (>= 'A' and <= 'Z') or
+                (>= 'a' and <= 'z') or
+                (>= '0' and <= '9') or
+                '_';
 
             if (i == 0 && c is >= '0' and <= '9')
             {

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -256,24 +256,27 @@ public sealed class PrometheusCollectionManagerTests
 
             await secondCollectStarted.Task;
 
-            var completion = await Task.WhenAny(secondCollectTask, Task.Delay(TimeSpan.FromSeconds(1)));
+            var firstTimeout = TimeSpan.FromSeconds(1);
 
-            Assert.NotSame(secondCollectTask, completion);
-            Assert.False(secondCollectTask.IsCompleted);
+            using (var cts = new CancellationTokenSource(firstTimeout))
+            {
+                var completion = await Task.WhenAny(secondCollectTask, Task.Delay(firstTimeout, cts.Token));
+                Assert.NotSame(secondCollectTask, completion);
+                Assert.False(secondCollectTask.IsCompleted);
+            }
+
             Assert.Equal(1, collectCount);
 
             exporter.CollectionManager.ExitCollect();
             firstCollectExited = true;
 
-            var timeout = TimeSpan.FromSeconds(5);
+            var secondTimeout = TimeSpan.FromSeconds(5);
 
-#if NET
-            await secondCollectTask.WaitAsync(timeout);
-#else
-            using var cts = new CancellationTokenSource(timeout);
-            completion = await Task.WhenAny(secondCollectTask, Task.Delay(timeout, cts.Token));
-            Assert.Same(secondCollectTask, completion);
-#endif
+            using (var cts = new CancellationTokenSource(secondTimeout))
+            {
+                var completion = await Task.WhenAny(secondCollectTask, Task.Delay(secondTimeout, cts.Token));
+                Assert.Same(secondCollectTask, completion);
+            }
 
             var secondResponse = await secondCollectTask;
 
@@ -320,9 +323,11 @@ public sealed class PrometheusCollectionManagerTests
             var view = response.PlainTextView;
             var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
 
+#pragma warning disable SYSLIB1045 // Convert to 'GeneratedRegexAttribute'.
             Assert.Single(Regex.Matches(output, "^# TYPE test_metric_bytes_total counter$", RegexOptions.Multiline).Cast<Match>());
             Assert.Single(Regex.Matches(output, "^# UNIT test_metric_bytes_total bytes$", RegexOptions.Multiline).Cast<Match>());
             Assert.Single(Regex.Matches(output, "^# HELP test_metric_bytes_total Test help$", RegexOptions.Multiline).Cast<Match>());
+#pragma warning restore SYSLIB1045 // Convert to 'GeneratedRegexAttribute'.
             Assert.Contains("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"a\"} 1", output, StringComparison.Ordinal);
             Assert.Contains("test_metric_bytes_total{otel_scope_name=\"" + meter.Name + "\",source=\"b\"} 2", output, StringComparison.Ordinal);
         }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -244,7 +244,7 @@ public class PrometheusHttpListenerTests
     {
         using var meter = new Meter(MeterName, MeterVersion);
 
-        int port = 0;
+        var port = 0;
 
         using var context = CreateMeterProvider(meter, configureListener: (options) =>
         {
@@ -341,7 +341,9 @@ public class PrometheusHttpListenerTests
         // Confirm Dispose() is actually blocked (meaning it has cancelled the
         // token and is now waiting for activeRequestCount to reach 0). If
         // disposeTask completes within 500ms it means the request wasn't held.
-        var completed = await Task.WhenAny(disposeTask, Task.Delay(500));
+        var timeout = TimeSpan.FromSeconds(0.5);
+        using var cts = new CancellationTokenSource(timeout);
+        var completed = await Task.WhenAny(disposeTask, Task.Delay(timeout, cts.Token));
         Assert.NotSame(disposeTask, completed);
 
         // Release the blocker so EnterCollect can finish.
@@ -481,7 +483,7 @@ public class PrometheusHttpListenerTests
 
         while (attemptsLeft-- > 0)
         {
-            int port = -1;
+            var port = -1;
 
             var builder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
@@ -608,7 +610,7 @@ public class PrometheusHttpListenerTests
     {
         var maximumAttempts = 5;
         var attemptsLeft = maximumAttempts;
-        int boundPort = 0;
+        var boundPort = 0;
 
         var exporterOptions = new PrometheusExporterOptions();
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -1231,7 +1231,10 @@ public sealed class PrometheusSerializerTests
 
         return new string(chars);
 
-        static char GetHexValue(int value) => (char)(value < 10 ? '0' + value : 'A' + (value - 10));
+        static char GetHexValue(int value)
+        {
+            return (char)(value < 10 ? '0' + value : 'A' + (value - 10));
+        }
     }
 
     private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics) =>

--- a/test/OpenTelemetry.Tests/Internal/DelegatingOptionsFactoryTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/DelegatingOptionsFactoryTests.cs
@@ -251,8 +251,7 @@ public class DelegatingOptionsFactoryTests
 
         factory.Create(Options.DefaultName);
 
-        static string[] GetExpectedOrder() => ["factory", "configure", "postconfigure", "validate"];
-        Assert.Equal(GetExpectedOrder(), order);
+        Assert.Equal<string>(["factory", "configure", "postconfigure", "validate"], order);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -738,7 +738,7 @@ public class MetricExemplarTests : MetricTestsBase
 
         foreach (var metric in exportedItems)
         {
-            var metricPoint = GetFirstMetricPoint(new[] { metric });
+            var metricPoint = GetFirstMetricPoint([metric]);
             Assert.NotNull(metricPoint);
 
             var exemplars = GetExemplars(metricPoint.Value);


### PR DESCRIPTION
## Changes

Fix new code analysis warnings found with the .NET 11 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
