### PR TITLE
Relax instrument name validation per opentelemetry-specification#5092

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,17 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Relax instrument name validation to accept the expanded character set
+  defined by the OpenTelemetry specification. The allowed character set now
+  includes `:`, `\`, `(`, `)`, `%`, `*`, `#`, and space (with space restricted
+  to non-leading, non-trailing positions), and the first character is no
+  longer required to be alphabetic. This enables, among other things, names
+  shaped like Windows performance counters
+  (`\Processor(_Total)\% Processor Time`,
+  `\.NET CLR Memory(*)\# Bytes in all Heaps`). ASCII, case-insensitivity, and
+  the 255-character maximum are unchanged. See
+  [opentelemetry-specification#5092](https://github.com/open-telemetry/opentelemetry-specification/pull/5092).
+
 * Fix incorrect validation of `OTEL_BSP_*` and `OTEL_BLRP_*` environment
   variables.
   ([#7187](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7187))

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -18,7 +18,7 @@ internal sealed partial class MeterProviderBuilderSdk : MeterProviderBuilder, IM
     public const int DefaultMetricLimit = 1000;
     public const int DefaultCardinalityLimit = 2000;
     private const string DefaultInstrumentationVersion = "1.0.0.0";
-    private const string InstrumentNameRegexPattern = @"^[a-z][a-z0-9-._/]{0,254}$";
+    private const string InstrumentNameRegexPattern = @"^[A-Za-z0-9_.:%\\()*#/-](?:[A-Za-z0-9_.:%\\()*# /-]{0,253}[A-Za-z0-9_.:%\\()*#/-])?$";
 
     private readonly IServiceProvider serviceProvider;
     private MeterProviderSdk? meterProvider;

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
@@ -11,11 +11,19 @@ internal static class MetricTestData
     public static TheoryData<string> InvalidInstrumentNames =>
     [
         " ",
-        "-first-char-not-alphabetic",
-        "1first-char-not-alphabetic",
+        "  ",
+        " leading-space",
+        "trailing-space ",
         "invalid+separator",
+        "invalid[separator",
+        "invalid;separator",
+        "invalid,separator",
+        "invalid=separator",
+        "invalid?separator",
         new('m', 256),
-        "a\xb5", // `\xb5` is the Micro character
+        "a\xb5", // `\xb5` is the Micro character (non-ASCII)
+        "name\twith\ttab",
+        "name\nwith\nnewline",
     ];
 
     public static TheoryData<string> ValidInstrumentNames =>
@@ -28,6 +36,39 @@ internal static class MetricTestData
         new('m', 255),
         "CaSe-InSeNsItIvE",
         "my_metric/environment/database",
+
+        // Newly valid characters: ':', '\', '(', ')', '%', '*', '#', and space.
+        // See https://github.com/open-telemetry/opentelemetry-specification/pull/5092.
+        "with:colon",
+        @"with\backslash",
+        "with(parens)",
+        "with%percent",
+        "with*asterisk",
+        "with#hash",
+        "name with spaces",
+        "name with  consecutive  spaces",
+
+        // Newly valid: leading character no longer required to be alphabetic.
+        "-leadingDash",
+        ".leadingDot",
+        "1leadingDigit",
+        "_leadingUnderscore",
+        ":leadingColon",
+        @"\leadingBackslash",
+        "(leadingParen)",
+        "%leadingPercent",
+        "*leadingAsterisk",
+        "#leadingHash",
+
+        // Real-world Windows performance counter style names.
+        @"\Processor(_Total)\% Processor Time",
+        @"\Memory\Available Bytes",
+        @"\PhysicalDisk(_Total)\Avg. Disk Queue Length",
+        @"\Network Interface(*)\Bytes Total/sec",
+
+        // Real-world .NET CLR performance counter style names.
+        @"\.NET CLR Memory(*)\# Bytes in all Heaps",
+        @"\.NET CLR Memory(_Global_)\# Gen 0 Collections",
     ];
 
     public static TheoryData<double[]> InvalidHistogramBoundaries =>


### PR DESCRIPTION
**Draft** — depends on [opentelemetry-specification#5092](https://github.com/open-telemetry/opentelemetry-specification/pull/5092). Will be ready for review once the spec PR is merged.

**Description**

Relaxes the SDK instrument-name validation to match the proposed expanded character set in [opentelemetry-specification#5092](https://github.com/open-telemetry/opentelemetry-specification/pull/5092):

- Adds `:`, `\`, `(`, `)`, `%`, `*`, `#`, and space to the allowed character set.
- Drops the requirement that the first character be alphabetic.
- Space is restricted to non-leading and non-trailing positions.
- ASCII-only, case-insensitive identity, and the 255-character maximum are unchanged.

This enables Windows performance counter style names to be used directly as instrument names without workarounds — e.g. `\Processor(_Total)\% Processor Time`, `\.NET CLR Memory(*)\# Bytes in all Heaps`.

**Backwards compatibility**

Strict superset of the existing rule. Every name valid under the old regex remains valid; some previously-rejected names are now accepted.
