### PR TITLE
[OTLP] Enable HttpClientFactory for logs

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -24,6 +24,10 @@ Notes](../../RELEASENOTES.md).
   container implementations such as Autofac.
   ([#7234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7234))
 
+* Fixed `OtlpLogExporter` integration with `IHttpClientFactory` so named clients
+  can be used without triggering circular dependencies during logger construction.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -26,7 +26,7 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed `OtlpLogExporter` integration with `IHttpClientFactory` so named clients
   can be used without triggering circular dependencies during logger construction.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7298](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7298))
 
 ## 1.15.3
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/LazyExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/LazyExportClient.cs
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+
+internal sealed class LazyExportClient : IExportClient
+{
+    private readonly Lazy<IExportClient> exportClient;
+
+    public LazyExportClient(Func<IExportClient> exportClientFactory)
+    {
+        this.exportClient = new(exportClientFactory ?? throw new ArgumentNullException(nameof(exportClientFactory)));
+    }
+
+    public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
+        => this.exportClient.Value.SendExportRequest(buffer, contentLength, deadlineUtc, cancellationToken);
+
+    public bool Shutdown(int timeoutMilliseconds)
+        => !this.exportClient.IsValueCreated || this.exportClient.Value.Shutdown(timeoutMilliseconds);
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -68,16 +68,34 @@ internal static class OtlpExporterOptionsExtensions
         return headers;
     }
 
-    public static OtlpExporterTransmissionHandler GetExportTransmissionHandler(this OtlpExporterOptions options, ExperimentalOptions experimentalOptions, OtlpSignalType otlpSignalType)
+    public static OtlpExporterTransmissionHandler GetExportTransmissionHandler(
+        this OtlpExporterOptions options,
+        ExperimentalOptions experimentalOptions,
+        OtlpSignalType otlpSignalType,
+        bool deferExportClientCreation = false)
     {
-        var exportClient = GetExportClient(options, otlpSignalType);
+        IExportClient exportClient;
+        double timeoutMilliseconds;
 
-        // `HttpClient.Timeout.TotalMilliseconds` would be populated with the correct timeout value for both the exporter configuration cases:
-        // 1. User provides their own HttpClient. This case is straightforward as the user wants to use their `HttpClient` and thereby the same client's timeout value.
-        // 2. If the user configures timeout via the exporter options, then the timeout set for the `HttpClient` initialized by the exporter will be set to user provided value.
-        var timeoutMilliseconds = exportClient is OtlpHttpExportClient httpTraceExportClient
-            ? httpTraceExportClient.HttpClient.Timeout.TotalMilliseconds
-            : options.TimeoutMilliseconds;
+        if (deferExportClientCreation)
+        {
+            // Defer creating the export client until the first export so named
+            // HttpClient pipelines can safely resolve logging services after
+            // ILoggerFactory construction has completed.
+            exportClient = new LazyExportClient(() => GetExportClient(options, otlpSignalType));
+            timeoutMilliseconds = options.TimeoutMilliseconds;
+        }
+        else
+        {
+            exportClient = GetExportClient(options, otlpSignalType);
+
+            // `HttpClient.Timeout.TotalMilliseconds` would be populated with the correct timeout value for both the exporter configuration cases:
+            // 1. User provides their own HttpClient. This case is straightforward as the user wants to use their `HttpClient` and thereby the same client's timeout value.
+            // 2. If the user configures timeout via the exporter options, then the timeout set for the `HttpClient` initialized by the exporter will be set to user provided value.
+            timeoutMilliseconds = exportClient is OtlpHttpExportClient httpTraceExportClient
+                ? httpTraceExportClient.HttpClient.Timeout.TotalMilliseconds
+                : options.TimeoutMilliseconds;
+        }
 
         if (experimentalOptions.EnableInMemoryRetry)
         {
@@ -108,26 +126,28 @@ internal static class OtlpExporterOptionsExtensions
             throw new NotSupportedException($"Protocol {options.Protocol} is not supported.");
         }
 
+        bool isGrpc = options.Protocol == OtlpExportProtocol.Grpc;
+#pragma warning restore CS0618 // Suppressing gRPC obsolete warning
+
         return otlpSignalType switch
         {
-            OtlpSignalType.Traces => options.Protocol == OtlpExportProtocol.Grpc
+            OtlpSignalType.Traces => isGrpc
                 ? new OtlpGrpcExportClient(options, httpClient, TraceGrpcServicePath)
                 : new OtlpHttpExportClient(options, httpClient, TraceHttpServicePath),
 
-            OtlpSignalType.Metrics => options.Protocol == OtlpExportProtocol.Grpc
+            OtlpSignalType.Metrics => isGrpc
                 ? new OtlpGrpcExportClient(options, httpClient, MetricsGrpcServicePath)
                 : new OtlpHttpExportClient(options, httpClient, MetricsHttpServicePath),
 
-            OtlpSignalType.Logs => options.Protocol == OtlpExportProtocol.Grpc
+            OtlpSignalType.Logs => isGrpc
                 ? new OtlpGrpcExportClient(options, httpClient, LogsGrpcServicePath)
                 : new OtlpHttpExportClient(options, httpClient, LogsHttpServicePath),
 
             _ => throw new NotSupportedException($"OtlpSignalType {otlpSignalType} is not supported."),
         };
-#pragma warning restore CS0618 // Suppressing gRPC obsolete warning
     }
 
-    public static void TryEnableIHttpClientFactoryIntegration(this OtlpExporterOptions options, IServiceProvider serviceProvider, string httpClientName)
+    public static bool TryEnableIHttpClientFactoryIntegration(this OtlpExporterOptions options, IServiceProvider serviceProvider, string httpClientName)
     {
         if (serviceProvider != null
             && options.Protocol == OtlpExportProtocol.HttpProtobuf
@@ -163,7 +183,11 @@ internal static class OtlpExporterOptionsExtensions
 
                 return options.DefaultHttpClientFactory();
             };
+
+            return true;
         }
+
+        return false;
     }
 
     internal static Uri AppendPathIfNotPresent(this Uri uri, string path)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Logs;
@@ -297,25 +298,21 @@ public static class OtlpLogExporterHelperExtensions
             serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        // TODO IHttpClientFactory integration should be safe on .NET 8+. On earlier versions,
-        // DefaultHttpClientFactory took ILoggerFactory eagerly in its constructor, creating a
-        // circular dependency: ILoggerFactory -> OpenTelemetryLoggerProvider -> OtlpLogExporter
-        // -> IHttpClientFactory -> ILoggerFactory. This was fixed in .NET 8 (dotnet/runtime#89531).
-        // However, this doesn't appear to be true in all cases and can create circular dependencies
-        // when using Autofac and the .NET 11 IHttpClientFactory integration.
-        // Disabled until we can safely resolve this and have appropriate test coverage to ensure
-        // the circular dependency does not exist. See https://github.com/open-telemetry/opentelemetry-dotnet/issues/7233.
-        /*
-#if NET8_0_OR_GREATER
-        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter");
-#endif
-        */
+        OtlpExporterTransmissionHandler? transmissionHandler = null;
+        if (exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter"))
+        {
+            transmissionHandler = exporterOptions.GetExportTransmissionHandler(
+                experimentalOptions,
+                OtlpSignalType.Logs,
+                deferExportClientCreation: true);
+        }
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         BaseExporter<LogRecord> otlpExporter = new OtlpLogExporter(
             exporterOptions,
             sdkLimitOptions,
-            experimentalOptions);
+            experimentalOptions,
+            transmissionHandler);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         try

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -4,6 +4,9 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -108,8 +111,10 @@ public class OtlpLogExporterTests
         });
     }
 
-    [Fact]
-    public void ServiceProviderHttpClientFactoryNotInvoked()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ServiceProviderHttpClientFactoryNotInvokedDuringLoggerFactoryCreation(bool callUseOpenTelemetry)
     {
         var services = new ServiceCollection();
 
@@ -119,39 +124,64 @@ public class OtlpLogExporterTests
 
         services.AddHttpClient("OtlpLogExporter", configureClient: (client) => invocations++);
 
-        services.AddOpenTelemetry().WithLogging(builder => builder
-            .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.HttpProtobuf));
+        services.AddLogging(builder =>
+        {
+            ConfigureOtlpExporter(
+                builder,
+                callUseOpenTelemetry,
+                configureExporter: o => o.Protocol = OtlpExportProtocol.HttpProtobuf);
+        });
 
         using var serviceProvider = services.BuildServiceProvider();
+        _ = serviceProvider.GetRequiredService<ILoggerFactory>();
 
         Assert.NotNull(serviceProvider);
         Assert.Equal(0, invocations);
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/7233")]
-    public void ServiceProviderHttpClientFactoryInvoked()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ServiceProviderHttpClientFactoryInvokedForExportWithoutCircularDependency(bool callUseOpenTelemetry)
     {
-        var services = new ServiceCollection();
+        using var testHandler = new TestHttpMessageHandler();
 
-        services.AddHttpClient();
+        var services = new ServiceCollection();
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpLogExporter", configureClient: (client) => invocations++);
+        services.AddHttpClient("OtlpLogExporter")
+            .ConfigurePrimaryHttpMessageHandler(() => testHandler)
+            .AddHttpMessageHandler(sp =>
+            {
+                _ = sp.GetRequiredService<ILoggerFactory>();
+                invocations++;
+                return new PassThroughDelegatingHandler();
+            });
 
-        services.AddOpenTelemetry().WithLogging(builder => builder
-            .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.HttpProtobuf));
+        services.AddLogging(builder =>
+        {
+            ConfigureOtlpExporter(
+                builder,
+                callUseOpenTelemetry,
+                configureExporterAndProcessor: (exporter, processor) =>
+                {
+                    exporter.Protocol = OtlpExportProtocol.HttpProtobuf;
+                    exporter.Endpoint = new Uri("http://localhost:4318");
+                    processor.ExportProcessorType = ExportProcessorType.Simple;
+                });
+        });
 
         using var serviceProvider = services.BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger(nameof(OtlpLogExporterTests));
 
-        var loggerProvider = serviceProvider.GetRequiredService<LoggerProvider>();
-
-        // IHttpClientFactory integration is only enabled for OtlpLogExporter on .NET 8+.
-#if NET8_0_OR_GREATER
-        Assert.Equal(1, invocations);
-#else
         Assert.Equal(0, invocations);
-#endif
+
+        logger.HelloFrom("tomato", 2.99);
+
+        Assert.Equal(1, invocations);
+        Assert.NotNull(testHandler.HttpRequestMessage);
     }
 
     [Fact]
@@ -1802,4 +1832,6 @@ public class OtlpLogExporterTests
 
         return resourceSpans;
     }
+
+    private sealed class PassThroughDelegatingHandler : DelegatingHandler;
 }


### PR DESCRIPTION
Fixes #7233

## Changes

Re-enable support for HttpClientFactory for exporting logs with OTLP.

Verified fix with https://github.com/martincostello/costellobot/pull/3084 - without the fix [telemetry tests fail](https://github.com/martincostello/costellobot/actions/runs/25863318706) due to the circular dependency. With this fix [they pass](https://github.com/martincostello/costellobot/actions/runs/25869490641?pr=3084).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
