### PR TITLE
Stop validating View-provided stream Name against instrument name syntax

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,19 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* The View-provided metric stream `Name` (set via
+  `MetricStreamConfiguration.Name` or the `AddView(instrumentName, name)`
+  overload) is no longer validated against the
+  [instrument name syntax](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-name-syntax).
+  Previously, supplying a name that did not match the syntax threw
+  `ArgumentException` (or, when set inside a Func-based view, caused the
+  metric to be silently ignored). With this change, View-provided names are
+  accepted as-is, allowing Views to be used to rename instruments to names
+  that fall outside the syntax (e.g. legacy/third-party names, OS-level
+  counter names). Aligns with OpenTelemetry specification clarification
+  [#5094](https://github.com/open-telemetry/opentelemetry-specification/pull/5094).
+  Direct instrument creation via `Meter` continues to enforce the syntax.
+
 * Fix incorrect validation of `OTEL_BSP_*` and `OTEL_BLRP_*` environment
   variables.
   ([#7187](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7187))

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,19 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* The View-provided metric stream `Name` (set via
-  `MetricStreamConfiguration.Name` or the `AddView(instrumentName, name)`
-  overload) is no longer validated against the
-  [instrument name syntax](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-name-syntax).
-  Previously, supplying a name that did not match the syntax threw
-  `ArgumentException` (or, when set inside a Func-based view, caused the View
-  to be silently ignored and the instrument to be exported under its original
-  name). With this change, View-provided names are accepted as-is, allowing
-  Views to be used to rename instruments to names that fall outside the
-  syntax (e.g. legacy/third-party names, OS-level counter names). Aligns
-  with OpenTelemetry specification clarification
-  [#5094](https://github.com/open-telemetry/opentelemetry-specification/pull/5094).
-  Direct instrument creation via `Meter` continues to enforce the syntax.
+* Stop validating View-provided metric stream `Name` against the instrument
+  name syntax, per
+  [spec clarification](https://github.com/open-telemetry/opentelemetry-specification/pull/5094).
+  ([#7300](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7300))
 
 * Fix incorrect validation of `OTEL_BSP_*` and `OTEL_BLRP_*` environment
   variables.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -11,11 +11,12 @@ Notes](../../RELEASENOTES.md).
   overload) is no longer validated against the
   [instrument name syntax](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-name-syntax).
   Previously, supplying a name that did not match the syntax threw
-  `ArgumentException` (or, when set inside a Func-based view, caused the
-  metric to be silently ignored). With this change, View-provided names are
-  accepted as-is, allowing Views to be used to rename instruments to names
-  that fall outside the syntax (e.g. legacy/third-party names, OS-level
-  counter names). Aligns with OpenTelemetry specification clarification
+  `ArgumentException` (or, when set inside a Func-based view, caused the View
+  to be silently ignored and the instrument to be exported under its original
+  name). With this change, View-provided names are accepted as-is, allowing
+  Views to be used to rename instruments to names that fall outside the
+  syntax (e.g. legacy/third-party names, OS-level counter names). Aligns
+  with OpenTelemetry specification clarification
   [#5094](https://github.com/open-telemetry/opentelemetry-specification/pull/5094).
   Direct instrument creation via `Meter` continues to enforce the syntax.
 

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -107,7 +107,8 @@ public static class MeterProviderBuilderExtensions
 
         // Per the OpenTelemetry specification, the View-provided stream name
         // is not subject to the instrument name syntax and the SDK MUST NOT
-        // validate it against that syntax.
+        // validate it against that syntax. See:
+        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view
 
 #pragma warning disable CA1062 // Validate arguments of public methods - needed for netstandard2.1
 #if NET || NETSTANDARD2_1_OR_GREATER

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -105,10 +105,9 @@ public static class MeterProviderBuilderExtensions
     {
         Guard.ThrowIfNull(instrumentName);
 
-        if (!MeterProviderBuilderSdk.IsValidInstrumentName(name))
-        {
-            throw new ArgumentException($"Custom view name {name} is invalid.", nameof(name));
-        }
+        // Per the OpenTelemetry specification, the View-provided stream name
+        // is not subject to the instrument name syntax and the SDK MUST NOT
+        // validate it against that syntax.
 
 #pragma warning disable CA1062 // Validate arguments of public methods - needed for netstandard2.1
 #if NET || NETSTANDARD2_1_OR_GREATER

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -62,15 +62,6 @@ internal sealed partial class MeterProviderBuilderSdk : MeterProviderBuilder, IM
     public static bool IsValidInstrumentName(string instrumentName)
         => !string.IsNullOrWhiteSpace(instrumentName) && InstrumentNameRegex.IsMatch(instrumentName);
 
-    /// <summary>
-    /// Returns whether the given custom view name is valid according to the specification.
-    /// </summary>
-    /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
-    /// <param name="customViewName">The view name.</param>
-    /// <returns>Boolean indicating if the instrument is valid.</returns>
-    public static bool IsValidViewName(string customViewName) =>
-        customViewName == null || InstrumentNameRegex.IsMatch(customViewName); // Only validate the view name in case it's not null. In case it's null, the view name will be the instrument name as per the spec.
-
     public void RegisterProvider(MeterProviderSdk meterProvider)
     {
         Debug.Assert(meterProvider != null, "meterProvider was null");

--- a/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
@@ -131,12 +131,18 @@ public abstract partial class MetricReader
                     ? this.exemplarFilterForHistograms ?? this.exemplarFilter
                     : this.exemplarFilter;
 
-                if (!MeterProviderBuilderSdk.IsValidInstrumentName(metricStreamIdentity.InstrumentName))
+                // Per the OpenTelemetry specification, View-provided names are
+                // not subject to the instrument name syntax. Only validate the
+                // name when it originates from the instrument itself (no View
+                // rename). The Meter API does not validate instrument names,
+                // so the SDK must validate them here.
+                if (metricStreamConfig?.Name == null
+                    && !MeterProviderBuilderSdk.IsValidInstrumentName(metricStreamIdentity.InstrumentName))
                 {
                     OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
                         metricStreamIdentity.InstrumentName,
                         metricStreamIdentity.MeterName,
-                        metricStreamConfig?.Name == null ? "Instrument name is invalid." : "View name is invalid.",
+                        "Instrument name is invalid.",
                         "The name must comply with the OpenTelemetry specification.");
 
                     continue;

--- a/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
@@ -27,9 +27,11 @@ public class MetricStreamConfiguration
     /// </summary>
     /// <remarks>
     /// <para>Note: If not provided the instrument name will be used.</para>
-    /// <para>Per the OpenTelemetry specification, the View-provided stream
-    /// <c>name</c> is not subject to the instrument name syntax and the SDK
-    /// MUST NOT validate it against that syntax.</para>
+    /// <para>The name supplied here is used as-is; it is not required to
+    /// follow the instrument name syntax. This lets you rename instruments
+    /// to names that the OpenTelemetry instrument naming rules would
+    /// otherwise reject (for example, legacy or third-party names, or
+    /// OS-level counter names).</para>
     /// </remarks>
     public string? Name { get; set; }
 

--- a/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
@@ -26,21 +26,12 @@ public class MetricStreamConfiguration
     /// Gets or sets the optional name of the metric stream.
     /// </summary>
     /// <remarks>
-    /// Note: If not provided the instrument name will be used.
+    /// <para>Note: If not provided the instrument name will be used.</para>
+    /// <para>Per the OpenTelemetry specification, the View-provided stream
+    /// <c>name</c> is not subject to the instrument name syntax and the SDK
+    /// MUST NOT validate it against that syntax.</para>
     /// </remarks>
-    public string? Name
-    {
-        get;
-        set
-        {
-            if (value != null && !MeterProviderBuilderSdk.IsValidViewName(value))
-            {
-                throw new ArgumentException($"Custom view name {value} is invalid.", nameof(value));
-            }
-
-            field = value;
-        }
-    }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets the optional description of the metric stream.

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -34,25 +34,45 @@ public class MetricViewTests : MetricTestsBase
 
     [Theory]
     [MemberData(nameof(MetricTestData.InvalidInstrumentNames), MemberType = typeof(MetricTestData))]
-    public void AddViewWithInvalidNameThrowsArgumentException(string viewNewName)
+    public void AddViewWithNonInstrumentSyntaxNameAccepted_StringOverload(string viewNewName)
+    {
+        // Per spec, View-provided stream names are NOT subject to the
+        // instrument name syntax. Names that would be invalid as instrument
+        // names (and previously threw ArgumentException) MUST now be accepted.
+        var exportedItems = new List<Metric>();
+
+        using var meter = new Meter("AddViewWithNonInstrumentSyntaxNameAccepted_StringOverload");
+        using var container = BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter(meter.Name)
+            .AddView("name1", viewNewName)
+            .AddInMemoryExporter(exportedItems));
+
+        var counter = meter.CreateCounter<long>("name1");
+        counter.Add(10);
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        Assert.Single(exportedItems);
+        Assert.Equal(viewNewName, exportedItems[0].Name);
+    }
+
+    [Theory]
+    [MemberData(nameof(MetricTestData.InvalidInstrumentNames), MemberType = typeof(MetricTestData))]
+    public void AddViewWithNonInstrumentSyntaxNameAccepted_ConfigOverload(string viewNewName)
     {
         var exportedItems = new List<Metric>();
 
-        using var meter1 = new Meter("AddViewWithInvalidNameThrowsArgumentException");
-
-        var ex = Assert.Throws<ArgumentException>(() => BuildMeterProvider(out var meterProvider, builder => builder
-            .AddMeter(meter1.Name)
-            .AddView("name1", viewNewName)
-            .AddInMemoryExporter(exportedItems)));
-
-        Assert.Contains($"Custom view name {viewNewName} is invalid.", ex.Message, StringComparison.Ordinal);
-
-        ex = Assert.Throws<ArgumentException>(() => BuildMeterProvider(out var meterProvider, builder => builder
-            .AddMeter(meter1.Name)
+        using var meter = new Meter("AddViewWithNonInstrumentSyntaxNameAccepted_ConfigOverload");
+        using var container = BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter(meter.Name)
             .AddView("name1", new MetricStreamConfiguration() { Name = viewNewName })
-            .AddInMemoryExporter(exportedItems)));
+            .AddInMemoryExporter(exportedItems));
 
-        Assert.Contains($"Custom view name {viewNewName} is invalid.", ex.Message, StringComparison.Ordinal);
+        var counter = meter.CreateCounter<long>("name1");
+        counter.Add(10);
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        Assert.Single(exportedItems);
+        Assert.Equal(viewNewName, exportedItems[0].Name);
     }
 
     [Fact]
@@ -295,21 +315,20 @@ public class MetricViewTests : MetricTestsBase
 
     [Theory]
     [MemberData(nameof(MetricTestData.InvalidInstrumentNames), MemberType = typeof(MetricTestData))]
-    public void ViewWithInvalidNameIgnoredConditionally(string viewNewName)
+    public void ViewWithNonInstrumentSyntaxNameAcceptedConditionally(string viewNewName)
     {
+        // Per spec, View-provided stream names are NOT subject to the
+        // instrument name syntax. Names that would be invalid as instrument
+        // names MUST still be accepted when supplied via a View.
         using var meter1 = new Meter("ViewToRenameMetricConditionallyTest");
         var exportedItems = new List<Metric>();
         using var container = BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter1.Name)
-
-            // since here it's a func, we can't validate the name right away
-            // so the view is allowed to be added, but upon instrument creation it's going to be ignored.
             .AddView((instrument) =>
             {
                 if (instrument.Meter.Name.Equals(meter1.Name, StringComparison.OrdinalIgnoreCase)
                     && instrument.Name.Equals("name1", StringComparison.OrdinalIgnoreCase))
                 {
-                    // invalid instrument name as per the spec
                     return new MetricStreamConfiguration() { Name = viewNewName, Description = "new description" };
                 }
                 else
@@ -319,14 +338,14 @@ public class MetricViewTests : MetricTestsBase
             })
             .AddInMemoryExporter(exportedItems));
 
-        // Because the MetricStreamName passed is invalid, the view is ignored,
-        // and default aggregation is used.
         var counter1 = meter1.CreateCounter<long>("name1", "unit", "original_description");
         counter1.Add(10);
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
         Assert.Single(exportedItems);
+        Assert.Equal(viewNewName, exportedItems[0].Name);
+        Assert.Equal("new description", exportedItems[0].Description);
     }
 
     [Theory]


### PR DESCRIPTION
Per the OpenTelemetry specification clarification in open-telemetry/opentelemetry-specification#5094, the View-provided metric stream `Name` is NOT subject to the instrument name syntax and the SDK MUST NOT validate it against that syntax.

Removes name-syntax validation from `MetricStreamConfiguration.Name` setter, the `AddView(instrumentName, name)` overload, and the runtime check in `MetricReaderExt` (which now only validates names that originate from the instrument itself, not View-renamed names). Also removes the now-unused internal `MeterProviderBuilderSdk.IsValidViewName`. Direct instrument creation via `Meter` continues to enforce the syntax.

Spec PR: open-telemetry/opentelemetry-specification#5094

**Update (2026-05-19):** Spec PR open-telemetry/opentelemetry-specification#5094 has been merged.
