### PR TITLE
[OTLP] Cache resource bytes for protobuf serializer

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Cached pre-serialized resource bytes to avoid re-encoding on every OTLP export.
+  ([#7303](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7303))
+
 * Fixed `NullReferenceException` when exporting logs if the scope key is null.
   ([#7186](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7186))
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,9 +7,6 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Cached pre-serialized resource bytes to avoid re-encoding on every OTLP export.
-  ([#7303](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7303))
-
 * Fixed `NullReferenceException` when exporting logs if the scope key is null.
   ([#7186](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7186))
 
@@ -26,6 +23,9 @@ Notes](../../RELEASENOTES.md).
   an issue with circular dependencies detected by some dependency injection
   container implementations such as Autofac.
   ([#7234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7234))
+
+* Cached pre-serialized resource bytes to avoid re-encoding on every OTLP export.
+  ([#7303](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7303))
 
 ## 1.15.3
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer
 internal static class ProtobufOtlpResourceSerializer
 {
     private const int ReserveSizeForLength = 4;
-    private const int InitialScratchSize = 2048;
+    private const int InitialBufferSize = 2048;
 
     private static readonly ConcurrentDictionary<Resource, byte[]> CachedResourceBytes = new();
 
@@ -33,26 +33,26 @@ internal static class ProtobufOtlpResourceSerializer
     {
         var pool = ArrayPool<byte>.Shared;
 
-        var scratch = pool.Rent(InitialScratchSize);
+        var buffer = pool.Rent(InitialBufferSize);
         try
         {
             while (true)
             {
                 try
                 {
-                    var length = WriteResourceCore(scratch, 0, resource);
-                    return scratch.AsSpan(0, length).ToArray();
+                    var length = WriteResourceCore(buffer, 0, resource);
+                    return buffer.AsSpan(0, length).ToArray();
                 }
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                 {
-                    pool.Return(scratch);
-                    scratch = pool.Rent(scratch.Length * 2);
+                    pool.Return(buffer);
+                    buffer = pool.Rent(buffer.Length * 2);
                 }
             }
         }
         finally
         {
-            pool.Return(scratch);
+            pool.Return(buffer);
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Buffers;
+using System.Collections.Concurrent;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
@@ -8,8 +10,43 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer
 internal static class ProtobufOtlpResourceSerializer
 {
     private const int ReserveSizeForLength = 4;
+    private const int InitialScratchSize = 8192;
+
+    private static readonly ConcurrentDictionary<Resource, byte[]> CachedResourceBytes = new();
 
     internal static int WriteResource(byte[] buffer, int writePosition, Resource? resource)
+    {
+        var cached = CachedResourceBytes.GetOrAdd(resource ?? Resource.Empty, static r => SerializeResourceToBytes(r));
+        Buffer.BlockCopy(cached, 0, buffer, writePosition, cached.Length);
+        return writePosition + cached.Length;
+    }
+
+    private static byte[] SerializeResourceToBytes(Resource resource)
+    {
+        var scratch = ArrayPool<byte>.Shared.Rent(InitialScratchSize);
+        try
+        {
+            while (true)
+            {
+                try
+                {
+                    var length = WriteResourceCore(scratch, 0, resource);
+                    return scratch.AsSpan(0, length).ToArray();
+                }
+                catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
+                {
+                    ArrayPool<byte>.Shared.Return(scratch);
+                    scratch = ArrayPool<byte>.Shared.Rent(scratch.Length * 2);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(scratch);
+        }
+    }
+
+    private static int WriteResourceCore(byte[] buffer, int writePosition, Resource resource)
     {
         var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
@@ -21,7 +58,7 @@ internal static class ProtobufOtlpResourceSerializer
         var resourceLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
-        if (resource != null && resource != Resource.Empty)
+        if (resource != Resource.Empty)
         {
             if (resource.Attributes is IReadOnlyList<KeyValuePair<string, object>> resourceAttributesList)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -23,7 +23,9 @@ internal static class ProtobufOtlpResourceSerializer
 
     private static byte[] SerializeResourceToBytes(Resource resource)
     {
-        var scratch = ArrayPool<byte>.Shared.Rent(InitialScratchSize);
+        var pool = ArrayPool<byte>.Shared;
+
+        var scratch = pool.Rent(InitialScratchSize);
         try
         {
             while (true)
@@ -35,14 +37,14 @@ internal static class ProtobufOtlpResourceSerializer
                 }
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                 {
-                    ArrayPool<byte>.Shared.Return(scratch);
-                    scratch = ArrayPool<byte>.Shared.Rent(scratch.Length * 2);
+                    pool.Return(scratch);
+                    scratch = pool.Rent(scratch.Length * 2);
                 }
             }
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(scratch);
+            pool.Return(scratch);
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -14,9 +14,17 @@ internal static class ProtobufOtlpResourceSerializer
 
     private static readonly ConcurrentDictionary<Resource, byte[]> CachedResourceBytes = new();
 
+    private static ReadOnlySpan<byte> EmptyResourceBytes => [0x0A, 0x80, 0x80, 0x80, 0x00];
+
     internal static int WriteResource(byte[] buffer, int writePosition, Resource? resource)
     {
-        var cached = CachedResourceBytes.GetOrAdd(resource ?? Resource.Empty, static r => SerializeResourceToBytes(r));
+        if (resource == null || resource == Resource.Empty)
+        {
+            EmptyResourceBytes.CopyTo(buffer.AsSpan(writePosition));
+            return writePosition + EmptyResourceBytes.Length;
+        }
+
+        var cached = CachedResourceBytes.GetOrAdd(resource, static r => SerializeResourceToBytes(r));
         Buffer.BlockCopy(cached, 0, buffer, writePosition, cached.Length);
         return writePosition + cached.Length;
     }
@@ -60,21 +68,18 @@ internal static class ProtobufOtlpResourceSerializer
         var resourceLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
-        if (resource != Resource.Empty)
+        if (resource.Attributes is IReadOnlyList<KeyValuePair<string, object>> resourceAttributesList)
         {
-            if (resource.Attributes is IReadOnlyList<KeyValuePair<string, object>> resourceAttributesList)
+            for (var i = 0; i < resourceAttributesList.Count; i++)
             {
-                for (var i = 0; i < resourceAttributesList.Count; i++)
-                {
-                    ProcessResourceAttribute(ref otlpTagWriterState, resourceAttributesList[i]);
-                }
+                ProcessResourceAttribute(ref otlpTagWriterState, resourceAttributesList[i]);
             }
-            else
+        }
+        else
+        {
+            foreach (var attribute in resource.Attributes)
             {
-                foreach (var attribute in resource.Attributes)
-                {
-                    ProcessResourceAttribute(ref otlpTagWriterState, attribute);
-                }
+                ProcessResourceAttribute(ref otlpTagWriterState, attribute);
             }
         }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer
 internal static class ProtobufOtlpResourceSerializer
 {
     private const int ReserveSizeForLength = 4;
-    private const int InitialScratchSize = 8192;
+    private const int InitialScratchSize = 2048;
 
     private static readonly ConcurrentDictionary<Resource, byte[]> CachedResourceBytes = new();
 

--- a/test/Benchmarks/Exporter/ProtobufOtlpResourceSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ProtobufOtlpResourceSerializerBenchmarks.cs
@@ -1,0 +1,104 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+extern alias OpenTelemetryProtocol;
+
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry.Resources;
+using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
+
+namespace Benchmarks.Exporter;
+
+public class ProtobufOtlpResourceSerializerBenchmarks
+{
+    private readonly byte[] buffer = new byte[32 * 1024];
+    private Resource resource = Resource.Empty;
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:Enumeration items should be documented", Justification = "Test only.")]
+    public enum ResourceShape
+    {
+        Empty,
+        Default,
+        Service,
+        Production,
+    }
+
+    [Params(ResourceShape.Empty, ResourceShape.Default, ResourceShape.Service, ResourceShape.Production)]
+    public ResourceShape Shape { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.resource = this.Shape switch
+        {
+            ResourceShape.Empty => Resource.Empty,
+            ResourceShape.Default => BuildDefault(),
+            ResourceShape.Service => BuildService(),
+            ResourceShape.Production => BuildProduction(),
+            _ => Resource.Empty,
+        };
+    }
+
+    [Benchmark]
+    public int WriteResource() => ProtobufOtlpResourceSerializer.WriteResource(this.buffer, 0, this.resource);
+
+    private static Resource BuildDefault()
+        => new(new Dictionary<string, object>
+        {
+            ["service.name"] = "unknown_service:benchmark",
+            ["telemetry.sdk.name"] = "opentelemetry",
+            ["telemetry.sdk.language"] = "dotnet",
+            ["telemetry.sdk.version"] = "1.13.0",
+        });
+
+    private static Resource BuildService()
+        => new(new Dictionary<string, object>
+        {
+            ["service.name"] = "checkout-api",
+            ["service.namespace"] = "shop",
+            ["service.version"] = "2.4.1",
+            ["service.instance.id"] = "9a8d1f3e-4b2c-4e15-9a4f-1b2c3d4e5f6a",
+            ["telemetry.sdk.name"] = "opentelemetry",
+            ["telemetry.sdk.language"] = "dotnet",
+            ["telemetry.sdk.version"] = "1.13.0",
+            ["deployment.environment"] = "production",
+            ["host.name"] = "ip-10-0-12-47.eu-west-1.compute.internal",
+            ["host.id"] = "i-0abcdef1234567890",
+        });
+
+    private static Resource BuildProduction()
+        => new(new Dictionary<string, object>
+        {
+            ["service.name"] = "checkout-api",
+            ["service.namespace"] = "shop",
+            ["service.version"] = "2.4.1",
+            ["service.instance.id"] = "9a8d1f3e-4b2c-4e15-9a4f-1b2c3d4e5f6a",
+            ["telemetry.sdk.name"] = "opentelemetry",
+            ["telemetry.sdk.language"] = "dotnet",
+            ["telemetry.sdk.version"] = "1.13.0",
+            ["deployment.environment"] = "production",
+            ["host.name"] = "ip-10-0-12-47.eu-west-1.compute.internal",
+            ["host.id"] = "i-0abcdef1234567890",
+            ["host.type"] = "c6a.2xlarge",
+            ["host.arch"] = "amd64",
+            ["os.type"] = "linux",
+            ["os.description"] = "Ubuntu 22.04.4 LTS",
+            ["process.pid"] = 18742L,
+            ["process.executable.name"] = "Checkout.Api",
+            ["process.runtime.name"] = ".NET",
+            ["process.runtime.version"] = "10.0.8",
+            ["container.id"] = "8f3a7b4c9e1d2f5a6b8c0e2f4a6b8d0c2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b",
+            ["container.image.name"] = "registry.example.com/shop/checkout-api",
+            ["container.image.tag"] = "2.4.1-abc1234",
+            ["k8s.namespace.name"] = "shop-prod",
+            ["k8s.pod.name"] = "checkout-api-7d8c9f4b6c-x9k2m",
+            ["k8s.pod.uid"] = "d4e5f6a7-b8c9-4d0e-9f1a-2b3c4d5e6f7a",
+            ["k8s.node.name"] = "ip-10-0-12-47.eu-west-1.compute.internal",
+            ["k8s.deployment.name"] = "checkout-api",
+            ["k8s.cluster.name"] = "shop-prod-eu-west-1",
+            ["cloud.provider"] = "aws",
+            ["cloud.region"] = "eu-west-1",
+            ["cloud.availability_zone"] = "eu-west-1a",
+            ["cloud.account.id"] = "123456789012",
+        });
+}

--- a/test/Benchmarks/Exporter/ProtobufOtlpResourceSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ProtobufOtlpResourceSerializerBenchmarks.cs
@@ -63,13 +63,13 @@ public class ProtobufOtlpResourceSerializerBenchmarks
         }
 
         var attributes = new Dictionary<string, object>(this.AttributeCount);
-        var realistic = Math.Min(this.AttributeCount, AllAttributes.Length);
-        for (var i = 0; i < realistic; i++)
+        var count = Math.Min(this.AttributeCount, AllAttributes.Length);
+        for (var i = 0; i < count; i++)
         {
             attributes[AllAttributes[i].Key] = AllAttributes[i].Value;
         }
 
-        for (var i = realistic; i < this.AttributeCount; i++)
+        for (var i = count; i < this.AttributeCount; i++)
         {
             attributes[$"custom.attribute.{i}"] = Guid.NewGuid().ToString();
         }

--- a/test/Benchmarks/Exporter/ProtobufOtlpResourceSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ProtobufOtlpResourceSerializerBenchmarks.cs
@@ -11,94 +11,72 @@ namespace Benchmarks.Exporter;
 
 public class ProtobufOtlpResourceSerializerBenchmarks
 {
-    private readonly byte[] buffer = new byte[32 * 1024];
+    private static readonly KeyValuePair<string, object>[] AllAttributes =
+    [
+        new("service.name", "checkout-api"),
+        new("service.namespace", "shop"),
+        new("service.version", "2.4.1"),
+        new("service.instance.id", "9a8d1f3e-4b2c-4e15-9a4f-1b2c3d4e5f6a"),
+        new("telemetry.sdk.name", "opentelemetry"),
+        new("telemetry.sdk.language", "dotnet"),
+        new("telemetry.sdk.version", "1.13.0"),
+        new("deployment.environment", "production"),
+        new("host.name", "ip-10-0-12-47.eu-west-1.compute.internal"),
+        new("host.id", "i-0abcdef1234567890"),
+        new("host.type", "c6a.2xlarge"),
+        new("host.arch", "amd64"),
+        new("os.type", "linux"),
+        new("os.description", "Ubuntu 22.04.4 LTS"),
+        new("process.pid", 18742L),
+        new("process.executable.name", "Checkout.Api"),
+        new("process.runtime.name", ".NET"),
+        new("process.runtime.version", "10.0.8"),
+        new("container.id", "8f3a7b4c9e1d2f5a6b8c0e2f4a6b8d0c2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b"),
+        new("container.image.name", "registry.example.com/shop/checkout-api"),
+        new("container.image.tag", "2.4.1-abc1234"),
+        new("k8s.namespace.name", "shop-prod"),
+        new("k8s.pod.name", "checkout-api-7d8c9f4b6c-x9k2m"),
+        new("k8s.pod.uid", "d4e5f6a7-b8c9-4d0e-9f1a-2b3c4d5e6f7a"),
+        new("k8s.node.name", "ip-10-0-12-47.eu-west-1.compute.internal"),
+        new("k8s.deployment.name", "checkout-api"),
+        new("k8s.cluster.name", "shop-prod-eu-west-1"),
+        new("cloud.provider", "aws"),
+        new("cloud.region", "eu-west-1"),
+        new("cloud.availability_zone", "eu-west-1a"),
+        new("cloud.account.id", "123456789012"),
+        new("deployment.id", "deploy-2024-05-17-abc"),
+    ];
+
+    private readonly byte[] buffer = new byte[64 * 1024];
     private Resource resource = Resource.Empty;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:Enumeration items should be documented", Justification = "Test only.")]
-    public enum ResourceShape
-    {
-        Empty,
-        Default,
-        Service,
-        Production,
-    }
-
-    [Params(ResourceShape.Empty, ResourceShape.Default, ResourceShape.Service, ResourceShape.Production)]
-    public ResourceShape Shape { get; set; }
+    [Params(0, 4, 8, 16, 32)]
+    public int AttributeCount { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
-        this.resource = this.Shape switch
+        if (this.AttributeCount == 0)
         {
-            ResourceShape.Empty => Resource.Empty,
-            ResourceShape.Default => BuildDefault(),
-            ResourceShape.Service => BuildService(),
-            ResourceShape.Production => BuildProduction(),
-            _ => Resource.Empty,
-        };
+            this.resource = Resource.Empty;
+            return;
+        }
+
+        var attributes = new Dictionary<string, object>(this.AttributeCount);
+        var realistic = Math.Min(this.AttributeCount, AllAttributes.Length);
+        for (var i = 0; i < realistic; i++)
+        {
+            attributes[AllAttributes[i].Key] = AllAttributes[i].Value;
+        }
+
+        for (var i = realistic; i < this.AttributeCount; i++)
+        {
+            attributes[$"custom.attribute.{i}"] = Guid.NewGuid().ToString();
+        }
+
+        this.resource = new Resource(attributes);
     }
 
     [Benchmark]
     public int WriteResource() => ProtobufOtlpResourceSerializer.WriteResource(this.buffer, 0, this.resource);
-
-    private static Resource BuildDefault()
-        => new(new Dictionary<string, object>
-        {
-            ["service.name"] = "unknown_service:benchmark",
-            ["telemetry.sdk.name"] = "opentelemetry",
-            ["telemetry.sdk.language"] = "dotnet",
-            ["telemetry.sdk.version"] = "1.13.0",
-        });
-
-    private static Resource BuildService()
-        => new(new Dictionary<string, object>
-        {
-            ["service.name"] = "checkout-api",
-            ["service.namespace"] = "shop",
-            ["service.version"] = "2.4.1",
-            ["service.instance.id"] = "9a8d1f3e-4b2c-4e15-9a4f-1b2c3d4e5f6a",
-            ["telemetry.sdk.name"] = "opentelemetry",
-            ["telemetry.sdk.language"] = "dotnet",
-            ["telemetry.sdk.version"] = "1.13.0",
-            ["deployment.environment"] = "production",
-            ["host.name"] = "ip-10-0-12-47.eu-west-1.compute.internal",
-            ["host.id"] = "i-0abcdef1234567890",
-        });
-
-    private static Resource BuildProduction()
-        => new(new Dictionary<string, object>
-        {
-            ["service.name"] = "checkout-api",
-            ["service.namespace"] = "shop",
-            ["service.version"] = "2.4.1",
-            ["service.instance.id"] = "9a8d1f3e-4b2c-4e15-9a4f-1b2c3d4e5f6a",
-            ["telemetry.sdk.name"] = "opentelemetry",
-            ["telemetry.sdk.language"] = "dotnet",
-            ["telemetry.sdk.version"] = "1.13.0",
-            ["deployment.environment"] = "production",
-            ["host.name"] = "ip-10-0-12-47.eu-west-1.compute.internal",
-            ["host.id"] = "i-0abcdef1234567890",
-            ["host.type"] = "c6a.2xlarge",
-            ["host.arch"] = "amd64",
-            ["os.type"] = "linux",
-            ["os.description"] = "Ubuntu 22.04.4 LTS",
-            ["process.pid"] = 18742L,
-            ["process.executable.name"] = "Checkout.Api",
-            ["process.runtime.name"] = ".NET",
-            ["process.runtime.version"] = "10.0.8",
-            ["container.id"] = "8f3a7b4c9e1d2f5a6b8c0e2f4a6b8d0c2e4f6a8b0c2d4e6f8a0b2c4d6e8f0a2b",
-            ["container.image.name"] = "registry.example.com/shop/checkout-api",
-            ["container.image.tag"] = "2.4.1-abc1234",
-            ["k8s.namespace.name"] = "shop-prod",
-            ["k8s.pod.name"] = "checkout-api-7d8c9f4b6c-x9k2m",
-            ["k8s.pod.uid"] = "d4e5f6a7-b8c9-4d0e-9f1a-2b3c4d5e6f7a",
-            ["k8s.node.name"] = "ip-10-0-12-47.eu-west-1.compute.internal",
-            ["k8s.deployment.name"] = "checkout-api",
-            ["k8s.cluster.name"] = "shop-prod-eu-west-1",
-            ["cloud.provider"] = "aws",
-            ["cloud.region"] = "eu-west-1",
-            ["cloud.availability_zone"] = "eu-west-1a",
-            ["cloud.account.id"] = "123456789012",
-        });
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
@@ -12,21 +12,21 @@ public class OtlpResourceTests
     [Fact]
     public void EmptyResourceSerializesToExpectedBytes()
     {
-        var buffer = new byte[16];
+        var buffer = new byte[5];
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, Resource.Empty);
 
         Assert.Equal(5, writePosition);
-        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer.AsSpan(0, writePosition).ToArray());
+        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer);
     }
 
     [Fact]
     public void NullResourceSerializesToExpectedBytes()
     {
-        var buffer = new byte[16];
+        var buffer = new byte[5];
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, resource: null);
 
         Assert.Equal(5, writePosition);
-        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer.AsSpan(0, writePosition).ToArray());
+        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer);
     }
 
     [Theory]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
@@ -16,7 +16,7 @@ public class OtlpResourceTests
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, Resource.Empty);
 
         Assert.Equal(5, writePosition);
-        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer[..writePosition]);
+        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer.AsSpan(0, writePosition).ToArray());
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class OtlpResourceTests
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, resource: null);
 
         Assert.Equal(5, writePosition);
-        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer[..writePosition]);
+        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer.AsSpan(0, writePosition).ToArray());
     }
 
     [Theory]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
@@ -9,6 +9,26 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
 public class OtlpResourceTests
 {
+    [Fact]
+    public void EmptyResourceSerializesToExpectedBytes()
+    {
+        var buffer = new byte[16];
+        var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, Resource.Empty);
+
+        Assert.Equal(5, writePosition);
+        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer[..writePosition]);
+    }
+
+    [Fact]
+    public void NullResourceSerializesToExpectedBytes()
+    {
+        var buffer = new byte[16];
+        var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, resource: null);
+
+        Assert.Equal(5, writePosition);
+        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer[..writePosition]);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
## Changes

Caches bytes for the protobuf serializer for the Resource, since Resource is immutable
## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
