### PR TITLE
[OTLP] Do not enable HttpClientFactory with mTLS

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -31,8 +31,7 @@ Notes](../../RELEASENOTES.md).
 * Reduce the overhead of GZip compression.
   ([#7275](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7275))
 
-* Do not enable the `OtlpLogExporter` integration with `IHttpClientFactory`
-  when mTLS is enabled.
+* Do not enable the integration with `IHttpClientFactory` when mTLS is enabled.
   ([#7305](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7305))
 
 ## 1.15.3

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -33,7 +33,7 @@ Notes](../../RELEASENOTES.md).
 
 * Do not enable the `OtlpLogExporter` integration with `IHttpClientFactory`
   when mTLS is enabled.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7305](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7305))
 
 ## 1.15.3
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -31,6 +31,10 @@ Notes](../../RELEASENOTES.md).
 * Reduce the overhead of GZip compression.
   ([#7275](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7275))
 
+* Do not enable the `OtlpLogExporter` integration with `IHttpClientFactory`
+  when mTLS is enabled.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -151,6 +151,9 @@ internal static class OtlpExporterOptionsExtensions
     {
         if (serviceProvider != null
             && options.Protocol == OtlpExportProtocol.HttpProtobuf
+#if NET
+            && options.MtlsOptions?.IsEnabled != true
+#endif
             && options.HttpClientFactory == options.DefaultHttpClientFactory)
         {
             options.HttpClientFactory = () =>

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -5,6 +5,9 @@
 using System.Net.Http;
 #endif
 using Microsoft.Extensions.Configuration;
+#if NET
+using Microsoft.Extensions.DependencyInjection;
+#endif
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
@@ -97,6 +100,38 @@ public class OtlpExporterOptionsExtensionsTests
 
         Assert.Equal(expected, resultUri.AbsoluteUri);
     }
+
+#if NET
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TryEnableIHttpClientFactoryIntegration_DoesNotReplaceDefaultFactory_WhenMutualTlsIsEnabled(bool enabled)
+    {
+        var services = new ServiceCollection();
+
+        services.AddHttpClient("OtlpLogExporter");
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var options = new OtlpExporterOptions
+        {
+            Protocol = OtlpExportProtocol.HttpProtobuf,
+            MtlsOptions = new OtlpMtlsOptions
+            {
+                CaCertificatePath = "ca.pem",
+                ClientCertificatePath = enabled ? "client.pem" : null,
+            },
+        };
+
+        var originalFactory = options.HttpClientFactory;
+
+        var actual = options.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter");
+
+        Assert.False(actual);
+        Assert.Same(originalFactory, options.HttpClientFactory);
+        Assert.Same(options.DefaultHttpClientFactory, options.HttpClientFactory);
+    }
+#endif
 
     [Theory]
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -103,9 +103,12 @@ public class OtlpExporterOptionsExtensionsTests
 
 #if NET
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void TryEnableIHttpClientFactoryIntegration_DoesNotReplaceDefaultFactory_WhenMutualTlsIsEnabled(bool enabled)
+    [InlineData(null, "client.pem")]
+    [InlineData("ca.pem", null)]
+    [InlineData("ca.pem", "client.pem")]
+    public void TryEnableIHttpClientFactoryIntegration_DoesNotReplaceDefaultFactory_WhenTlsIsEnabled(
+        string? caCertificatePath,
+        string? clientCertificatePath)
     {
         var services = new ServiceCollection();
 
@@ -118,8 +121,8 @@ public class OtlpExporterOptionsExtensionsTests
             Protocol = OtlpExportProtocol.HttpProtobuf,
             MtlsOptions = new OtlpMtlsOptions
             {
-                CaCertificatePath = "ca.pem",
-                ClientCertificatePath = enabled ? "client.pem" : null,
+                CaCertificatePath = caCertificatePath,
+                ClientCertificatePath = clientCertificatePath,
             },
         };
 


### PR DESCRIPTION
Follow-up to Codex finding from #7298.

## Changes

If mTLS is enabled for the OTLP exporter do not enable the HttpClientFactory integration so that settings are not overridden.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
