### PR TITLE
[Infra] Update tests for ActivityTraceFlags

### DIFF
--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
@@ -21,8 +21,16 @@ internal static class Generators
 
     public static Arbitrary<ActivityContext> ActivityContextArbitrary()
     {
+#if NET
+        var allTraceFlags = Enum.GetValues<ActivityTraceFlags>();
+#else
+        var allTraceFlags = Enum.GetValues(typeof(ActivityTraceFlags)).OfType<ActivityTraceFlags>().ToArray();
+#endif
+
         var gen =
-            from traceFlags in Gen.Elements(default, ActivityTraceFlags.Recorded)
+            from traceFlags in Gen
+                .SubListOf(allTraceFlags)
+                .Select((flags) => flags.Aggregate(ActivityTraceFlags.None, (current, next) => current | next))
             from traceState in Gen.OneOf(
                 Gen.Constant((string?)null),
                 ValidTraceStateArbitrary().Generator.Select(static value => (string?)value))

--- a/test/OpenTelemetry.Api.Tests/ActivityTraceFlagsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/ActivityTraceFlagsTests.cs
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using Xunit;
+
+namespace OpenTelemetry.Api.Tests;
+
+public static class ActivityTraceFlagsTests
+{
+    [Fact]
+    public static void ActivityTraceFlags_MembersAreKnown()
+    {
+        // Act
+#if NET
+        var actual = Enum.GetValues<ActivityTraceFlags>();
+#else
+        var actual = Enum.GetValues(typeof(ActivityTraceFlags)).OfType<ActivityTraceFlags>().ToArray();
+#endif
+
+        // If this test fails, new members have been added to the ActivityTraceFlags
+        // enum. Review the code for any changes that are needed to accommodate the
+        // new value(s) and then update this test to include them.
+        Assert.Equal<ActivityTraceFlags>([ActivityTraceFlags.None, ActivityTraceFlags.Recorded], actual);
+    }
+}

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
@@ -85,6 +85,16 @@ internal static class Generators
                 activity.AddEvent(new ActivityEvent($"Event_{i}", DateTimeOffset.UtcNow, eventTags));
             }
 
+#if NET
+            var allTraceFlags = Enum.GetValues<ActivityTraceFlags>();
+#else
+            var allTraceFlags = Enum.GetValues(typeof(ActivityTraceFlags)).OfType<ActivityTraceFlags>().ToArray();
+#endif
+
+            var traceFlagsGenerator = Gen
+                .SubListOf(allTraceFlags)
+                .Select((flags) => flags.Aggregate(ActivityTraceFlags.None, (current, next) => current | next));
+
             // Generate links
             var linkCount = Math.Min(size / 10, 10);
             for (var i = 0; i < linkCount; i++)
@@ -97,7 +107,7 @@ internal static class Generators
                 var context = new ActivityContext(
                     ActivityTraceId.CreateRandom(),
                     ActivitySpanId.CreateRandom(),
-                    ActivityTraceFlags.Recorded);
+                    traceFlagsGenerator.Sample(0, 1).First());
 
                 activity.AddLink(new ActivityLink(context, linkTags));
             }


### PR DESCRIPTION
Contributes to #6768.

## Changes

Update tests to handle new members of the `ActivityTraceFlags` enum.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
