### PR TITLE
[Api] W3C propagator - deduplicate `tracestate` keys

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -13,6 +13,10 @@ Notes](../../RELEASENOTES.md).
 * Update `TraceContextPropagator` to support the W3C randomness flag.
   ([#7301](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7301))
 
+* Fixed `TraceContextPropagator` to deduplicate duplicate `tracestate` keys
+  instead of discarding the entire `tracestate` header.
+  ([#7309](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7309))
+
 ## 1.15.3
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -445,8 +445,7 @@ public class TraceContextPropagator : TextMapPropagator
                 if (!keySet.Add(key.ToString()))
                 {
                     // test_tracestate_duplicated_keys
-                    tracestateResult = string.Empty;
-                    return false;
+                    continue;
                 }
 
                 if (result.Length > 0)
@@ -542,6 +541,7 @@ public class TraceContextPropagator : TextMapPropagator
                     return false;
                 }
 
+                var duplicateKey = false;
                 var useHashedDuplicateCheck = keyLength <= Limit;
                 var keyHash = 0;
                 if (useHashedDuplicateCheck)
@@ -556,7 +556,8 @@ public class TraceContextPropagator : TextMapPropagator
 
                         if (key.SequenceEqual(tracestateSpan.Slice(memberStarts[i], keyLength)))
                         {
-                            return false;
+                            duplicateKey = true;
+                            break;
                         }
                     }
                 }
@@ -567,9 +568,17 @@ public class TraceContextPropagator : TextMapPropagator
                         if (keyLengths[i] == keyLength &&
                             key.SequenceEqual(tracestateSpan.Slice(memberStarts[i], keyLength)))
                         {
-                            return false;
+                            duplicateKey = true;
+                            break;
                         }
                     }
+                }
+
+                if (duplicateKey)
+                {
+                    normalized = true;
+                    begin = end + 1;
+                    continue;
                 }
 
                 memberStarts[memberCount] = memberStart;

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -38,6 +38,6 @@ RUN tdnf install -y python3-pip \
   && python3 -m pip install --requirement requirements.txt --require-hashes --break-system-packages \
   && tdnf clean all
 ENV SPEC_LEVEL=2
-ENV STRICT_LEVEL=1
+ENV STRICT_LEVEL=2
 
 ENTRYPOINT ["dotnet", "vstest", "OpenTelemetry.Instrumentation.W3cTraceContext.Tests.dll", "--logger:console;verbosity=detailed"]

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
@@ -281,11 +281,12 @@ public class TraceContextPropagatorTests
     }
 
     [Fact]
-    public void TryExtractTracestate_SingleHeaderRejectsDuplicateLongKeys()
+    public void TryExtractTracestate_SingleHeaderDeduplicatesDuplicateLongKeys()
     {
         var key = new string('a', 33);
 
-        Assert.False(TraceContextPropagator.TryExtractTracestate([$"{key}=1,{key}=2"], out _));
+        Assert.True(TraceContextPropagator.TryExtractTracestate([$"{key}=1,{key}=2"], out var actual));
+        Assert.Equal($"{key}=1", actual);
     }
 
     [Fact]
@@ -401,11 +402,11 @@ public class TraceContextPropagatorTests
     public void DuplicateKeys()
     {
         // test_tracestate_duplicated_keys
-        Assert.Empty(CallTraceContextPropagator("foo=1,foo=1"));
-        Assert.Empty(CallTraceContextPropagator("foo=1,foo=2"));
-        Assert.Empty(CallTraceContextPropagator(["foo=1", "foo=1"]));
-        Assert.Empty(CallTraceContextPropagator(["foo=1", "foo=2"]));
-        Assert.Empty(CallTraceContextPropagator("foo=1,bar=2,baz=3,foo=4"));
+        Assert.Equal("foo=1", CallTraceContextPropagator("foo=1,foo=1"));
+        Assert.Equal("foo=1", CallTraceContextPropagator("foo=1,foo=2"));
+        Assert.Equal("foo=1", CallTraceContextPropagator(["foo=1", "foo=1"]));
+        Assert.Equal("foo=1", CallTraceContextPropagator(["foo=1", "foo=2"]));
+        Assert.Equal("foo=1,bar=2,baz=3", CallTraceContextPropagator("foo=1,bar=2,baz=3,foo=4"));
     }
 
     [Fact]


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet/issues/6768#issuecomment-4478340209
## Changes

[Api] W3C propagator - deduplicate duplicate `tracestate` keys

New tests executed with strict level 2:

* test_tracestate_duplicated_keys
* test_tracestate_key_illegal_characters
* test_tracestate_key_illegal_vendor_format
* test_tracestate_member_count_limit
* test_tracestate_key_length_limit
* test_tracestate_value_illegal_characters

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
