### PR TITLE
[Infra] Reduce console log noise in CI

### DIFF
--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -290,6 +290,7 @@ public class OtlpLogExporterTests
         var hostBuilder = new HostBuilder();
         hostBuilder.ConfigureLogging(logging =>
         {
+            logging.ClearProviders();
             ConfigureOtlpExporter(logging, callUseOpenTelemetry, logRecords: logRecords);
         });
 

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/InMemoryExporterMetricsExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/InMemoryExporterMetricsExtensionsTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
@@ -73,6 +74,7 @@ public class InMemoryExporterMetricsExtensionsTests
         using var host = await new HostBuilder()
            .ConfigureWebHost(webBuilder => webBuilder
                .UseTestServer()
+               .ConfigureLogging((logging) => logging.SetMinimumLevel(LogLevel.Warning))
                .ConfigureServices(services => services.AddOpenTelemetry().WithMetrics(configure))
                .Configure(app => app.Run(httpContext =>
                {

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -22,6 +23,8 @@ public class OpenTelemetryServicesExtensionsTests
             services.AddOpenTelemetry();
         });
 
+        builder.ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));
+
         var host = builder.Build();
 
         await host.StartAsync();
@@ -34,31 +37,33 @@ public class OpenTelemetryServicesExtensionsTests
     {
         var expectedInnerExceptionThrown = false;
 
-        var builder = new HostBuilder().ConfigureServices(services =>
-        {
-            services.AddOpenTelemetry()
-                .WithTracing(builder =>
-                {
-                    if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
+        var builder = new HostBuilder()
+            .ConfigureLogging((logging) => logging.SetMinimumLevel(LogLevel.Warning))
+            .ConfigureServices(services =>
+            {
+                services.AddOpenTelemetry()
+                    .WithTracing(builder =>
                     {
-                        deferredTracerProviderBuilder.Configure((sp, sdkBuilder) =>
+                        if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
                         {
-                            try
+                            deferredTracerProviderBuilder.Configure((sp, sdkBuilder) =>
                             {
-                                // Note: This throws because services cannot be
-                                // registered after IServiceProvider has been
-                                // created.
-                                sdkBuilder.SetSampler<MySampler>();
-                            }
-                            catch (NotSupportedException)
-                            {
-                                expectedInnerExceptionThrown = true;
-                                throw;
-                            }
-                        });
-                    }
-                });
-        });
+                                try
+                                {
+                                    // Note: This throws because services cannot be
+                                    // registered after IServiceProvider has been
+                                    // created.
+                                    sdkBuilder.SetSampler<MySampler>();
+                                }
+                                catch (NotSupportedException)
+                                {
+                                    expectedInnerExceptionThrown = true;
+                                    throw;
+                                }
+                            });
+                        }
+                    });
+            });
 
         var host = builder.Build();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 #endif
 using OpenTelemetry.Internal;
 using Xunit;
@@ -33,6 +34,7 @@ public abstract class MetricTestsBase
     {
         var hostBuilder = new HostBuilder()
             .ConfigureDefaults(null)
+            .ConfigureLogging((logging) => logging.SetMinimumLevel(LogLevel.Warning))
             .ConfigureAppConfiguration((context, builder) =>
             {
                 configureAppConfiguration?.Invoke(context, builder);


### PR DESCRIPTION
## Changes

Disable the console logger, or change logs to warnings and greater, in CI to speed things up by avoiding writing ASP.NET Core hosting logs to the console.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
