### PR TITLE
[Infra] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -151,15 +151,15 @@ public class TraceContextPropagator : TextMapPropagator
             // to include the new value(s) for better readability and performance where possible.
             if (context.TraceFlags == ActivityTraceFlags.Recorded)
             {
-                "-01".CopyTo(destination.Slice(52));
+                "-01".CopyTo(destination[52..]);
             }
             else if (context.TraceFlags == (ActivityTraceFlags)2)
             {
-                "-02".CopyTo(destination.Slice(52));
+                "-02".CopyTo(destination[52..]);
             }
             else if (context.TraceFlags == (ActivityTraceFlags.Recorded | (ActivityTraceFlags)2))
             {
-                "-03".CopyTo(destination.Slice(52));
+                "-03".CopyTo(destination[52..]);
             }
             else
             {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
@@ -16,7 +16,7 @@ public class OtlpResourceTests
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, Resource.Empty);
 
         Assert.Equal(5, writePosition);
-        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer);
+        Assert.Equal([0x0A, 0x80, 0x80, 0x80, 0x00], buffer);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class OtlpResourceTests
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, resource: null);
 
         Assert.Equal(5, writePosition);
-        Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x00 }, buffer);
+        Assert.Equal([0x0A, 0x80, 0x80, 0x80, 0x00], buffer);
     }
 
     [Theory]


### PR DESCRIPTION
## Changes

Fix new code analysis warnings from .NET 11 in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
