### PR TITLE
[Infra] Fix flaky tests

### DIFF
--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorCollection.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorCollection.cs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+#pragma warning disable CA1515 // Consider making public types internal
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class MockCollectorCollection
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+#pragma warning restore CA1515 // Consider making public types internal
+{
+    public const string Name = "Mock collector";
+}

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
@@ -24,16 +24,14 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
+[Collection(MockCollectorCollection.Name)]
 public sealed class MockCollectorIntegrationTests
 {
-    private static int gRPCPort = 4317;
-    private static int httpPort = 5051;
-
     [Fact]
     public async Task TestRecoveryAfterFailedExport()
     {
-        var testGrpcPort = Interlocked.Increment(ref gRPCPort);
-        var testHttpPort = Interlocked.Increment(ref httpPort);
+        var testGrpcPort = TcpPortProvider.GetOpenPort();
+        var testHttpPort = TcpPortProvider.GetOpenPort();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
@@ -136,8 +134,8 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, Grpc.Core.StatusCode.DeadlineExceeded)]
     public async Task GrpcRetryTests(bool useRetryTransmissionHandler, ExportResult expectedResult, Grpc.Core.StatusCode initialStatusCode)
     {
-        var testGrpcPort = Interlocked.Increment(ref gRPCPort);
-        var testHttpPort = Interlocked.Increment(ref httpPort);
+        var testGrpcPort = TcpPortProvider.GetOpenPort();
+        var testHttpPort = TcpPortProvider.GetOpenPort();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
@@ -222,7 +220,7 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, HttpStatusCode.BadRequest)]
     public async Task HttpRetryTests(bool useRetryTransmissionHandler, ExportResult expectedResult, HttpStatusCode initialHttpStatusCode)
     {
-        var testHttpPort = Interlocked.Increment(ref httpPort);
+        var testHttpPort = TcpPortProvider.GetOpenPort();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
@@ -308,7 +306,8 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, HttpStatusCode.BadRequest)]
     public async Task HttpPersistentStorageRetryTests(bool usePersistentStorageTransmissionHandler, ExportResult expectedResult, HttpStatusCode initialHttpStatusCode)
     {
-        var testHttpPort = Interlocked.Increment(ref httpPort);
+        var testGrpcPort = TcpPortProvider.GetOpenPort();
+        var testHttpPort = TcpPortProvider.GetOpenPort();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
@@ -445,8 +444,8 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, Grpc.Core.StatusCode.DeadlineExceeded)]
     public async Task GrpcPersistentStorageRetryTests(bool usePersistentStorageTransmissionHandler, ExportResult expectedResult, Grpc.Core.StatusCode initialgrpcStatusCode)
     {
-        var testGrpcPort = Interlocked.Increment(ref gRPCPort);
-        var testHttpPort = Interlocked.Increment(ref httpPort);
+        var testGrpcPort = TcpPortProvider.GetOpenPort();
+        var testHttpPort = TcpPortProvider.GetOpenPort();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
@@ -564,12 +563,10 @@ public sealed class MockCollectorIntegrationTests
             this.statusCodes = [.. statusCodes.Select(x => (Grpc.Core.StatusCode)x)];
         }
 
-        public Grpc.Core.StatusCode NextStatus()
-        {
-            return this.statusCodeIndex < this.statusCodes.Length
+        public Grpc.Core.StatusCode NextStatus() =>
+            this.statusCodeIndex < this.statusCodes.Length
                 ? this.statusCodes[this.statusCodeIndex++]
                 : Grpc.Core.StatusCode.OK;
-        }
     }
 
     private sealed class MockCollectorHttpState
@@ -583,12 +580,10 @@ public sealed class MockCollectorIntegrationTests
             this.statusCodes = [.. statusCodes.Select(x => (HttpStatusCode)x)];
         }
 
-        public HttpStatusCode NextStatus()
-        {
-            return this.statusCodeIndex < this.statusCodes.Length
+        public HttpStatusCode NextStatus() =>
+            this.statusCodeIndex < this.statusCodes.Length
                 ? this.statusCodes[this.statusCodeIndex++]
                 : HttpStatusCode.OK;
-        }
     }
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes
@@ -605,12 +600,9 @@ public sealed class MockCollectorIntegrationTests
         public override Task<ExportTraceServiceResponse> Export(ExportTraceServiceRequest request, ServerCallContext context)
         {
             var statusCode = this.state.NextStatus();
-            if (statusCode != Grpc.Core.StatusCode.OK)
-            {
-                throw new RpcException(new Grpc.Core.Status(statusCode, "Error."));
-            }
-
-            return Task.FromResult(new ExportTraceServiceResponse());
+            return statusCode != Grpc.Core.StatusCode.OK
+                ? throw new RpcException(new Grpc.Core.Status(statusCode, "Error."))
+                : Task.FromResult(new ExportTraceServiceResponse());
         }
     }
 
@@ -672,15 +664,9 @@ public sealed class MockCollectorIntegrationTests
             return true;
         }
 
-        protected override bool OnTryLease(int leasePeriodMilliseconds)
-        {
-            return true;
-        }
+        protected override bool OnTryLease(int leasePeriodMilliseconds) => true;
 
-        protected override bool OnTryDelete()
-        {
-            return this.mockStorage.Remove(this);
-        }
+        protected override bool OnTryDelete() => this.mockStorage.Remove(this);
     }
 }
 #endif

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
@@ -30,15 +30,14 @@ public sealed class MockCollectorIntegrationTests
     [Fact]
     public async Task TestRecoveryAfterFailedExport()
     {
-        var testGrpcPort = TcpPortProvider.GetOpenPort();
-        var testHttpPort = TcpPortProvider.GetOpenPort();
+        (var grpcPort, var httpPort) = GetTwoOpenPorts();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
                 .ConfigureKestrel(options =>
                 {
-                    options.ListenLocalhost(testHttpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
-                    options.ListenLocalhost(testGrpcPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2);
+                    options.ListenLocalhost(httpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
+                    options.ListenLocalhost(grpcPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2);
                 })
                .ConfigureServices(services =>
                {
@@ -65,13 +64,13 @@ public sealed class MockCollectorIntegrationTests
                }))
            .StartAsync();
 
-        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{testHttpPort}") };
+        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{httpPort}") };
 
         var codes = new[] { Grpc.Core.StatusCode.Unimplemented, Grpc.Core.StatusCode.OK };
         await httpClient.GetAsync(new Uri($"/MockCollector/SetResponseCodes/{string.Join(",", codes.Select(x => (int)x))}", UriKind.Relative));
 
         var exportResults = new List<ExportResult>();
-        using var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions() { Endpoint = new Uri($"http://localhost:{testGrpcPort}") });
+        using var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions() { Endpoint = new Uri($"http://localhost:{grpcPort}") });
 #pragma warning disable CA2000 // Dispose objects before losing scope
         var delegatingExporter = new DelegatingExporter<Activity>
 #pragma warning disable CA2000 // Dispose objects before losing scope
@@ -134,15 +133,14 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, Grpc.Core.StatusCode.DeadlineExceeded)]
     public async Task GrpcRetryTests(bool useRetryTransmissionHandler, ExportResult expectedResult, Grpc.Core.StatusCode initialStatusCode)
     {
-        var testGrpcPort = TcpPortProvider.GetOpenPort();
-        var testHttpPort = TcpPortProvider.GetOpenPort();
+        (var grpcPort, var httpPort) = GetTwoOpenPorts();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
                 .ConfigureKestrel(options =>
                 {
-                    options.ListenLocalhost(testHttpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
-                    options.ListenLocalhost(testGrpcPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2);
+                    options.ListenLocalhost(httpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
+                    options.ListenLocalhost(grpcPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2);
                 })
                .ConfigureServices(services =>
                {
@@ -169,13 +167,13 @@ public sealed class MockCollectorIntegrationTests
                }))
            .StartAsync();
 
-        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{testHttpPort}") };
+        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{httpPort}") };
 
         // First reply with failure and then Ok
         var codes = new[] { initialStatusCode, Grpc.Core.StatusCode.OK };
         await httpClient.GetAsync(new Uri($"/MockCollector/SetResponseCodes/{string.Join(",", codes.Select(x => (int)x))}", UriKind.Relative));
 
-        var endpoint = new Uri($"http://localhost:{testGrpcPort}");
+        var endpoint = new Uri($"http://localhost:{grpcPort}");
 
         var exporterOptions = new OtlpExporterOptions() { Endpoint = endpoint, TimeoutMilliseconds = 20000, Protocol = OtlpExportProtocol.Grpc };
 
@@ -220,13 +218,13 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, HttpStatusCode.BadRequest)]
     public async Task HttpRetryTests(bool useRetryTransmissionHandler, ExportResult expectedResult, HttpStatusCode initialHttpStatusCode)
     {
-        var testHttpPort = TcpPortProvider.GetOpenPort();
+        var httpPort = TcpPortProvider.GetOpenPort();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
                 .ConfigureKestrel(options =>
                 {
-                    options.ListenLocalhost(testHttpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
+                    options.ListenLocalhost(httpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
                 })
                .ConfigureServices(services =>
                {
@@ -258,12 +256,12 @@ public sealed class MockCollectorIntegrationTests
                }))
            .StartAsync();
 
-        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{testHttpPort}") };
+        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{httpPort}") };
 
         var codes = new[] { initialHttpStatusCode, HttpStatusCode.OK };
         await httpClient.GetAsync(new Uri($"/MockCollector/SetResponseCodes/{string.Join(",", codes.Select(x => (int)x))}", UriKind.Relative));
 
-        var endpoint = new Uri($"http://localhost:{testHttpPort}/v1/traces");
+        var endpoint = new Uri($"http://localhost:{httpPort}/v1/traces");
 
         var exporterOptions = new OtlpExporterOptions() { Endpoint = endpoint, TimeoutMilliseconds = 20000, Protocol = OtlpExportProtocol.HttpProtobuf };
 
@@ -306,14 +304,13 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, HttpStatusCode.BadRequest)]
     public async Task HttpPersistentStorageRetryTests(bool usePersistentStorageTransmissionHandler, ExportResult expectedResult, HttpStatusCode initialHttpStatusCode)
     {
-        var testGrpcPort = TcpPortProvider.GetOpenPort();
-        var testHttpPort = TcpPortProvider.GetOpenPort();
+        (var grpcPort, var httpPort) = GetTwoOpenPorts();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
                 .ConfigureKestrel(options =>
                 {
-                    options.ListenLocalhost(testHttpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
+                    options.ListenLocalhost(httpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
                 })
                .ConfigureServices(services =>
                {
@@ -345,12 +342,12 @@ public sealed class MockCollectorIntegrationTests
                }))
            .StartAsync();
 
-        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{testHttpPort}") };
+        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{httpPort}") };
 
         var codes = new[] { initialHttpStatusCode, HttpStatusCode.OK };
         await httpClient.GetAsync(new Uri($"/MockCollector/SetResponseCodes/{string.Join(",", codes.Select(x => (int)x))}", UriKind.Relative));
 
-        var endpoint = new Uri($"http://localhost:{testHttpPort}/v1/traces");
+        var endpoint = new Uri($"http://localhost:{httpPort}/v1/traces");
 
         var exporterOptions = new OtlpExporterOptions() { Endpoint = endpoint, TimeoutMilliseconds = 20000 };
 
@@ -444,15 +441,14 @@ public sealed class MockCollectorIntegrationTests
     [InlineData(false, ExportResult.Failure, Grpc.Core.StatusCode.DeadlineExceeded)]
     public async Task GrpcPersistentStorageRetryTests(bool usePersistentStorageTransmissionHandler, ExportResult expectedResult, Grpc.Core.StatusCode initialgrpcStatusCode)
     {
-        var testGrpcPort = TcpPortProvider.GetOpenPort();
-        var testHttpPort = TcpPortProvider.GetOpenPort();
+        (var grpcPort, var httpPort) = GetTwoOpenPorts();
 
         using var host = await new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
                 .ConfigureKestrel(options =>
                 {
-                    options.ListenLocalhost(testHttpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
-                    options.ListenLocalhost(testGrpcPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2);
+                    options.ListenLocalhost(httpPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1);
+                    options.ListenLocalhost(grpcPort, listenOptions => listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2);
                 })
                .ConfigureServices(services =>
                {
@@ -479,12 +475,12 @@ public sealed class MockCollectorIntegrationTests
                }))
            .StartAsync();
 
-        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{testHttpPort}") };
+        using var httpClient = new HttpClient() { BaseAddress = new Uri($"http://localhost:{httpPort}") };
 
         var codes = new[] { initialgrpcStatusCode, Grpc.Core.StatusCode.OK };
         await httpClient.GetAsync(new Uri($"/MockCollector/SetResponseCodes/{string.Join(",", codes.Select(x => (int)x))}", UriKind.Relative));
 
-        var endpoint = new Uri($"http://localhost:{testGrpcPort}");
+        var endpoint = new Uri($"http://localhost:{grpcPort}");
 
         var exporterOptions = new OtlpExporterOptions() { Endpoint = endpoint, TimeoutMilliseconds = 20000 };
 
@@ -550,6 +546,19 @@ public sealed class MockCollectorIntegrationTests
         transmissionHandler.Shutdown(0);
 
         transmissionHandler.Dispose();
+    }
+
+    private static (int First, int Second) GetTwoOpenPorts()
+    {
+        int first = TcpPortProvider.GetOpenPort();
+        int second;
+
+        while ((second = TcpPortProvider.GetOpenPort()) == first)
+        {
+            // Try again
+        }
+
+        return (first, second);
     }
 
     private sealed class MockCollectorState

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\DelegatingExporter.cs" Link="Includes\DelegatingExporter.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\SkipUnlessEnvVarFoundTheoryAttribute.cs" Link="Includes\SkipUnlessEnvVarFoundTheoryAttribute.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestActivityProcessor.cs" Link="Includes\TestActivityProcessor.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Includes\Utils.cs" />


### PR DESCRIPTION
Cherry-pick fixes from #7311

## Changes

- Avoid port conflict by not running the mock collector tests in parallel with other tests.
- Use `TcpPortProvider` to avoid port conflicts.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
