### PR TITLE
[Infra] Enable fail-fast in merge queue

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -27,6 +27,9 @@ on:
         default: '[ "net462", "net8.0", "net9.0", "net10.0" ]'
         required: false
         type: string
+      trigger:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -35,7 +38,7 @@ jobs:
   build-test:
 
     strategy:
-      fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
+      fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
         os: ${{ fromJSON(inputs.os-list) }}
         version: ${{ fromJSON(inputs.tfm-list) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    with:
+      trigger: ${{ github.event_name }}
 
   detect-changes:
     runs-on: windows-latest
@@ -73,6 +75,7 @@ jobs:
     with:
       project-name: 'OpenTelemetry.slnx'
       code-cov-name: 'Solution'
+      trigger: ${{ github.event_name }}
 
   build-test-project-stable:
     needs: detect-changes
@@ -85,6 +88,7 @@ jobs:
       project-name: './build/OpenTelemetry.proj'
       project-build-commands: '-p:ExposeExperimentalFeatures=false'
       code-cov-name: 'Project-Stable'
+      trigger: ${{ github.event_name }}
 
   build-test-project-experimental:
     needs: detect-changes
@@ -97,6 +101,7 @@ jobs:
       project-name: './build/OpenTelemetry.proj'
       project-build-commands: '-p:ExposeExperimentalFeatures=true'
       code-cov-name: 'Project-Experimental'
+      trigger: ${{ github.event_name }}
 
   # Build unstable core libraries using stable packages released to NuGet
   build-test-unstable-core:
@@ -110,6 +115,7 @@ jobs:
       project-name: './build/UnstableCoreLibraries.proj'
       project-build-commands: '-p:RunningDotNetPack=true -p:ExposeExperimentalFeatures=true'
       code-cov-name: 'UnstableCoreLibraries-Experimental'
+      trigger: ${{ github.event_name }}
 
   otlp-integration-test:
     needs: detect-changes
@@ -121,7 +127,7 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'shared')
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         version: [ net8.0, net9.0, net10.0 ]
     env:
@@ -143,7 +149,7 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'shared')
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         version: [ net8.0, net9.0, net10.0 ]
     steps:
@@ -160,7 +166,7 @@ jobs:
       contains(needs.detect-changes.outputs.changes, 'build') ||
       contains(needs.detect-changes.outputs.changes, 'shared')
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         os: [ ubuntu-24.04, windows-latest ]
     runs-on: ${{ matrix.os }}
@@ -215,6 +221,8 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'build')
       || contains(needs.detect-changes.outputs.changes, 'shared')
     uses: ./.github/workflows/verifyaotcompat.yml
+    with:
+      trigger: ${{ github.event_name }}
 
   concurrency-tests:
     needs: detect-changes
@@ -224,6 +232,8 @@ jobs:
       || contains(needs.detect-changes.outputs.changes, 'build')
       || contains(needs.detect-changes.outputs.changes, 'shared')
     uses: ./.github/workflows/concurrency-tests.yml
+    with:
+      trigger: ${{ github.event_name }}
 
   build-test:
     needs: [

--- a/.github/workflows/codeql-analysis-steps.yml
+++ b/.github/workflows/codeql-analysis-steps.yml
@@ -2,6 +2,10 @@ name: codeql-analysis-steps
 
 on:
   workflow_call:
+    inputs:
+      trigger:
+        required: true
+        type: string
 
 permissions: {}
 
@@ -14,7 +18,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
-      fail-fast: false
+      fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
         language: ['actions', 'csharp']
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,3 +15,5 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    with:
+      trigger: ${{ github.event_name }}

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -4,6 +4,10 @@ name: Concurrency Tests
 
 on:
   workflow_call:
+    inputs:
+      trigger:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,7 +16,7 @@ jobs:
   run-concurrency-tests:
 
     strategy:
-      fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
+      fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
         os: [ windows-latest, ubuntu-22.04 ]
         version: [ net8.0, net10.0 ]

--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -4,6 +4,10 @@ name: Publish & Verify AOT Compatibility
 
 on:
   workflow_call:
+    inputs:
+      trigger:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,7 +16,7 @@ jobs:
   run-verify-aot-compat:
 
     strategy:
-      fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
+      fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
         os: [ ubuntu-22.04, windows-latest ]
         version: [ net8.0, net9.0, net10.0 ]


### PR DESCRIPTION
## Changes

Enable fail-fast in the merge queue as there's no ability to re-run only failing jobs so there's no benefit in running all jobs.

This should reduce cycle time if CI is being flaky when trying to merge renovate updates.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
