### PR TITLE
[API] Fix flaky fuzz test

### DIFF
--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/Generators.cs
@@ -10,6 +10,8 @@ namespace OpenTelemetry.Api.FuzzTests;
 
 internal static class Generators
 {
+    private const int MaxTraceStateLength = 512;
+
     private static readonly Gen<char> LowerAlphaChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz".ToCharArray());
     private static readonly Gen<char> TraceStateKeyChar = Gen.Elements("abcdefghijklmnopqrstuvwxyz0123456789_-*/".ToCharArray());
     private static readonly Gen<char> TraceStateValueChar = Gen.Elements("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~:/".ToCharArray());
@@ -206,9 +208,7 @@ internal static class Generators
             return
                 from count in Gen.Choose(1, maxCount)
                 from members in Gen.ArrayOf(memberGen, count)
-                select string.Join(
-                    ",",
-                    members.Select(static (member, index) => $"{AppendIndexToTraceStateKey(member.Key, index)}={member.Value}"));
+                select CreateValidTraceState(members);
         });
 
         return gen.ToArbitrary();
@@ -284,6 +284,28 @@ internal static class Generators
         }
 
         return $"{key}{suffix}";
+    }
+
+    private static string CreateValidTraceState(KeyValuePair<string, string>[] members)
+    {
+        var entries = new List<string>(members.Length);
+        var length = 0;
+
+        foreach (var (member, index) in members.Select(static (member, index) => (member, index)))
+        {
+            var entry = $"{AppendIndexToTraceStateKey(member.Key, index)}={member.Value}";
+            var nextLength = length + entry.Length + (entries.Count > 0 ? 1 : 0);
+
+            if (nextLength > MaxTraceStateLength)
+            {
+                break;
+            }
+
+            entries.Add(entry);
+            length = nextLength;
+        }
+
+        return string.Join(",", entries);
     }
 
     private static Dictionary<string, string> ToDictionary(IEnumerable<KeyValuePair<string, string>> pairs)

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/TraceContextPropagatorFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/TraceContextPropagatorFuzzTests.cs
@@ -39,6 +39,9 @@ public class TraceContextPropagatorFuzzTests
     });
 
     [Property(MaxTest = MaxTests)]
+    public Property ValidTraceStateGeneratorRespectsLengthLimit() => Prop.ForAll(Generators.ValidTraceStateArbitrary(), traceState => traceState.Length <= 512);
+
+    [Property(MaxTest = MaxTests)]
     public Property ExtractIsDeterministicForArbitraryHeaders() => Prop.ForAll(Generators.TraceContextCarrierArbitrary(), (carrier) =>
     {
         try


### PR DESCRIPTION
Fixes #7327

## Changes

Fix flaky fuzz test from tracestates being created that's too long.

~~I had Copilot work on this, so I haven't deeply checked the attached issue yet in case this fix is unrelated and the problem as-reported still exists.~~

The `[Property(MaxTest = MaxTests, Replay = "(8887274353307222202,1046009578951611291,50)")]` repro passes with this change.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
