### PR TITLE
[Infra] Zizmor fixes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,20 @@
   "automerge": false,
   "commitBodyTable": true,
   "commitMessageAction": "Bump",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": ["Update GitHub runner labels in workflow fields and matrix values"],
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate:\\s*datasource=(?<datasource>github-runners)\\s+depName=(?<depName>[^\\s]+)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*[A-Za-z0-9_-]+:\\s*['\"]?(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}github-runner{{/if}}"
+    }
+  ],
   "dependencyDashboard": false,
   "extends": [
     "config:best-practices",

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -36,6 +36,7 @@ permissions:
 
 jobs:
   build-test:
+    name: build-test
 
     strategy:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
@@ -57,12 +58,15 @@ jobs:
       TARGET_FRAMEWORK: ${{ matrix.version }}
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit. MinVer needs to find
         # the version tag which is typically NOT on the first commit so we
         # retrieve them all.
         fetch-depth: 0
+        persist-credentials: false
+        show-progress: false
 
     - name: Setup previous .NET runtimes
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
       os-list:
-        default: '[ "windows-latest", "windows-11-arm", "ubuntu-22.04", "ubuntu-22.04-arm" ]'
+        default: '[ "windows-2025", "windows-11-arm", "ubuntu-22.04", "ubuntu-22.04-arm" ]'
         required: false
         type: string
       tfm-list:
@@ -44,8 +44,10 @@ jobs:
         os: ${{ fromJSON(inputs.os-list) }}
         version: ${{ fromJSON(inputs.tfm-list) }}
         exclude:
+        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
         - os: ubuntu-22.04
           version: net462
+        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
         - os: ubuntu-22.04-arm
           version: net462
 
@@ -53,6 +55,7 @@ jobs:
     timeout-minutes: 30
 
     env:
+      DISABLE_APP_DOMAIN: ${{ matrix.version == 'net462' && 'false' || 'true' }}
       PROJECT_NAME: ${{ inputs.project-name }}
       PROJECT_BUILD_COMMANDS: ${{ inputs.project-build-commands }}
       TARGET_FRAMEWORK: ${{ matrix.version }}
@@ -99,7 +102,7 @@ jobs:
         --logger:"console;verbosity=detailed"
         --logger:"GitHubActions;report-warnings=false"
         --logger:"junit;LogFilePath=TestResults/junit.xml"
-        -- RunConfiguration.DisableAppDomain=${{ matrix.version == 'net462' && 'false' || 'true' }}
+        -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
 
     - name: Install coverage tool
       shell: pwsh

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -3,23 +3,27 @@ on:
   issues:
     types: [ opened ]
 
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] Only code from the main branch is executed
     branches: [ 'main*' ]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   add-labels-on-issues:
     permissions:
-      issues: write
+      contents: read # To checkout the code
+      issues: write # To add labels to the issue
     if: github.event.repository.fork == false && github.event_name == 'issues' && !github.event.issue.pull_request
 
     runs-on: ubuntu-24.04
 
     steps:
-      - name: check out code
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
 
       - name: Add labels for package found in bug issue descriptions
         shell: pwsh
@@ -36,16 +40,20 @@ jobs:
 
   add-labels-on-pull-requests:
     permissions:
-      pull-requests: write
+      contents: read # To checkout the code
+      pull-requests: write # To add labels to the PR
     if: github.event.repository.fork == false && github.event_name == 'pull_request_target'
 
     runs-on: ubuntu-24.04
 
     steps:
-      - name: check out code
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          filter: 'tree:0'
+          persist-credentials: false
           ref: ${{ github.event.repository.default_branch }} # Note: Do not run on the PR branch we want to execute add-labels.psm1 from main on the base repo only because pull_request_target can see secrets
+          show-progress: false
 
       - name: Add labels for files changed on pull requests
         shell: pwsh

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -8,8 +8,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   add-labels-on-issues:
+    name: Add labels to issues
     permissions:
       contents: read # To checkout the code
       issues: write # To add labels to the issue
@@ -39,6 +44,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
   add-labels-on-pull-requests:
+    name: Add labels to pull requests
     permissions:
       contents: read # To checkout the code
       pull-requests: write # To add labels to the PR
@@ -52,7 +58,8 @@ jobs:
         with:
           filter: 'tree:0'
           persist-credentials: false
-          ref: ${{ github.event.repository.default_branch }} # Note: Do not run on the PR branch we want to execute add-labels.psm1 from main on the base repo only because pull_request_target can see secrets
+          # Note: Do not run on the PR branch we want to execute add-labels.psm1 from main on the base repo only because pull_request_target can see secrets
+          ref: ${{ github.event.repository.default_branch }}
           show-progress: false
 
       - name: Add labels for files changed on pull requests

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   resolve-automation:
+    name: Resolve automation secrets access
 
     runs-on: ubuntu-24.04
 
@@ -31,7 +32,8 @@ jobs:
       enabled: ${{ steps.evaluate.outputs.enabled }}
 
     steps:
-    - id: evaluate
+    - name: Evaluate settings
+      id: evaluate
       env:
         IS_ENABLED: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY != '' }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
       matrix:
         os:
           # renovate: datasource=github-runners depName=ubuntu depType=github-runner
-          - ubuntu-22.04
+          - ubuntu-24.04
           # renovate: datasource=github-runners depName=windows depType=github-runner
           - windows-2025
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
   code-ql:
     uses: ./.github/workflows/codeql-analysis-steps.yml
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab
     with:
       trigger: ${{ github.event_name }}
 
@@ -32,7 +32,12 @@ jobs:
     outputs:
       changes: ${{ steps.changes.outputs.changes }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
     - uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
       id: changes
       with:
@@ -133,7 +138,12 @@ jobs:
     env:
       FRAMEWORK_VERSION: ${{ matrix.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
       - name: Build OTLP test image
         run: docker compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml "--file=build/docker-compose.${FRAMEWORK_VERSION}.yml" --project-directory=. --profile build build build-image
       - name: Run OTLP Exporter docker compose
@@ -153,7 +163,12 @@ jobs:
       matrix:
         version: [ net8.0, net9.0, net10.0 ]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
       - name: Run W3C Trace Context docker compose
         run: docker compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml "--file=build/docker-compose.${FRAMEWORK_VERSION}.yml" --project-directory=. up --exit-code-from=tests --build
         env:
@@ -236,6 +251,7 @@ jobs:
       trigger: ${{ github.event_name }}
 
   build-test:
+    name: build-test
     needs: [
       detect-changes,
       code-ql,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   lint-misspell-sanitycheck:
     uses: ./.github/workflows/sanitycheck.yml
@@ -28,7 +32,8 @@ jobs:
       trigger: ${{ github.event_name }}
 
   detect-changes:
-    runs-on: windows-latest
+    name: Detect changes
+    runs-on: windows-2025
     outputs:
       changes: ${{ steps.changes.outputs.changes }}
     steps:
@@ -38,7 +43,8 @@ jobs:
         filter: 'tree:0'
         persist-credentials: false
         show-progress: false
-    - uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
+    - name: Filter paths
+      uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
       id: changes
       with:
         filters: |
@@ -123,6 +129,7 @@ jobs:
       trigger: ${{ github.event_name }}
 
   otlp-integration-test:
+    name: OTLP integration tests
     needs: detect-changes
     if: |
       contains(needs.detect-changes.outputs.changes, 'api-packages')
@@ -150,6 +157,7 @@ jobs:
         run: docker compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml "--file=build/docker-compose.${FRAMEWORK_VERSION}.yml" --project-directory=. up --exit-code-from=tests --no-build
 
   w3c-trace-context-integration-test:
+    name: W3C Trace Context integration tests
     needs: detect-changes
     if: |
       contains(needs.detect-changes.outputs.changes, 'api-packages')
@@ -175,6 +183,7 @@ jobs:
           FRAMEWORK_VERSION: ${{ matrix.version }}
 
   validate-benchmarks:
+    name: Validate benchmarks
     needs: detect-changes
     if: |
       contains(needs.detect-changes.outputs.changes, 'code') ||
@@ -183,7 +192,11 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        os: [ ubuntu-24.04, windows-latest ]
+        os:
+          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          - ubuntu-22.04
+          # renovate: datasource=github-runners depName=windows depType=github-runner
+          - windows-2025
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/codeql-analysis-steps.yml
+++ b/.github/workflows/codeql-analysis-steps.yml
@@ -11,11 +11,12 @@ permissions: {}
 
 jobs:
   analyze:
+    name: 'Analyze ${{ matrix.language }}'
     permissions:
       actions: read # Scan GitHub Actions workflows
       contents: read # Checkout the repository
       security-events: write # Store results in the Security tab
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     strategy:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
@@ -50,6 +51,7 @@ jobs:
           category: '/language:${{ matrix.language }}'
 
   results:
+    name: results
     if: ${{ !cancelled() }}
     needs: [ analyze ]
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis-steps.yml
+++ b/.github/workflows/codeql-analysis-steps.yml
@@ -12,9 +12,9 @@ permissions: {}
 jobs:
   analyze:
     permissions:
-      actions: read  # for github/codeql-action/init to get workflow details
-      contents: read  # for actions/checkout to fetch code
-      security-events: write  # for github/codeql-action/analyze to upload SARIF results
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab
     runs-on: windows-latest
 
     strategy:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   schedule:
-    - cron: '0 0 * * *' # once in a day at 00:00
+    - cron: '0 0 * * *' # Once a day at 00:00 UTC
   workflow_dispatch:
 
 permissions: {}
@@ -12,8 +12,8 @@ jobs:
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.event.repository.fork == false)
     uses: ./.github/workflows/codeql-analysis-steps.yml
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab
     with:
       trigger: ${{ github.event_name }}

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   run-concurrency-tests:
+    name: run-concurrency-tests
 
     strategy:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
@@ -24,9 +25,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: Run Coyote Tests

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -19,7 +19,11 @@ jobs:
     strategy:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
-        os: [ windows-latest, ubuntu-22.04 ]
+        os:
+          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          - ubuntu-22.04
+          # renovate: datasource=github-runners depName=windows depType=github-runner
+          - windows-2025
         version: [ net8.0, net10.0 ]
         project: [ OpenTelemetry.Tests, OpenTelemetry.Api.Tests ]
 

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -13,10 +13,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: install docfx

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -1,5 +1,3 @@
-# Called by ci.yml to run documentation build
-# See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
 name: Build docfx
 
 on:
@@ -10,7 +8,8 @@ permissions:
 
 jobs:
   run-docfx-build:
-    runs-on: windows-latest
+    name: Build docfx
+    runs-on: windows-2025
 
     steps:
     - name: Checkout code
@@ -23,13 +22,13 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
-    - name: install docfx
+    - name: Install docfx
       shell: pwsh
       env:
         # renovate: datasource=nuget depName=docfx
         DOCFX_VERSION: '2.78.5'
       run: dotnet tool install -g docfx --version ${env:DOCFX_VERSION}
 
-    - name: run .\build\docfx.cmd
-      shell: cmd
+    - name: Build docfx
+      shell: pwsh
       run: .\build\docfx.cmd

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   run-dotnet-format-stable:
-    runs-on: windows-latest
+    name: Run dotnet format (stable)
+    runs-on: windows-2025
 
     steps:
     - name: Checkout code
@@ -32,7 +33,8 @@ jobs:
         ExposeExperimentalFeatures: false
 
   run-dotnet-format-experimental:
-    runs-on: windows-latest
+    name: Run dotnet format (experimental)
+    runs-on: windows-2025
 
     steps:
     - name: Checkout code

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -13,10 +13,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: dotnet restore
@@ -31,10 +35,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: dotnet restore

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,8 +8,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   fossa:
+    name: Run FOSSA scan
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     steps:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,9 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
 
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+      - name: Run FOSSA analysis
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           team: OpenTelemetry

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,8 +13,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
     - name: run markdownlint
       uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   run-markdownlint:
+    name: Run markdownlint
     runs-on: ubuntu-24.04
 
     steps:
@@ -20,7 +21,7 @@ jobs:
         persist-credentials: false
         show-progress: false
 
-    - name: run markdownlint
+    - name: Run markdownlint
       uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
       with:
         globs: |

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -8,7 +8,7 @@ on:
     - cron: "24 5 * * 0" # once a week
   workflow_dispatch:
 
-permissions: read-all
+permissions: read-all # zizmor: ignore[excessive-permissions] OSSF Scorecard needs these read permissions
 
 jobs:
   analysis:
@@ -20,9 +20,12 @@ jobs:
       # Needed for GitHub OIDC token if publish_results is true
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          filter: 'tree:0'
           persist-credentials: false
+          show-progress: false
 
       - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -20,8 +20,11 @@ jobs:
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.event.repository.fork == false)
     runs-on: ubuntu-latest
     permissions:
+      checks: read # Read CI results
       contents: read # Checkout the repository
       id-token: write # Publish Scorecard results with GitHub OIDC
+      issues: read # Read issues
+      pull-requests: read # Read pull requests
       security-events: write # Upload the SARIF results to code scanning
     steps:
       - name: Checkout code

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -5,20 +5,24 @@ on:
     branches:
       - main
   schedule:
-    - cron: "24 5 * * 0" # once a week
+    - cron: "24 5 * * 0" # Once a week
   workflow_dispatch:
 
-permissions: read-all # zizmor: ignore[excessive-permissions] OSSF Scorecard needs these read permissions
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   analysis:
+    name: Scorecard analysis
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.event.repository.fork == false)
     runs-on: ubuntu-latest
     permissions:
-      # Needed for Code scanning upload
-      security-events: write
-      # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
+      contents: read # Checkout the repository
+      id-token: write # Publish Scorecard results with GitHub OIDC
+      security-events: write # Upload the SARIF results to code scanning
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,25 +31,21 @@ jobs:
           persist-credentials: false
           show-progress: false
 
-      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      # Upload the results as artifacts (optional). Commenting out will disable
-      # uploads of run results in SARIF format to the repository Actions tab.
-      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
-      - name: "Upload artifact"
+      - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      # Upload the results to GitHub's code scanning dashboard (optional).
-      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
-      - name: "Upload to code-scanning"
+      - name: Upload code scanning results
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -13,14 +13,17 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit. MinVer needs to find
         # the version tag which is typically NOT on the first commit so we
         # retrieve them all.
         fetch-depth: 0
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: dotnet pack
@@ -37,14 +40,17 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit. MinVer needs to find
         # the version tag which is typically NOT on the first commit so we
         # retrieve them all.
         fetch-depth: 0
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: dotnet pack

--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -1,5 +1,3 @@
-# Called by ci.yml to perform package validation
-# See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
 name: Package Validation
 
 on:
@@ -10,7 +8,8 @@ permissions:
 
 jobs:
   run-package-validation-stable:
-    runs-on: windows-latest
+    name: Validate packages (stable)
+    runs-on: windows-2025
 
     steps:
     - name: Checkout code
@@ -37,7 +36,8 @@ jobs:
         if-no-files-found: error
 
   run-package-validation-experimental:
-    runs-on: windows-latest
+    name: Validate packages (experimental)
+    runs-on: windows-2025
 
     steps:
     - name: Checkout code

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -52,11 +52,13 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
         token: ${{ steps.otelbot-token.outputs.token }}
         ref: ${{ github.event.repository.default_branch }}
+        show-progress: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
@@ -108,15 +110,19 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        # Note: By default GitHub only fetches 1 commit. We need all the tags
-        # for this work.
+        # Note: By default GitHub only fetches 1 commit. MinVer needs to find
+        # the version tag which is typically NOT on the first commit so we
+        # retrieve them all.
         fetch-depth: 0
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
         ref: ${{ github.event.repository.default_branch }}
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: Create GitHub Pull Request to update stable build version in props

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -26,12 +30,13 @@ jobs:
       OTELBOT_DOTNET_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
 
   push-packages-and-publish-release:
+    name: Push packages and publish release
     runs-on: ubuntu-24.04
 
     needs: automation
 
     permissions:
-      id-token: write
+      id-token: write # Publish NuGet packages with trusted GitHub OIDC
 
     if: |
       github.event_name == 'issue_comment' &&
@@ -44,7 +49,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
@@ -92,6 +98,7 @@ jobs:
           -pushToNuget $HasToken
 
   post-release-published:
+    name: Post release published notice
     runs-on: ubuntu-24.04
 
     needs:
@@ -102,7 +109,8 @@ jobs:
       (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -48,9 +48,11 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create GitHub Pull Request to prepare release
@@ -96,9 +98,11 @@ jobs:
         permission-contents: read
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Lock GitHub Pull Request to prepare release
@@ -139,11 +143,13 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Create release tag
@@ -189,11 +195,13 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Update release date
@@ -240,11 +248,13 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
         fetch-depth: 0
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Update release notes

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -33,6 +37,7 @@ jobs:
       OTELBOT_DOTNET_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
 
   prepare-release-pr:
+    name: Prepare release pull request
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -40,7 +45,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
@@ -77,6 +83,7 @@ jobs:
           -gitUserEmail ${env:BOT_USER_EMAIL}
 
   lock-pr-and-post-notice-to-create-release-tag:
+    name: Lock pull request and post release tag notice
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -90,7 +97,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
@@ -120,6 +128,7 @@ jobs:
           -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME}
 
   create-release-tag-pr-post-notice:
+    name: Create release tag and post notice
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -135,7 +144,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
@@ -172,6 +182,7 @@ jobs:
           -gitUserEmail ${env:BOT_USER_EMAIL}
 
   update-changelog-release-dates-on-prepare-pr-post-notice:
+    name: Update changelog release dates and post notice
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -187,7 +198,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}
@@ -225,6 +237,7 @@ jobs:
           -gitUserEmail ${env:BOT_USER_EMAIL}
 
   update-releasenotes-on-prepare-pr-post-notice:
+    name: Update release notes and post notice
     runs-on: ubuntu-24.04
 
     needs: automation
@@ -240,7 +253,8 @@ jobs:
       needs.automation.outputs.enabled
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -14,10 +14,14 @@ on:
       - 'core-*'
       - 'coreunstable-*'
   schedule:
-    - cron: '0 0 * * *' # once in a day at 00:00
+    - cron: '0 0 * * *' # Once a day at 00:00 UTC
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   automation:
@@ -27,13 +31,14 @@ jobs:
       OTELBOT_DOTNET_PRIVATE_KEY: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
 
   build-pack-publish:
+    name: Build, pack, and publish
     if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.event.repository.fork == false)
-    runs-on: windows-latest
+    runs-on: windows-2025
     permissions:
-      artifact-metadata: write
-      attestations: write
-      contents: read
-      id-token: write
+      artifact-metadata: write # Publish artifact metadata for the uploaded packages
+      attestations: write # Create GitHub attestations for the build outputs
+      contents: read # Checkout the repository
+      id-token: write # Sign packages and attestations with GitHub OIDC
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       COSIGN_YES: "yes"
@@ -197,6 +202,7 @@ jobs:
       run: dotnet nuget push *.nupkg --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
 
   post-build:
+    name: Post build release tasks
     runs-on: ubuntu-24.04
 
     needs:
@@ -206,7 +212,8 @@ jobs:
     if: needs.automation.outputs.enabled && github.event_name == 'push'
 
     steps:
-    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+    - name: Generate GitHub App token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: otelbot-token
       with:
         client-id: ${{ vars.OTELBOT_DOTNET_APP_ID }}

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -43,14 +43,17 @@ jobs:
       artifact-id: ${{ steps.upload-artifacts.outputs.artifact-id }}
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         # Note: By default GitHub only fetches 1 commit. MinVer needs to find
         # the version tag which is typically NOT on the first commit so we
         # retrieve them all.
         fetch-depth: 0
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
     - name: Install Cosign
@@ -211,9 +214,11 @@ jobs:
         permission-contents: write
         permission-pull-requests: write
 
-    - name: Check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+        show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Download Artifacts

--- a/.github/workflows/sanitycheck.yml
+++ b/.github/workflows/sanitycheck.yml
@@ -1,5 +1,3 @@
-# Called by ci.yml to perform general linting
-# See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
 name: Lint - Spelling & Encoding
 
 on:
@@ -10,6 +8,7 @@ permissions:
 
 jobs:
   run-typos:
+    name: Check for typos
     runs-on: ubuntu-24.04
 
     steps:
@@ -20,11 +19,11 @@ jobs:
         persist-credentials: false
         show-progress: false
 
-    - name: check for typos
+    - name: Check for typos
       uses: crate-ci/typos@aca895bf05aec0cb7dffa6f94495e923224d9f17 # v1.46.2
 
   run-sanitycheck:
-    name: run-sanitycheck
+    name: Run sanity check
     runs-on: ubuntu-24.04
 
     steps:
@@ -35,5 +34,5 @@ jobs:
         persist-credentials: false
         show-progress: false
 
-    - name: detect non-ASCII encoding and trailing space
+    - name: Detect non-ASCII encoding and trailing space
       run: python3 ./build/scripts/sanitycheck.py

--- a/.github/workflows/sanitycheck.yml
+++ b/.github/workflows/sanitycheck.yml
@@ -13,18 +13,27 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
     - name: check for typos
       uses: crate-ci/typos@aca895bf05aec0cb7dffa6f94495e923224d9f17 # v1.46.2
 
   run-sanitycheck:
+    name: run-sanitycheck
     runs-on: ubuntu-24.04
 
     steps:
-    - name: check out code
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
     - name: detect non-ASCII encoding and trailing space
       run: python3 ./build/scripts/sanitycheck.py

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,23 +1,24 @@
-# Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
-# Github Actions Stale: https://github.com/actions/stale
-
 name: "Manage stale issues and pull requests"
 on:
   schedule:
     - cron: "12 3 * * *"  # arbitrary time not to DDOS GitHub
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   stale:
     if: github.event.repository.fork == false
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
+    name: stale
     permissions:
-      issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
+      issues: write  # For actions/stale to close stale issues
+      pull-requests: write  # For actions/stale to close stale PRs
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-issue-message: 'This issue was marked stale due to lack of activity and will be closed in 7 days. Commenting will instruct the bot to automatically remove the label. This bot runs once per day.'
           close-issue-message: 'Closed as inactive. Feel free to reopen if this issue is still a concern.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: "Manage stale issues and pull requests"
 on:
   schedule:
-    - cron: "12 3 * * *"  # arbitrary time not to DDOS GitHub
+    - cron: "12 3 * * *"  # Arbitrary time not to DDoS GitHub
 
 permissions: {}
 

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,7 +1,7 @@
 name: Survey on Merged PR by Non-Member
 
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers] This usage is safe as no user code is excecuted
+  pull_request_target: # zizmor: ignore[dangerous-triggers] This usage is safe as no user code is executed
     branches: [main]
     types: [closed]
 

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,7 +1,7 @@
 name: Survey on Merged PR by Non-Member
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] This usage is safe as no user code is excecuted
     branches: [main]
     types: [closed]
 
@@ -10,8 +10,11 @@ permissions: {}
 jobs:
   comment-on-pr:
     name: Add survey to PR if author is not a member
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
     permissions:
-      pull-requests: write
+      pull-requests: write # To add comment to the PR
     runs-on: ubuntu-latest
     # Only run for merged pull requests by non-members users (i.e. not bots or opentelemetrybot)
     if: |

--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   run-verify-aot-compat:
+    name: run-verify-aot-compat
 
     strategy:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
@@ -23,12 +24,17 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
-    - name: publish AOT testApp, assert static analysis warning count, and run the app
+    - name: Publish AOT testApp, assert static analysis warning count, and run the app
       shell: pwsh
       run: .\build\scripts\test-aot-compatibility.ps1 ${env:TARGET_FRAMEWORK}
       env:

--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -1,5 +1,3 @@
-# Called by ci.yml to perform AOT validation
-# See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow
 name: Publish & Verify AOT Compatibility
 
 on:
@@ -14,12 +12,16 @@ permissions:
 
 jobs:
   run-verify-aot-compat:
-    name: run-verify-aot-compat
+    name: Verify AOT compatibility
 
     strategy:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
-        os: [ ubuntu-22.04, windows-latest ]
+        os:
+          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          - ubuntu-22.04
+          # renovate: datasource=github-runners depName=windows depType=github-runner
+          - windows-2025
         version: [ net8.0, net9.0, net10.0 ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Changes

- Fix zizmor findings from #7331.
- Use `windows-2025` instead of `windows-latest`
- Allow renovate to update GitHub Actions runner labels in matricies

Post-merge we should be able to enforce these as required:

<img width="488" height="59" alt="image" src="https://github.com/user-attachments/assets/7f024346-6da4-43d6-890a-eb6983b4d5f4" />


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
