### PR TITLE
[Repo] Fix renovate regex not matching

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
         "/(^|/)action\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate:\\s*datasource=(?<datasource>github-runners)\\s+depName=(?<depName>[^\\s]+)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*[A-Za-z0-9_-]+:\\s*['\"]?(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
+        "# renovate:\\s*datasource=(?<datasource>github-runners)\\s+depName=(?<depName>[^\\s]+)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}github-runner{{/if}}"
     }


### PR DESCRIPTION
## Changes

Fix the regex not matching arrays in all cases. It didn't pick up the `os:` entries [here](https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-dotnet%20%22ubuntu-22.04%22&type=code) as it didn't cater for the array listing correctly.

The `default` list still doesn't match (on purpose, because there's no way to add a comment that would work correctly) so that will need updating manually.

Checked the matches are now found using regex101.com.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
