### PR TITLE
[Infra] Fix slow windows-11-arm runs

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -100,7 +100,7 @@ jobs:
         --no-restore
         --no-build
         --logger:"GitHubActions;report-warnings=false"
-        --logger:"junit;LogFilePath=TestResults/junit.xml"
+        --logger:"junit;LogFilePath=${env:GITHUB_WORKSPACE}/TestResults/junit.xml"
         -- RunConfiguration.DisableAppDomain=${env:DISABLE_APP_DOMAIN}
 
     - name: Install coverage tool
@@ -120,18 +120,21 @@ jobs:
         OS: ${{ matrix.os }}
         TFM: ${{ matrix.version }}
       with:
-        files: TestResults/Cobertura.xml
+        disable_search: true
         env_vars: OS,TFM
+        files: TestResults/Cobertura.xml
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Code Coverage for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
         codecov_yml_path: .github/codecov.yml
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
-      if: ${{ !cancelled() && hashFiles('./**/TestResults/junit.xml') != '' }}
+      if: ${{ !cancelled() && hashFiles('./TestResults/junit.xml') != '' }}
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
+        disable_search: true
         env_vars: OS,TFM
+        files: TestResults/junit.xml
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Test results for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
         report_type: test_results


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4430

## Changes

Apply Copilot-suggested fix to solve slow windows-11-arm jobs by containing the search path for codecov files and specifying the results path to avoid slow x64 emulation and file search.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
