### PR TITLE
[Repo] Fix renovate GitHub Runner updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
         "/(^|/)action\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate:\\s*datasource=(?<datasource>github-runners)\\s+depName=(?<depName>[^\\s]+)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
+        "# renovate:\\s*datasource=(?<datasource>github-runners)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<depName>[a-zA-Z]+)-(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}github-runner{{/if}}"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,8 +14,7 @@
       ],
       "matchStrings": [
         "# renovate:\\s*datasource=(?<datasource>github-runners)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<depName>[a-zA-Z]+)-(?<currentValue>[A-Za-z0-9._-]+)['\"]?"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}github-runner{{/if}}"
+      ]
     }
   ],
   "dependencyDashboard": false,

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -44,10 +44,10 @@ jobs:
         os: ${{ fromJSON(inputs.os-list) }}
         version: ${{ fromJSON(inputs.tfm-list) }}
         exclude:
-        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+        # renovate: datasource=github-runners depType=github-runner
         - os: ubuntu-22.04
           version: net462
-        # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+        # renovate: datasource=github-runners depType=github-runner
         - os: ubuntu-22.04-arm
           version: net462
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,9 +193,9 @@ jobs:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         os:
-          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          # renovate: datasource=github-runners depType=github-runner
           - ubuntu-24.04
-          # renovate: datasource=github-runners depName=windows depType=github-runner
+          # renovate: datasource=github-runners depType=github-runner
           - windows-2025
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/.github/workflows/concurrency-tests.yml
+++ b/.github/workflows/concurrency-tests.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
         os:
-          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          # renovate: datasource=github-runners depType=github-runner
           - ubuntu-22.04
-          # renovate: datasource=github-runners depName=windows depType=github-runner
+          # renovate: datasource=github-runners depType=github-runner
           - windows-2025
         version: [ net8.0, net10.0 ]
         project: [ OpenTelemetry.Tests, OpenTelemetry.Api.Tests ]

--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: ${{ inputs.trigger == 'merge_group' }}
       matrix:
         os:
-          # renovate: datasource=github-runners depName=ubuntu depType=github-runner
+          # renovate: datasource=github-runners depType=github-runner
           - ubuntu-22.04
-          # renovate: datasource=github-runners depName=windows depType=github-runner
+          # renovate: datasource=github-runners depType=github-runner
           - windows-2025
         version: [ net8.0, net9.0, net10.0 ]
 


### PR DESCRIPTION
Context: #7337

## Changes

Update the regex to split the value into the dependency name and the current version and remove `depName` from the comments (as it's duplicative).

Tested via https://github.com/martincostello/renovate-config/pull/170 then https://github.com/martincostello/xunit-logging/pull/1255, which created https://github.com/martincostello/xunit-logging/pull/1256 and https://github.com/martincostello/xunit-logging/pull/1257.

Then a follow-up fix for Ubuntu with https://github.com/martincostello/renovate-config/pull/173 and tested via https://github.com/martincostello/xunit-logging/pull/1259 to get https://github.com/martincostello/xunit-logging/pull/1260.

Reverse-engineered the fix from [renovate's code](https://github.com/renovatebot/renovate/blob/6c6a6b793d6f339a18222e6aec851df77ceaa8f4/lib/modules/manager/github-actions/extract.ts#L218-L248).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
