### PR TITLE
otlp httpclient magic string as consts

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -4,3 +4,7 @@ OpenTelemetry.Exporter.OtlpExportCompression.GZip = 1 -> OpenTelemetry.Exporter.
 OpenTelemetry.Exporter.OtlpExportCompression.None = 0 -> OpenTelemetry.Exporter.OtlpExportCompression
 OpenTelemetry.Exporter.OtlpExporterOptions.Compression.get -> OpenTelemetry.Exporter.OtlpExportCompression
 OpenTelemetry.Exporter.OtlpExporterOptions.Compression.set -> void
+OpenTelemetry.Exporter.OtlpExporterHttpClientConstants
+const OpenTelemetry.Exporter.OtlpExporterHttpClientConstants.LogExporterHttpClientName = "OtlpLogExporter" -> string!
+const OpenTelemetry.Exporter.OtlpExporterHttpClientConstants.MetricExporterHttpClientName = "OtlpMetricExporter" -> string!
+const OpenTelemetry.Exporter.OtlpExporterHttpClientConstants.TraceExporterHttpClientName = "OtlpTraceExporter" -> string!

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added `OtlpExporterHttpClientConstants` to expose the HTTP client names used
+  by the OTLP trace, metric, and log exporters as public constants.
+  ([#7344](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7344))
+
 * Fixed `NullReferenceException` when exporting logs if the scope key is null.
   ([#7186](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7186))
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterHttpClientConstants.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterHttpClientConstants.cs
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter;
+
+/// <summary>
+/// Contains HTTP client name constants for the OpenTelemetry Protocol (OTLP) exporter.
+/// </summary>
+public static class OtlpExporterHttpClientConstants
+{
+    /// <summary>The <see cref="System.Net.Http.HttpClient"/> name used for the OTLP trace exporter.</summary>
+    public const string TraceExporterHttpClientName = "OtlpTraceExporter";
+
+    /// <summary>The <see cref="System.Net.Http.HttpClient"/> name used for the OTLP log exporter.</summary>
+    public const string LogExporterHttpClientName = "OtlpLogExporter";
+
+    /// <summary>The <see cref="System.Net.Http.HttpClient"/> name used for the OTLP metric exporter.</summary>
+    public const string MetricExporterHttpClientName = "OtlpMetricExporter";
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterHttpClientConstants.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterHttpClientConstants.cs
@@ -9,11 +9,11 @@ namespace OpenTelemetry.Exporter;
 public static class OtlpExporterHttpClientConstants
 {
     /// <summary>The <see cref="System.Net.Http.HttpClient"/> name used for the OTLP trace exporter.</summary>
-    public const string TraceExporterHttpClientName = "OtlpTraceExporter";
+    public static readonly string TraceExporterHttpClientName = nameof(OtlpTraceExporter);
 
     /// <summary>The <see cref="System.Net.Http.HttpClient"/> name used for the OTLP log exporter.</summary>
-    public const string LogExporterHttpClientName = "OtlpLogExporter";
+    public static readonly string LogExporterHttpClientName = nameof(OtlpLogExporter);
 
     /// <summary>The <see cref="System.Net.Http.HttpClient"/> name used for the OTLP metric exporter.</summary>
-    public const string MetricExporterHttpClientName = "OtlpMetricExporter";
+    public static readonly string MetricExporterHttpClientName = nameof(OtlpMetricExporter);
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -299,7 +299,7 @@ public static class OtlpLogExporterHelperExtensions
         }
 
         OtlpExporterTransmissionHandler? transmissionHandler = null;
-        if (exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter"))
+        if (exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, OtlpExporterHttpClientConstants.LogExporterHttpClientName))
         {
             transmissionHandler = exporterOptions.GetExportTransmissionHandler(
                 experimentalOptions,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -178,7 +178,7 @@ public static class OtlpMetricExporterExtensions
             serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpMetricExporter");
+        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, OtlpExporterHttpClientConstants.MetricExporterHttpClientName);
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         BaseExporter<Metric> metricExporter = new OtlpMetricExporter(exporterOptions, experimentalOptions);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -139,7 +139,7 @@ public static class OtlpTraceExporterHelperExtensions
             serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpTraceExporter");
+        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, OtlpExporterHttpClientConstants.TraceExporterHttpClientName);
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         BaseExporter<Activity> otlpExporter = new OtlpTraceExporter(exporterOptions, sdkLimitOptions, experimentalOptions);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Configuration;
 #if NET
 using Microsoft.Extensions.DependencyInjection;
 #endif
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 #if NET
 using Microsoft.Extensions.DependencyInjection;
 #endif
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
@@ -112,7 +113,7 @@ public class OtlpExporterOptionsExtensionsTests
     {
         var services = new ServiceCollection();
 
-        services.AddHttpClient("OtlpLogExporter");
+        services.AddHttpClient(OtlpExporterHttpClientConstants.LogExporterHttpClientName);
 
         using var serviceProvider = services.BuildServiceProvider();
 
@@ -128,7 +129,7 @@ public class OtlpExporterOptionsExtensionsTests
 
         var originalFactory = options.HttpClientFactory;
 
-        var actual = options.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter");
+        var actual = options.TryEnableIHttpClientFactoryIntegration(serviceProvider, OtlpExporterHttpClientConstants.LogExporterHttpClientName);
 
         Assert.False(actual);
         Assert.Same(originalFactory, options.HttpClientFactory);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
@@ -122,7 +123,7 @@ public class OtlpLogExporterTests
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpLogExporter", configureClient: (client) => invocations++);
+        services.AddHttpClient(OtlpExporterHttpClientConstants.LogExporterHttpClientName, configureClient: (client) => invocations++);
 
         services.AddLogging(builder =>
         {
@@ -150,7 +151,7 @@ public class OtlpLogExporterTests
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpLogExporter")
+        services.AddHttpClient(OtlpExporterHttpClientConstants.LogExporterHttpClientName)
             .ConfigurePrimaryHttpMessageHandler(() => testHandler)
             .AddHttpMessageHandler(sp =>
             {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using Google.Protobuf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Google.Protobuf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -144,7 +145,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpMetricExporter", configureClient: (client) => invocations++);
+        services.AddHttpClient(OtlpExporterHttpClientConstants.MetricExporterHttpClientName, configureClient: (client) => invocations++);
 
         services.AddOpenTelemetry().WithMetrics(builder => builder
             .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.HttpProtobuf));

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
@@ -122,7 +123,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpTraceExporter", configureClient: (client) => invocations++);
+        services.AddHttpClient(OtlpExporterHttpClientConstants.TraceExporterHttpClientName, configureClient: (client) => invocations++);
 
         services.AddOpenTelemetry().WithTracing(builder => builder
             .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.HttpProtobuf));

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.DependencyInjection;
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Moving these magic strings to a public const. If anyone recommends a different format/pattern I can adjust.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [] Changes in public API reviewed (if applicable)
