### PR TITLE
chore: cleanup magic strings in favor of nameof(Otlp_____Exporter)

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -299,7 +299,7 @@ public static class OtlpLogExporterHelperExtensions
         }
 
         OtlpExporterTransmissionHandler? transmissionHandler = null;
-        if (exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter"))
+        if (exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, nameof(OtlpLogExporter)))
         {
             transmissionHandler = exporterOptions.GetExportTransmissionHandler(
                 experimentalOptions,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -178,7 +178,7 @@ public static class OtlpMetricExporterExtensions
             serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpMetricExporter");
+        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, nameof(OtlpMetricExporter));
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         BaseExporter<Metric> metricExporter = new OtlpMetricExporter(exporterOptions, experimentalOptions);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -139,7 +139,7 @@ public static class OtlpTraceExporterHelperExtensions
             serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpTraceExporter");
+        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, nameof(OtlpTraceExporter));
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         BaseExporter<Activity> otlpExporter = new OtlpTraceExporter(exporterOptions, sdkLimitOptions, experimentalOptions);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -619,18 +619,29 @@ services.AddOpenTelemetry()
 
 For users using
 [IHttpClientFactory](https://docs.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests)
-you may also customize the named "OtlpTraceExporter" and/or "OtlpMetricExporter"
-`HttpClient` using the built-in `AddHttpClient` extension:
+you may also customize the `HttpClient` for each exporter using the built-in
+`AddHttpClient` extension. The recommended way to obtain the client name is via
+`nameof()` on the exporter type:
 
 ```csharp
+// Traces
 services.AddHttpClient(
-    "OtlpTraceExporter",
+    nameof(OtlpTraceExporter),
+    configureClient: (client) =>
+        client.DefaultRequestHeaders.Add("X-MyCustomHeader", "value"));
+
+// Metrics
+services.AddHttpClient(
+    nameof(OtlpMetricExporter),
+    configureClient: (client) =>
+        client.DefaultRequestHeaders.Add("X-MyCustomHeader", "value"));
+
+// Logs
+services.AddHttpClient(
+    nameof(OtlpLogExporter),
     configureClient: (client) =>
         client.DefaultRequestHeaders.Add("X-MyCustomHeader", "value"));
 ```
-
-> [!NOTE]
-> `IHttpClientFactory` is NOT currently supported by `OtlpLogExporter`.
 
 ## Experimental features
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -112,7 +112,7 @@ public class OtlpExporterOptionsExtensionsTests
     {
         var services = new ServiceCollection();
 
-        services.AddHttpClient("OtlpLogExporter");
+        services.AddHttpClient(nameof(OtlpLogExporter));
 
         using var serviceProvider = services.BuildServiceProvider();
 
@@ -128,7 +128,7 @@ public class OtlpExporterOptionsExtensionsTests
 
         var originalFactory = options.HttpClientFactory;
 
-        var actual = options.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter");
+        var actual = options.TryEnableIHttpClientFactoryIntegration(serviceProvider, nameof(OtlpLogExporter));
 
         Assert.False(actual);
         Assert.Same(originalFactory, options.HttpClientFactory);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -122,7 +122,7 @@ public class OtlpLogExporterTests
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpLogExporter", configureClient: (client) => invocations++);
+        services.AddHttpClient(nameof(OtlpLogExporter), configureClient: (client) => invocations++);
 
         services.AddLogging(builder =>
         {
@@ -150,7 +150,7 @@ public class OtlpLogExporterTests
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpLogExporter")
+        services.AddHttpClient(nameof(OtlpLogExporter))
             .ConfigurePrimaryHttpMessageHandler(() => testHandler)
             .AddHttpMessageHandler(sp =>
             {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -144,7 +144,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpMetricExporter", configureClient: (client) => invocations++);
+        services.AddHttpClient(nameof(OtlpMetricExporter), configureClient: (client) => invocations++);
 
         services.AddOpenTelemetry().WithMetrics(builder => builder
             .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.HttpProtobuf));

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -122,7 +122,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
 
         var invocations = 0;
 
-        services.AddHttpClient("OtlpTraceExporter", configureClient: (client) => invocations++);
+        services.AddHttpClient(nameof(OtlpTraceExporter), configureClient: (client) => invocations++);
 
         services.AddOpenTelemetry().WithTracing(builder => builder
             .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.HttpProtobuf));


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

cleanup magic strings in favor of nameof(Otlp_____Exporter)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
