### PR TITLE
[tests] add Xunit namespaces to global usings

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project>
   <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'Directory.Build.props'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.slnx'))\build\Common.nonprod.props" />
+
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests')) or $(MSBuildProjectName.EndsWith('.FuzzTests'))">
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Logs;
-using Xunit;
 
 namespace OpenTelemetry.Api.ProviderBuilderExtensions.Tests;
 

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Metrics/MeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Metrics/MeterProviderBuilderExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Api.ProviderBuilderExtensions.Tests;
 

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/ServiceCollectionExtensionsTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Api.ProviderBuilderExtensions.Tests;
 

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Trace/TracerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Trace/TracerProviderBuilderExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Api.ProviderBuilderExtensions.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/ActivityTraceFlagsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/ActivityTraceFlagsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Api.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Context.Propagation.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Net;
-using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/CompositePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/CompositePropagatorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/EnvironmentVariableCarrierTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/EnvironmentVariableCarrierTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/PropagatorsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/PropagatorsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Context.Propagation.Tests;
 
 public sealed class PropagatorsTests : IDisposable

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/TracestateUtilsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/TracestateUtilsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Context.Propagation.Tests;
 
 public class TracestateUtilsTests

--- a/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Context.Tests;
 
 public sealed class RuntimeContextTests : IDisposable

--- a/test/OpenTelemetry.Api.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Api.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Api.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Internal/GuardTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Internal/GuardTests.cs
@@ -4,7 +4,6 @@
 #if NETFRAMEWORK
 using System.Runtime.CompilerServices;
 #endif
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Logs.Tests;
 
 public sealed class LogRecordAttributeListTests

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordDataTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordDataTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordSeverityExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordSeverityExtensionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Logs.Tests;
 
 public sealed class LogRecordSeverityExtensionsTests

--- a/test/OpenTelemetry.Api.Tests/Logs/LoggerProviderTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LoggerProviderTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.CodeAnalysis;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Trace/ActivityExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/ActivityExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Trace/SpanAttributesTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/SpanAttributesTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Trace.Tests;
 
 public class SpanAttributesTests

--- a/test/OpenTelemetry.Api.Tests/Trace/StatusTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/StatusTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Trace.Tests;
 
 public class StatusTests

--- a/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Api.Tests/Trace/TracerTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/TracerTests.cs
@@ -5,8 +5,6 @@ using System.Diagnostics;
 using Microsoft.Coyote;
 using Microsoft.Coyote.SystematicTesting;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleActivityExporterAdditionalTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleActivityExporterAdditionalTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Console.Tests;
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleActivityExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleActivityExporterTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Console.Tests;
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterLoggingExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterLoggingExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Console.Tests;
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterMetricsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterMetricsExtensionsTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Console.Tests;
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterOptionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Console.Tests;
 
 public class ConsoleExporterOptionsTests

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterTracerExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleExporterTracerExtensionsTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Console.Tests;
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Console.Tests;
 

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleMetricExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleMetricExporterTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.Metrics;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Console.Tests;
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/IntegrationTests.cs
@@ -11,7 +11,6 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -13,11 +13,9 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
@@ -19,8 +19,6 @@ using OpenTelemetry.Exporter.Prometheus.Tests;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PromToolCollection.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PromToolCollection.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 
 [CollectionDefinition(Name)]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusAcceptHeaders.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusAcceptHeaders.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Prometheus;
 
 public static class PrometheusAcceptHeaders

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollection.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollection.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 
 [CollectionDefinition(Name)]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHeadersParserTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHeadersParserTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 
 public class PrometheusHeadersParserTests

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -11,7 +11,6 @@ using System.Net.Http;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusIntegrationTests.cs
@@ -6,8 +6,6 @@ using System.Diagnostics.Metrics;
 using OpenTelemetry.Exporter.Prometheus.Tests;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Exporter.Prometheus.HttpListener.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Exporter.Zipkin.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/RemoteEndpointPriorityTestCase.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/RemoteEndpointPriorityTestCase.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Internal;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using OpenTelemetry.Exporter.Zipkin.Tests;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Exporter.Zipkin.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinEndpointLruCacheTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinEndpointLruCacheTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/PooledListTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/PooledListTests.cs
@@ -3,8 +3,6 @@
 
 using System.Collections;
 
-using Xunit;
-
 namespace OpenTelemetry.Internal.Tests;
 
 public class PooledListTests

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinActivitySource.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinActivitySource.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Tests;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -15,7 +15,6 @@ using OpenTelemetry.Exporter.Zipkin.Implementation;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Exporter.Zipkin.Tests;
 

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Extensions.Hosting.Implementation;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Hosting.Tests;
 

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/InMemoryExporterMetricsExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/InMemoryExporterMetricsExtensionsTests.cs
@@ -16,8 +16,6 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
-using Xunit;
-
 namespace OpenTelemetry.Extensions.Hosting.Tests;
 
 /// <summary>

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryBuilderTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryBuilderTests.cs
@@ -6,7 +6,6 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Hosting.Tests;
 

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
@@ -8,12 +8,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Metrics.Tests;
 using OpenTelemetry.Tests;
-using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Hosting.Tests;
 

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Hosting.Tests;
 

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
@@ -3,8 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Extensions.Propagators.Tests;
 

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/EventSourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Propagators.Tests;
 

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
-using Xunit;
 
 namespace OpenTelemetry.Extensions.Propagators.Tests;
 

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -9,8 +9,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
 
 [CollectionDefinition(nameof(ListenAndSampleAllActivitySources))]

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Trace;
 using OpenTracing.Tag;
-using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -7,7 +7,6 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
 using OpenTracing;
 using OpenTracing.Propagation;
-using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
 

--- a/test/OpenTelemetry.Tests/BaseExporterTests.cs
+++ b/test/OpenTelemetry.Tests/BaseExporterTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 public class BaseExporterTests

--- a/test/OpenTelemetry.Tests/BaseProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/BaseProcessorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 public class BaseProcessorTests

--- a/test/OpenTelemetry.Tests/Concurrency/MetricsConcurrencyTests.cs
+++ b/test/OpenTelemetry.Tests/Concurrency/MetricsConcurrencyTests.cs
@@ -4,8 +4,6 @@
 using Microsoft.Coyote;
 using Microsoft.Coyote.SystematicTesting;
 using OpenTelemetry.Metrics.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Tests.Concurrency;
 

--- a/test/OpenTelemetry.Tests/EventSourceTestHelperTests.cs
+++ b/test/OpenTelemetry.Tests/EventSourceTestHelperTests.cs
@@ -4,7 +4,6 @@
 // Adapted from https://github.com/dotnet/aspnetcore/blob/3a973a5f4d28242262f27c86eb3f14299fe712ba/src/Testing/test/EventSourceValidatorTests.cs
 
 using System.Diagnostics.Tracing;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 

--- a/test/OpenTelemetry.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Tests/EventSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Internal;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/AssemblyVersionExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/AssemblyVersionExtensionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Reflection;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/CircularBufferTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/CircularBufferTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Internal.Tests;
 
 public class CircularBufferTests

--- a/test/OpenTelemetry.Tests/Internal/DelegatingOptionsFactoryTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/DelegatingOptionsFactoryTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/InterlockedHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/InterlockedHelperTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Internal.Tests;
 
 public class InterlockedHelperTests

--- a/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/MathHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/MathHelperTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Internal.Tests;
 
 public class MathHelperTests

--- a/test/OpenTelemetry.Tests/Internal/PeriodicExportingMetricReaderHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/PeriodicExportingMetricReaderHelperTests.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigParserTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigParserTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Internal.Tests;
 
 public class SelfDiagnosticsConfigParserTests

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTests.cs
@@ -4,8 +4,6 @@
 using System.Diagnostics;
 using System.Text;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTests.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO.MemoryMappedFiles;
 using System.Text;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/StopwatchExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/StopwatchExtensionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/TaskWorkerTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/TaskWorkerTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 

--- a/test/OpenTelemetry.Tests/Internal/WildcardHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/WildcardHelperTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Internal.Tests;
 
 public class WildcardHelperTests

--- a/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
@@ -5,7 +5,6 @@
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/LogRecordSharedPoolTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordSharedPoolTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/LogRecordStateProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordStateProcessorTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/LogRecordThreadStaticPoolTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordThreadStaticPoolTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Logs.Tests;
 
 public sealed class LogRecordThreadStaticPoolTests

--- a/test/OpenTelemetry.Tests/Logs/LoggerFactoryAndResourceBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerFactoryAndResourceBuilderTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderBaseTests.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
 using static OpenTelemetry.OpenTelemetrySdk;
 
 namespace OpenTelemetry.Logs.Tests;

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderExtensionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Exporter;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Exporter;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggerProviderTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggerProviderTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggingExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggingExtensionsTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/Base2ExponentialBucketHistogramHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/Base2ExponentialBucketHistogramHelperTests.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/Base2ExponentialBucketHistogramTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/Base2ExponentialBucketHistogramTests.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/CircularBufferBucketsTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/CircularBufferBucketsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Metrics.Tests;
 
 public class CircularBufferBucketsTests

--- a/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Metrics.Tests;
 
 #pragma warning disable CA1819 // Properties should not return arrays

--- a/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
@@ -5,8 +5,6 @@ using System.Diagnostics.Metrics;
 
 using OpenTelemetry.Tests;
 
-using Xunit;
-
 namespace OpenTelemetry.Metrics.Tests;
 
 public class InMemoryExporterTests

--- a/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderBaseTests.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
 using static OpenTelemetry.OpenTelemetrySdk;
 
 namespace OpenTelemetry.Metrics.Tests;

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderExtensionsTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Resources;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderSdkTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Exporter;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
@@ -6,8 +6,6 @@ using System.Diagnostics.Metrics;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExporterTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Metrics.Tests;
 
 public class MetricExporterTests

--- a/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricReaderTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricReaderTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTests.cs
@@ -4,8 +4,6 @@
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Tests;
 
-using Xunit;
-
 namespace OpenTelemetry.Metrics.Tests;
 
 public class MetricSnapshotTests

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Metrics.Tests;
 
 internal static class MetricTestData

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 #endif
 using OpenTelemetry.Internal;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 

--- a/test/OpenTelemetry.Tests/OpenTelemetrySdkTests.cs
+++ b/test/OpenTelemetry.Tests/OpenTelemetrySdkTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 

--- a/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace OpenTelemetry.Resources.Tests;
 

--- a/test/OpenTelemetry.Tests/Resources/OtelServiceNameEnvVarDetectorTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelServiceNameEnvVarDetectorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace OpenTelemetry.Resources.Tests;
 

--- a/test/OpenTelemetry.Tests/Resources/ResourceBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceBuilderTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Resources.Tests;
 
 public class ResourceBuilderTests

--- a/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace OpenTelemetry.Resources.Tests;
 

--- a/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
+++ b/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
@@ -4,10 +4,6 @@
 using System.Diagnostics.Tracing;
 using System.Reflection;
 
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-using Xunit;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
-
 namespace OpenTelemetry.Tests;
 
 // Adapted from https://github.com/dotnet/aspnetcore/blob/3a973a5f4d28242262f27c86eb3f14299fe712ba/src/Testing/test/EventSourceValidatorTests.cs

--- a/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
+++ b/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 internal sealed class SkipUnlessEnvVarFoundFactAttribute : FactAttribute

--- a/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
+++ b/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
@@ -1,10 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-using Xunit;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
-
 namespace OpenTelemetry.Tests;
 
 internal sealed class SkipUnlessEnvVarFoundTheoryAttribute : TheoryAttribute

--- a/test/OpenTelemetry.Tests/SimpleExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/SimpleExportProcessorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 public class SimpleExportProcessorTests

--- a/test/OpenTelemetry.Tests/SuppressInstrumentationTests.cs
+++ b/test/OpenTelemetry.Tests/SuppressInstrumentationTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 public class SuppressInstrumentationTests

--- a/test/OpenTelemetry.Tests/Trace/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Tests/Trace/AttributesExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Trace.Tests;
 
 internal static class AttributesExtensions

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Exporter;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/BatchTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Internal;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/CurrentSpanTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CurrentSpanTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/ExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExportProcessorTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/LinkTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/LinkTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/SamplersTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplersTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/SamplingResultTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplingResultTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Trace.Tests;
 
 public class SamplingResultTests

--- a/test/OpenTelemetry.Tests/Trace/SimpleExportActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SimpleExportActivityProcessorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Exporter;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/SpanContextTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanContextTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/TraceIdRatioBasedSamplerTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TraceIdRatioBasedSamplerTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderBaseTests.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
 using static OpenTelemetry.OpenTelemetrySdk;
 
 namespace OpenTelemetry.Trace.Tests;

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderExtensionsTests.cs
@@ -4,8 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Tests;
 
-using Xunit;
-
 namespace OpenTelemetry.Trace.Tests;
 
 public class TracerProviderExtensionsTests

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Resources.Tests;
 using OpenTelemetry.Tests;
-using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;
 

--- a/test/Shared/EnabledOnDockerPlatformFactAttribute.cs
+++ b/test/Shared/EnabledOnDockerPlatformFactAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 /// <summary>

--- a/test/Shared/EnabledOnDockerPlatformTheoryAttribute.cs
+++ b/test/Shared/EnabledOnDockerPlatformTheoryAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.Tests;
 
 /// <summary>

--- a/test/Shared/StrongNameTests.cs
+++ b/test/Shared/StrongNameTests.cs
@@ -1,10 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma warning disable IDE0005 // Using directive is unnecessary.
-using Xunit;
-#pragma warning restore IDE0005 // Using directive is unnecessary.
-
 namespace OpenTelemetry.Tests;
 
 // The tests can only be strong named if they only depend on assemblies that are strong named,

--- a/test/Shared/XunitContainerFixture{T}.cs
+++ b/test/Shared/XunitContainerFixture{T}.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using DotNet.Testcontainers.Containers;
-using Xunit;
 
 namespace OpenTelemetry.Tests;
 


### PR DESCRIPTION
Inspired by https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/5133/changes#diff-af5b00be86cfd4b9af22d05535dc0c179aaa41549a0e6a978db498a55ca28075R17-R21 and new pragmas https://github.com/open-telemetry/opentelemetry-dotnet/pull/7354

## Changes

[tests] add Xunit namescpaces to global usings
Verify.XUnit brings this by default, so part of the test project does not need this. Enabling this globally.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
