### PR TITLE
[Infra] Add actionlint configuration file

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet/pull/7366#issuecomment-4621552478

## Changes

Configure actionlint to recognise the `oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24` label.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
