### PR TITLE
[OTLP] Fix Protobuf SpanKind field numbers

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceFieldNumberConstants.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceFieldNumberConstants.cs
@@ -44,11 +44,11 @@ internal static class ProtobufOtlpTraceFieldNumberConstants
     internal const int Span_Flags = 16;
 
     // SpanKind
-    internal const int SpanKind_Internal = 2;
-    internal const int SpanKind_Server = 3;
-    internal const int SpanKind_Client = 4;
-    internal const int SpanKind_Producer = 5;
-    internal const int SpanKind_Consumer = 6;
+    internal const int SpanKind_Internal = 1;
+    internal const int SpanKind_Server = 2;
+    internal const int SpanKind_Client = 3;
+    internal const int SpanKind_Producer = 4;
+    internal const int SpanKind_Consumer = 5;
 
     // Events
     internal const int Event_Time_Unix_Nano = 1;


### PR DESCRIPTION
## Changes

The `SpanKind` field numbers didn't match those [defined in the spec](https://github.com/open-telemetry/opentelemetry-proto/blob/6d0a56803a540ed526cd918895e72c79df25fc92/opentelemetry/proto/trace/v1/trace.proto#L153-L179). The values are actually unused currently, as far as I can see, so could also be removed entirely if that's preferred.

I just fixed the field numbers, rather than doing anything else, but can add extra tests etc if required/desired

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
