### PR TITLE
[Exporter.Prometheus] Use dictionary to key views

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/OpenTelemetry.Exporter.Prometheus.AspNetCore.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/OpenTelemetry.Exporter.Prometheus.AspNetCore.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\CharExtensions.cs" Link="Includes\CharExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\Lock.cs" Link="Includes\Shims\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -116,7 +116,7 @@ internal sealed class PrometheusExporterMiddleware
             }
             finally
             {
-                this.exporter.CollectionManager.ExitCollect();
+                this.exporter.CollectionManager.ExitCollect(protocol);
             }
         }
         catch (Exception ex)

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -79,13 +79,13 @@ internal sealed class PrometheusExporterMiddleware
 
             var protocol = Negotiate(requestHeaders);
 
-            var collectionResponse = await this.exporter.CollectionManager.EnterCollect(protocol.IsOpenMetrics);
+            var collectionResponse = await this.exporter.CollectionManager.EnterCollect(protocol);
 
             try
             {
                 linkedCts.Token.ThrowIfCancellationRequested();
 
-                var dataView = protocol.IsOpenMetrics ? collectionResponse.OpenMetricsView : collectionResponse.PlainTextView;
+                var dataView = collectionResponse.View;
 
                 response.StatusCode = StatusCodes.Status200OK;
 
@@ -272,7 +272,7 @@ internal sealed class PrometheusExporterMiddleware
         if (version is null)
         {
             // Use the oldest version if no version preference was specified
-            version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV0 : PrometheusProtocol.PrometheusVersion0;
+            version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV0 : PrometheusProtocol.PrometheusV0;
         }
         else if (version.Major is not > 0)
         {
@@ -286,6 +286,9 @@ internal sealed class PrometheusExporterMiddleware
         }
 
         protocol = new(mediaType, escaping, version, isOpenMetrics);
+
+        protocol.Value.Validate();
+
         return true;
     }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusHeadersParser.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusHeadersParser.cs
@@ -119,7 +119,7 @@ internal static class PrometheusHeadersParser
             if (version is null)
             {
                 // Use the oldest version if no version preference was specified
-                version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV0 : PrometheusProtocol.PrometheusVersion0;
+                version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV0 : PrometheusProtocol.PrometheusV0;
             }
             else if (version.Major is not > 0)
             {
@@ -137,6 +137,8 @@ internal static class PrometheusHeadersParser
                 escaping,
                 version,
                 isOpenMetrics);
+
+            protocol.Validate();
 
             preferences.Add((protocol, quality));
         }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -22,9 +22,9 @@ internal sealed class PrometheusCollectionManager
     private int metricsCacheCount;
     private int globalLockState;
     private int readerCount;
-    private bool collectionRunning;
-    private PrometheusProtocol collectionProtocol;
-    private TaskCompletionSource<CollectionResponse>? collectionTcs;
+    private CollectionContext? collectionContext;
+    private CollectionContext? onCollectContext;
+    private CollectionExecutionResult collectionExecutionResult;
 
     public PrometheusCollectionManager(PrometheusExporter exporter)
     {
@@ -46,47 +46,110 @@ internal sealed class PrometheusCollectionManager
 #endif
     {
         CollectionResponse? cachedResponse = null;
-        Task<CollectionResponse>? pendingCollectionTask = null;
-        var incrementReaderCount = false;
+        Task<CollectionResult>? pendingCollectionTask = null;
+        CollectionContext? activeCollectionContext = null;
+        var joinedActiveCollection = false;
 
-        this.EnterGlobalLock();
-
-        try
+        while (true)
         {
-            // If we are within {ScrapeResponseCacheDurationMilliseconds} of the
-            // last successful collect, return the previous view.
-            if (this.protocolStates.TryGetValue(protocol, out var state) &&
-                state.GeneratedAt is { } generatedAt &&
-                this.scrapeResponseCacheDuration > TimeSpan.Zero &&
-                this.GetElapsedTime() - state.GeneratedAtElapsed < this.scrapeResponseCacheDuration)
-            {
-                cachedResponse = new CollectionResponse(state.View, generatedAt, fromCache: true);
-                incrementReaderCount = true;
-            }
-            else if (this.collectionRunning)
-            {
-                this.collectionTcs ??= new TaskCompletionSource<CollectionResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-                pendingCollectionTask = this.collectionTcs.Task;
-                incrementReaderCount = this.collectionProtocol.Equals(protocol);
-            }
-            else
-            {
-                this.WaitForReadersToComplete();
+            pendingCollectionTask = null;
+            joinedActiveCollection = false;
+            var retry = false;
 
-                // Start a collection on the current thread.
-                this.collectionRunning = true;
-                this.collectionProtocol = protocol;
-                incrementReaderCount = true;
-            }
-        }
-        finally
-        {
-            if (incrementReaderCount)
+            this.EnterGlobalLock();
+
+            try
             {
+                // If we are within {ScrapeResponseCacheDurationMilliseconds} of the
+                // last successful collect, return the previous view.
+                if (this.TryGetCachedResponse(protocol, out var response))
+                {
+                    cachedResponse = response;
+                    Interlocked.Increment(ref this.readerCount);
+                    break;
+                }
+
+                if (this.collectionContext is { } currentCollectionContext)
+                {
+                    if (currentCollectionContext.Task.IsCompleted)
+                    {
+                        if (ReferenceEquals(this.collectionContext, currentCollectionContext))
+                        {
+                            this.collectionContext = null;
+                        }
+
+                        retry = true;
+                    }
+                    else
+                    {
+                    pendingCollectionTask = currentCollectionContext.Task;
+                    joinedActiveCollection = currentCollectionContext.TryRegisterProtocol(protocol);
+
+                    if (joinedActiveCollection)
+                    {
+                        Interlocked.Increment(ref this.readerCount);
+                    }
+
+                    break;
+                    }
+                }
+            }
+            finally
+            {
+                this.ExitGlobalLock();
+            }
+
+            if (retry)
+            {
+                continue;
+            }
+
+            this.WaitForReadersToComplete();
+
+            this.EnterGlobalLock();
+
+            try
+            {
+                if (this.TryGetCachedResponse(protocol, out var response))
+                {
+                    cachedResponse = response;
+                    Interlocked.Increment(ref this.readerCount);
+                    break;
+                }
+
+                if (this.collectionContext is { } currentCollectionContext)
+                {
+                    if (currentCollectionContext.Task.IsCompleted)
+                    {
+                        if (ReferenceEquals(this.collectionContext, currentCollectionContext))
+                        {
+                            this.collectionContext = null;
+                        }
+
+                        continue;
+                    }
+
+                    pendingCollectionTask = currentCollectionContext.Task;
+                    joinedActiveCollection = currentCollectionContext.TryRegisterProtocol(protocol);
+
+                    if (joinedActiveCollection)
+                    {
+                        Interlocked.Increment(ref this.readerCount);
+                    }
+
+                    break;
+                }
+
+                activeCollectionContext = new CollectionContext(protocol);
+                this.collectionContext = activeCollectionContext;
+
                 Interlocked.Increment(ref this.readerCount);
+                break;
             }
-
-            this.ExitGlobalLock();
+            finally
+            {
+                this.ExitGlobalLock();
+            }
         }
 
         if (cachedResponse is { } collectionResponse)
@@ -100,62 +163,44 @@ internal sealed class PrometheusCollectionManager
 
         if (pendingCollectionTask is not null)
         {
-            if (incrementReaderCount)
-            {
 #if NET
-                return new ValueTask<CollectionResponse>(pendingCollectionTask);
+            return this.WaitForCollectionResponseAsync(protocol, pendingCollectionTask, joinedActiveCollection);
 #else
-                return pendingCollectionTask;
+            return this.WaitForCollectionResponseAsync(protocol, pendingCollectionTask, joinedActiveCollection);
 #endif
-            }
-
-            return this.WaitForRunningCollectionAndRetryAsync(protocol, pendingCollectionTask);
         }
 
-        CollectionResponse response;
-        var result = this.ExecuteCollect(protocol);
+        var result = this.ExecuteCollect(activeCollectionContext!);
 
-        if (result)
-        {
-            var generatedAt = this.UtcNow();
-            var generatedAtElapsed = this.GetElapsedTime();
-
-            ArraySegment<byte> view;
-
-            if (this.protocolStates.TryGetValue(protocol, out var state))
-            {
-                state.UpdateTimestamps(generatedAt, generatedAtElapsed);
-                view = state.View;
-            }
-            else
-            {
-                view = PrometheusProtocolState.EmptyView;
-            }
-
-            response = new CollectionResponse(view, generatedAt, fromCache: false);
-        }
-        else
-        {
-            response = default;
-        }
+        activeCollectionContext!.SetResult(result);
 
         this.EnterGlobalLock();
 
         try
         {
-            this.collectionRunning = false;
-            this.collectionTcs?.SetResult(response);
-            this.collectionTcs = null;
+            if (ReferenceEquals(this.collectionContext, activeCollectionContext))
+            {
+                this.collectionContext = null;
+            }
         }
         finally
         {
             this.ExitGlobalLock();
         }
 
+        if (result.TryGetResponse(protocol, out collectionResponse))
+        {
 #if NET
-        return new ValueTask<CollectionResponse>(response);
+            return new ValueTask<CollectionResponse>(collectionResponse);
 #else
-        return Task.FromResult(response);
+            return Task.FromResult(collectionResponse);
+#endif
+        }
+
+#if NET
+        return new ValueTask<CollectionResponse>(default(CollectionResponse));
+#else
+        return Task.FromResult(default(CollectionResponse));
 #endif
     }
 
@@ -164,12 +209,24 @@ internal sealed class PrometheusCollectionManager
         => Interlocked.Decrement(ref this.readerCount);
 
 #if NET
-    private async ValueTask<CollectionResponse> WaitForRunningCollectionAndRetryAsync(PrometheusProtocol protocol, Task<CollectionResponse> pendingCollectionTask)
+    private async ValueTask<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
 #else
-    private async Task<CollectionResponse> WaitForRunningCollectionAndRetryAsync(PrometheusProtocol protocol, Task<CollectionResponse> pendingCollectionTask)
+    private async Task<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
 #endif
     {
-        await pendingCollectionTask.ConfigureAwait(false);
+        var collectionResult = await pendingCollectionTask.ConfigureAwait(false);
+
+        if (protocolWasRegistered &&
+            collectionResult.TryGetResponse(protocol, out var response))
+        {
+            return response;
+        }
+
+        if (protocolWasRegistered)
+        {
+            Interlocked.Decrement(ref this.readerCount);
+        }
+
         return await this.EnterCollect(protocol).ConfigureAwait(false);
     }
 
@@ -179,7 +236,7 @@ internal sealed class PrometheusCollectionManager
         SpinWait lockWait = default;
         while (true)
         {
-            if (Interlocked.CompareExchange(ref this.globalLockState, 1, this.globalLockState) != 0)
+            if (Interlocked.CompareExchange(ref this.globalLockState, 1, 0) != 0)
             {
                 lockWait.SpinOnce();
                 continue;
@@ -210,34 +267,61 @@ internal sealed class PrometheusCollectionManager
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ExecuteCollect(PrometheusProtocol protocol)
+    private CollectionResult ExecuteCollect(CollectionContext collectionContext)
     {
+        this.onCollectContext = collectionContext;
+        this.collectionExecutionResult = default;
         this.exporter.OnExport = this.onCollectRef;
 
         try
         {
-            this.exporter.Protocol = protocol;
-            return this.exporter.Collect!(Timeout.Infinite);
+            var succeeded = this.exporter.Collect!(Timeout.Infinite);
+            return this.CreateCollectionResult(collectionContext, succeeded, this.collectionExecutionResult);
         }
         finally
         {
             this.exporter.OnExport = null;
+            this.onCollectContext = null;
         }
     }
 
     private ExportResult OnCollect(in Batch<Metric> metrics)
     {
-        var protocol = this.exporter.Protocol;
-
-        if (!this.protocolStates.TryGetValue(protocol, out var state))
+        if (this.onCollectContext is not { } collectionContext)
         {
-            this.protocolStates[protocol] = state = new();
+            this.collectionExecutionResult = default;
+            return ExportResult.Failure;
         }
 
+        var protocols = collectionContext.FreezeProtocols();
+        HashSet<PrometheusProtocol>? successfulProtocols = null;
+
+        foreach (var protocol in protocols)
+        {
+            if (!this.protocolStates.TryGetValue(protocol, out var state))
+            {
+                this.protocolStates[protocol] = state = new();
+            }
+
+            if (this.TryWriteResponse(protocol, state, metrics))
+            {
+                successfulProtocols ??= [];
+                successfulProtocols.Add(protocol);
+            }
+        }
+
+        this.collectionExecutionResult = new CollectionExecutionResult(protocols, successfulProtocols);
+
+        return successfulProtocols is { Count: > 0 }
+            ? ExportResult.Success
+            : ExportResult.Failure;
+    }
+
+    private bool TryWriteResponse(PrometheusProtocol protocol, PrometheusProtocolState state, in Batch<Metric> metrics)
+    {
         try
         {
             var cursor = this.WriteTargetInfo(protocol, state);
-
             var metricStates = this.GetMetricStates(metrics, protocol.IsOpenMetrics);
 
             foreach (var metricState in metricStates)
@@ -288,7 +372,7 @@ internal sealed class PrometheusCollectionManager
 
             state.UpdateView(cursor);
 
-            return ExportResult.Success;
+            return true;
         }
         catch (Exception ex)
         {
@@ -296,8 +380,62 @@ internal sealed class PrometheusCollectionManager
 
             PrometheusExporterEventSource.Log.FailedExport(ex);
 
-            return ExportResult.Failure;
+            return false;
         }
+    }
+
+    private CollectionResult CreateCollectionResult(CollectionContext collectionContext, bool succeeded, CollectionExecutionResult executionResult)
+    {
+        var protocols = executionResult.Protocols ?? collectionContext.FreezeProtocols();
+        var responses = new Dictionary<PrometheusProtocol, CollectionResponse>(protocols.Length);
+
+        if (succeeded)
+        {
+            var generatedAt = this.UtcNow();
+            var generatedAtElapsed = this.GetElapsedTime();
+            var successfulProtocols = executionResult.SuccessfulProtocols;
+
+            foreach (var protocol in protocols)
+            {
+                if (successfulProtocols is not null &&
+                    !successfulProtocols.Contains(protocol))
+                {
+                    continue;
+                }
+
+                ArraySegment<byte> view;
+
+                if (this.protocolStates.TryGetValue(protocol, out var state))
+                {
+                    state.UpdateTimestamps(generatedAt, generatedAtElapsed);
+                    view = state.View;
+                }
+                else
+                {
+                    view = PrometheusProtocolState.EmptyView;
+                }
+
+                responses[protocol] = new CollectionResponse(view, generatedAt, fromCache: false);
+            }
+        }
+
+        return new CollectionResult(responses);
+    }
+
+    private bool TryGetCachedResponse(PrometheusProtocol protocol, out CollectionResponse response)
+    {
+        if (this.protocolStates.TryGetValue(protocol, out var state) &&
+            state.GeneratedAt is { } generatedAt &&
+            state.GeneratedAtElapsed is { } generatedAtElapsed &&
+            this.scrapeResponseCacheDuration > TimeSpan.Zero &&
+            this.GetElapsedTime() - generatedAtElapsed < this.scrapeResponseCacheDuration)
+        {
+            response = new CollectionResponse(state.View, generatedAt, fromCache: true);
+            return true;
+        }
+
+        response = default;
+        return false;
     }
 
     private int WriteTargetInfo(PrometheusProtocol protocol, PrometheusProtocolState state)
@@ -451,6 +589,27 @@ internal sealed class PrometheusCollectionManager
         public readonly bool FromCache { get; }
     }
 
+    private readonly struct CollectionResult
+    {
+        private readonly IReadOnlyDictionary<PrometheusProtocol, CollectionResponse>? responses;
+
+        public CollectionResult(IReadOnlyDictionary<PrometheusProtocol, CollectionResponse> responses)
+        {
+            this.responses = responses;
+        }
+
+        public bool TryGetResponse(PrometheusProtocol protocol, out CollectionResponse response)
+        {
+            if (this.responses?.TryGetValue(protocol, out response) == true)
+            {
+                return true;
+            }
+
+            response = default;
+            return false;
+        }
+    }
+
     private readonly struct MetricState
     {
         public MetricState(
@@ -518,16 +677,75 @@ internal sealed class PrometheusCollectionManager
         public readonly string? Unit { get; }
     }
 
+    private readonly struct CollectionExecutionResult
+    {
+        public CollectionExecutionResult(PrometheusProtocol[] protocols, HashSet<PrometheusProtocol>? successfulProtocols)
+        {
+            this.Protocols = protocols;
+            this.SuccessfulProtocols = successfulProtocols;
+        }
+
+        public PrometheusProtocol[] Protocols { get; }
+
+        public HashSet<PrometheusProtocol>? SuccessfulProtocols { get; }
+    }
+
+    private sealed class CollectionContext
+    {
+        private readonly Lock gate = new();
+        private readonly HashSet<PrometheusProtocol> protocols = [];
+        private readonly TaskCompletionSource<CollectionResult> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool frozen;
+
+        public CollectionContext(PrometheusProtocol protocol)
+        {
+            this.protocols.Add(protocol);
+        }
+
+        public Task<CollectionResult> Task => this.tcs.Task;
+
+        public PrometheusProtocol[] FreezeProtocols()
+        {
+            lock (this.gate)
+            {
+                this.frozen = true;
+                return [.. this.protocols];
+            }
+        }
+
+        public void SetResult(CollectionResult result)
+            => this.tcs.SetResult(result);
+
+        public bool TryRegisterProtocol(PrometheusProtocol protocol)
+        {
+            lock (this.gate)
+            {
+                if (this.protocols.Contains(protocol))
+                {
+                    return true;
+                }
+
+                if (this.frozen)
+                {
+                    return false;
+                }
+
+                this.protocols.Add(protocol);
+                return true;
+            }
+        }
+    }
+
     private sealed class PrometheusProtocolState
     {
-        private const int InitialBufferSize = 85_000; // Encourage the object to live in LOH (large object heap)
+        private const int InitialBufferSize = 85_000; // Encourage the object to live in Large Object Heap (LOH)
         private const int MaxBufferSize = 100 * 1024 * 1024; // 100 MB
 
         public static ArraySegment<byte> EmptyView { get; } =
 #if NET
             ArraySegment<byte>.Empty;
 #else
-            new([], 0, 0);
+            new([]);
 #endif
 
         public byte[] Buffer { get; private set; } = new byte[InitialBufferSize];

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -21,7 +21,6 @@ internal sealed class PrometheusCollectionManager
     private readonly Dictionary<Metric, PrometheusMetric> metricsCache;
     private int metricsCacheCount;
     private int globalLockState;
-    private int readerCount;
     private CollectionContext? collectionContext;
     private CollectionContext? onCollectContext;
     private CollectionExecutionResult collectionExecutionResult;
@@ -65,12 +64,21 @@ internal sealed class PrometheusCollectionManager
                 if (this.TryGetCachedResponse(protocol, out var response))
                 {
                     cachedResponse = response;
-                    Interlocked.Increment(ref this.readerCount);
+                    this.IncrementReaderCount(protocol);
                     break;
                 }
 
                 if (this.collectionContext is { } currentCollectionContext)
                 {
+                    pendingCollectionTask = currentCollectionContext.Task;
+                    joinedActiveCollection = currentCollectionContext.TryRegisterProtocol(protocol, this.HasActiveReaders(protocol));
+
+                    if (joinedActiveCollection)
+                    {
+                        this.IncrementReaderCount(protocol);
+                        break;
+                    }
+
                     if (currentCollectionContext.Task.IsCompleted)
                     {
                         if (ReferenceEquals(this.collectionContext, currentCollectionContext))
@@ -78,19 +86,12 @@ internal sealed class PrometheusCollectionManager
                             this.collectionContext = null;
                         }
 
+                        pendingCollectionTask = null;
                         retry = true;
                     }
                     else
                     {
-                    pendingCollectionTask = currentCollectionContext.Task;
-                    joinedActiveCollection = currentCollectionContext.TryRegisterProtocol(protocol);
-
-                    if (joinedActiveCollection)
-                    {
-                        Interlocked.Increment(ref this.readerCount);
-                    }
-
-                    break;
+                        break;
                     }
                 }
             }
@@ -104,7 +105,10 @@ internal sealed class PrometheusCollectionManager
                 continue;
             }
 
-            this.WaitForReadersToComplete();
+            if (this.WaitForReadersToComplete(protocol))
+            {
+                continue;
+            }
 
             this.EnterGlobalLock();
 
@@ -113,12 +117,21 @@ internal sealed class PrometheusCollectionManager
                 if (this.TryGetCachedResponse(protocol, out var response))
                 {
                     cachedResponse = response;
-                    Interlocked.Increment(ref this.readerCount);
+                    this.IncrementReaderCount(protocol);
                     break;
                 }
 
                 if (this.collectionContext is { } currentCollectionContext)
                 {
+                    pendingCollectionTask = currentCollectionContext.Task;
+                    joinedActiveCollection = currentCollectionContext.TryRegisterProtocol(protocol, this.HasActiveReaders(protocol));
+
+                    if (joinedActiveCollection)
+                    {
+                        this.IncrementReaderCount(protocol);
+                        break;
+                    }
+
                     if (currentCollectionContext.Task.IsCompleted)
                     {
                         if (ReferenceEquals(this.collectionContext, currentCollectionContext))
@@ -129,21 +142,13 @@ internal sealed class PrometheusCollectionManager
                         continue;
                     }
 
-                    pendingCollectionTask = currentCollectionContext.Task;
-                    joinedActiveCollection = currentCollectionContext.TryRegisterProtocol(protocol);
-
-                    if (joinedActiveCollection)
-                    {
-                        Interlocked.Increment(ref this.readerCount);
-                    }
-
                     break;
                 }
 
                 activeCollectionContext = new CollectionContext(protocol);
                 this.collectionContext = activeCollectionContext;
 
-                Interlocked.Increment(ref this.readerCount);
+                this.IncrementReaderCount(protocol);
                 break;
             }
             finally
@@ -205,8 +210,8 @@ internal sealed class PrometheusCollectionManager
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void ExitCollect()
-        => Interlocked.Decrement(ref this.readerCount);
+    public void ExitCollect(PrometheusProtocol protocol)
+        => this.GetProtocolState(protocol).DecrementReaderCount();
 
 #if NET
     private async ValueTask<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
@@ -224,7 +229,7 @@ internal sealed class PrometheusCollectionManager
 
         if (protocolWasRegistered)
         {
-            Interlocked.Decrement(ref this.readerCount);
+            this.ExitCollect(protocol);
         }
 
         return await this.EnterCollect(protocol).ConfigureAwait(false);
@@ -251,19 +256,45 @@ internal sealed class PrometheusCollectionManager
         => Interlocked.Exchange(ref this.globalLockState, 0);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void WaitForReadersToComplete()
+    private void IncrementReaderCount(PrometheusProtocol protocol)
+        => this.GetProtocolState(protocol).IncrementReaderCount();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool HasActiveReaders(PrometheusProtocol protocol)
+        => this.protocolStates.TryGetValue(protocol, out var state) && state.HasActiveReaders();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool WaitForReadersToComplete(PrometheusProtocol protocol)
     {
+        var state = this.GetProtocolState(protocol);
+        var didSpin = false;
         SpinWait readWait = default;
         while (true)
         {
-            if (Interlocked.CompareExchange(ref this.readerCount, 0, 0) != 0)
+            if (!state.HasActiveReaders())
             {
-                readWait.SpinOnce();
-                continue;
+                break;
             }
 
-            break;
+            this.EnterGlobalLock();
+
+            try
+            {
+                if (this.collectionContext is not null)
+                {
+                    return true;
+                }
+            }
+            finally
+            {
+                this.ExitGlobalLock();
+            }
+
+            didSpin = true;
+            readWait.SpinOnce();
         }
+
+        return didSpin;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -298,11 +329,7 @@ internal sealed class PrometheusCollectionManager
 
         foreach (var protocol in protocols)
         {
-            if (!this.protocolStates.TryGetValue(protocol, out var state))
-            {
-                this.protocolStates[protocol] = state = new();
-            }
-
+            var state = this.GetProtocolState(protocol);
             if (this.TryWriteResponse(protocol, state, metrics))
             {
                 successfulProtocols ??= [];
@@ -437,6 +464,10 @@ internal sealed class PrometheusCollectionManager
         response = default;
         return false;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private PrometheusProtocolState GetProtocolState(PrometheusProtocol protocol)
+        => this.protocolStates.GetOrAdd(protocol, static _ => new());
 
     private int WriteTargetInfo(PrometheusProtocol protocol, PrometheusProtocolState state)
     {
@@ -716,7 +747,7 @@ internal sealed class PrometheusCollectionManager
         public void SetResult(CollectionResult result)
             => this.tcs.SetResult(result);
 
-        public bool TryRegisterProtocol(PrometheusProtocol protocol)
+        public bool TryRegisterProtocol(PrometheusProtocol protocol, bool hasActiveReaders)
         {
             lock (this.gate)
             {
@@ -726,6 +757,11 @@ internal sealed class PrometheusCollectionManager
                 }
 
                 if (this.frozen)
+                {
+                    return false;
+                }
+
+                if (hasActiveReaders)
                 {
                     return false;
                 }
@@ -741,6 +777,8 @@ internal sealed class PrometheusCollectionManager
         private const int InitialBufferSize = 85_000; // Encourage the object to live in Large Object Heap (LOH)
         private const int MaxBufferSize = 100 * 1024 * 1024; // 100 MB
 
+        private int readerCount;
+
         public static ArraySegment<byte> EmptyView { get; } =
 #if NET
             ArraySegment<byte>.Empty;
@@ -755,6 +793,15 @@ internal sealed class PrometheusCollectionManager
         public DateTime? GeneratedAt { get; private set; }
 
         public TimeSpan? GeneratedAtElapsed { get; private set; }
+
+        public int DecrementReaderCount()
+            => Interlocked.Decrement(ref this.readerCount);
+
+        public bool HasActiveReaders()
+            => Interlocked.CompareExchange(ref this.readerCount, 0, 0) != 0;
+
+        public void IncrementReaderCount()
+            => Interlocked.Increment(ref this.readerCount);
 
         public bool TryExpandBuffer()
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -23,6 +23,7 @@ internal sealed class PrometheusCollectionManager
     private int globalLockState;
     private int readerCount;
     private bool collectionRunning;
+    private PrometheusProtocol collectionProtocol;
     private TaskCompletionSource<CollectionResponse>? collectionTcs;
 
     public PrometheusCollectionManager(PrometheusExporter exporter)
@@ -44,6 +45,10 @@ internal sealed class PrometheusCollectionManager
     public Task<CollectionResponse> EnterCollect(PrometheusProtocol protocol)
 #endif
     {
+        CollectionResponse? cachedResponse = null;
+        Task<CollectionResponse>? pendingCollectionTask = null;
+        var incrementReaderCount = false;
+
         this.EnterGlobalLock();
 
         try
@@ -55,36 +60,56 @@ internal sealed class PrometheusCollectionManager
                 this.scrapeResponseCacheDuration > TimeSpan.Zero &&
                 this.GetElapsedTime() - state.GeneratedAtElapsed < this.scrapeResponseCacheDuration)
             {
-                var collectionResponse = new CollectionResponse(state.View, generatedAt, fromCache: true);
-
-#if NET
-                return new ValueTask<CollectionResponse>(collectionResponse);
-#else
-                return Task.FromResult(collectionResponse);
-#endif
+                cachedResponse = new CollectionResponse(state.View, generatedAt, fromCache: true);
+                incrementReaderCount = true;
             }
-
-            // If a collection is already running, return a task to wait on the result.
-            if (this.collectionRunning)
+            else if (this.collectionRunning)
             {
                 this.collectionTcs ??= new TaskCompletionSource<CollectionResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-#if NET
-                return new ValueTask<CollectionResponse>(this.collectionTcs.Task);
-#else
-                return this.collectionTcs.Task;
-#endif
+                pendingCollectionTask = this.collectionTcs.Task;
+                incrementReaderCount = this.collectionProtocol.Equals(protocol);
             }
+            else
+            {
+                this.WaitForReadersToComplete();
 
-            this.WaitForReadersToComplete();
-
-            // Start a collection on the current thread.
-            this.collectionRunning = true;
+                // Start a collection on the current thread.
+                this.collectionRunning = true;
+                this.collectionProtocol = protocol;
+                incrementReaderCount = true;
+            }
         }
         finally
         {
-            Interlocked.Increment(ref this.readerCount);
+            if (incrementReaderCount)
+            {
+                Interlocked.Increment(ref this.readerCount);
+            }
+
             this.ExitGlobalLock();
+        }
+
+        if (cachedResponse is { } collectionResponse)
+        {
+#if NET
+            return new ValueTask<CollectionResponse>(collectionResponse);
+#else
+            return Task.FromResult(collectionResponse);
+#endif
+        }
+
+        if (pendingCollectionTask is not null)
+        {
+            if (incrementReaderCount)
+            {
+#if NET
+                return new ValueTask<CollectionResponse>(pendingCollectionTask);
+#else
+                return pendingCollectionTask;
+#endif
+            }
+
+            return this.WaitForRunningCollectionAndRetryAsync(protocol, pendingCollectionTask);
         }
 
         CollectionResponse response;
@@ -137,6 +162,16 @@ internal sealed class PrometheusCollectionManager
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ExitCollect()
         => Interlocked.Decrement(ref this.readerCount);
+
+#if NET
+    private async ValueTask<CollectionResponse> WaitForRunningCollectionAndRetryAsync(PrometheusProtocol protocol, Task<CollectionResponse> pendingCollectionTask)
+#else
+    private async Task<CollectionResponse> WaitForRunningCollectionAndRetryAsync(PrometheusProtocol protocol, Task<CollectionResponse> pendingCollectionTask)
+#endif
+    {
+        await pendingCollectionTask.ConfigureAwait(false);
+        return await this.EnterCollect(protocol).ConfigureAwait(false);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnterGlobalLock()

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Metrics;
@@ -11,10 +12,7 @@ internal sealed class PrometheusCollectionManager
 {
     private const int MaxCachedMetrics = 1024;
 
-    private readonly Dictionary<PrometheusProtocol, byte[]> buffers = [];
-    private readonly Dictionary<PrometheusProtocol, ArraySegment<byte>> previousViews = [];
-    private readonly Dictionary<PrometheusProtocol, DateTime> previouslyGeneratedAtUtc = [];
-    private readonly Dictionary<PrometheusProtocol, TimeSpan> previouslyGeneratedAtElapsed = [];
+    private readonly ConcurrentDictionary<PrometheusProtocol, PrometheusProtocolState> protocolStates = new();
 
     private readonly PrometheusExporter exporter;
     private readonly TimeSpan scrapeResponseCacheDuration;
@@ -22,8 +20,6 @@ internal sealed class PrometheusCollectionManager
     private readonly PrometheusExporter.ExportFunc onCollectRef;
     private readonly Dictionary<Metric, PrometheusMetric> metricsCache;
     private int metricsCacheCount;
-    private int plainTextTargetInfoBufferLength = -1;
-    private int openMetricsTargetInfoBufferLength = -1;
     private int globalLockState;
     private int readerCount;
     private bool collectionRunning;
@@ -54,13 +50,12 @@ internal sealed class PrometheusCollectionManager
         {
             // If we are within {ScrapeResponseCacheDurationMilliseconds} of the
             // last successful collect, return the previous view.
-            if (this.previouslyGeneratedAtUtc.TryGetValue(protocol, out var timestamp) &&
-                this.previouslyGeneratedAtElapsed.TryGetValue(protocol, out var elapsed) &&
+            if (this.protocolStates.TryGetValue(protocol, out var state) &&
+                state.GeneratedAt is { } generatedAt &&
                 this.scrapeResponseCacheDuration > TimeSpan.Zero &&
-                this.GetElapsedTime() - elapsed < this.scrapeResponseCacheDuration)
+                this.GetElapsedTime() - state.GeneratedAtElapsed < this.scrapeResponseCacheDuration)
             {
-                var view = this.previousViews[protocol];
-                var collectionResponse = new CollectionResponse(view, timestamp, fromCache: true);
+                var collectionResponse = new CollectionResponse(state.View, generatedAt, fromCache: true);
 
 #if NET
                 return new ValueTask<CollectionResponse>(collectionResponse);
@@ -85,9 +80,6 @@ internal sealed class PrometheusCollectionManager
 
             // Start a collection on the current thread.
             this.collectionRunning = true;
-
-            this.previouslyGeneratedAtUtc.Remove(protocol);
-            this.previouslyGeneratedAtElapsed.Remove(protocol);
         }
         finally
         {
@@ -103,16 +95,16 @@ internal sealed class PrometheusCollectionManager
             var generatedAt = this.UtcNow();
             var generatedAtElapsed = this.GetElapsedTime();
 
-            this.previouslyGeneratedAtUtc[protocol] = generatedAt;
-            this.previouslyGeneratedAtElapsed[protocol] = generatedAtElapsed;
+            ArraySegment<byte> view;
 
-            if (!this.previousViews.TryGetValue(protocol, out var view))
+            if (this.protocolStates.TryGetValue(protocol, out var state))
             {
-#if NET
-                view = ArraySegment<byte>.Empty;
-#else
-                view = new ArraySegment<byte>([], 0, 0);
-#endif
+                state.UpdateTimestamps(generatedAt, generatedAtElapsed);
+                view = state.View;
+            }
+            else
+            {
+                view = PrometheusProtocolState.EmptyView;
             }
 
             response = new CollectionResponse(view, generatedAt, fromCache: false);
@@ -145,22 +137,6 @@ internal sealed class PrometheusCollectionManager
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ExitCollect()
         => Interlocked.Decrement(ref this.readerCount);
-
-    private static bool IncreaseBufferSize(ref byte[] buffer)
-    {
-        var newBufferSize = buffer.Length * 2;
-
-        if (newBufferSize > 100 * 1024 * 1024)
-        {
-            return false;
-        }
-
-        var newBuffer = new byte[newBufferSize];
-        buffer.CopyTo(newBuffer, 0);
-        buffer = newBuffer;
-
-        return true;
-    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnterGlobalLock()
@@ -216,19 +192,16 @@ internal sealed class PrometheusCollectionManager
 
     private ExportResult OnCollect(in Batch<Metric> metrics)
     {
-        const int InitialBufferSize = 85_000; // Encourage the object to live in LOH (large object heap)
-
-        var cursor = 0;
         var protocol = this.exporter.Protocol;
 
-        if (!this.buffers.TryGetValue(protocol, out var buffer))
+        if (!this.protocolStates.TryGetValue(protocol, out var state))
         {
-            this.buffers[protocol] = buffer = new byte[InitialBufferSize];
+            this.protocolStates[protocol] = state = new();
         }
 
         try
         {
-            cursor = this.WriteTargetInfo(protocol, ref buffer);
+            var cursor = this.WriteTargetInfo(protocol, state);
 
             var metricStates = this.GetMetricStates(metrics, protocol.IsOpenMetrics);
 
@@ -239,7 +212,7 @@ internal sealed class PrometheusCollectionManager
                     try
                     {
                         cursor = PrometheusSerializer.WriteMetric(
-                            buffer,
+                            state.Buffer,
                             cursor,
                             metricState.Metric,
                             metricState.PrometheusMetric,
@@ -254,7 +227,7 @@ internal sealed class PrometheusCollectionManager
                     }
                     catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                     {
-                        if (!IncreaseBufferSize(ref buffer))
+                        if (!state.TryExpandBuffer())
                         {
                             throw;
                         }
@@ -266,29 +239,25 @@ internal sealed class PrometheusCollectionManager
             {
                 try
                 {
-                    cursor = PrometheusSerializer.WriteEof(buffer, cursor);
+                    cursor = PrometheusSerializer.WriteEof(state.Buffer, cursor);
                     break;
                 }
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                 {
-                    if (!IncreaseBufferSize(ref buffer))
+                    if (!state.TryExpandBuffer())
                     {
                         throw;
                     }
                 }
             }
 
-            this.previousViews[protocol] = new ArraySegment<byte>(buffer, 0, cursor);
+            state.UpdateView(cursor);
 
             return ExportResult.Success;
         }
         catch (Exception ex)
         {
-#if NET
-            this.previousViews[protocol] = ArraySegment<byte>.Empty;
-#else
-            this.previousViews[protocol] = new ArraySegment<byte>([], 0, 0);
-#endif
+            state.ResetView();
 
             PrometheusExporterEventSource.Log.FailedExport(ex);
 
@@ -296,32 +265,22 @@ internal sealed class PrometheusCollectionManager
         }
     }
 
-    private int WriteTargetInfo(PrometheusProtocol protocol, ref byte[] buffer)
+    private int WriteTargetInfo(PrometheusProtocol protocol, PrometheusProtocolState state)
     {
-        ref var targetInfoBufferLength = ref protocol.IsOpenMetrics
-            ? ref this.openMetricsTargetInfoBufferLength
-            : ref this.plainTextTargetInfoBufferLength;
-
-        if (targetInfoBufferLength < 0)
+        while (true)
         {
-            while (true)
+            try
             {
-                try
+                return PrometheusSerializer.WriteTargetInfo(state.Buffer, 0, this.exporter.Resource, protocol.IsOpenMetrics);
+            }
+            catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
+            {
+                if (!state.TryExpandBuffer())
                 {
-                    targetInfoBufferLength = PrometheusSerializer.WriteTargetInfo(buffer, 0, this.exporter.Resource, protocol.IsOpenMetrics);
-                    break;
-                }
-                catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
-                {
-                    if (!IncreaseBufferSize(ref buffer))
-                    {
-                        throw;
-                    }
+                    throw;
                 }
             }
         }
-
-        return targetInfoBufferLength;
     }
 
     private PrometheusMetric GetPrometheusMetric(Metric metric)
@@ -522,5 +481,53 @@ internal sealed class PrometheusCollectionManager
         public readonly string? Help { get; }
 
         public readonly string? Unit { get; }
+    }
+
+    private sealed class PrometheusProtocolState
+    {
+        private const int InitialBufferSize = 85_000; // Encourage the object to live in LOH (large object heap)
+        private const int MaxBufferSize = 100 * 1024 * 1024; // 100 MB
+
+        public static ArraySegment<byte> EmptyView { get; } =
+#if NET
+            ArraySegment<byte>.Empty;
+#else
+            new([], 0, 0);
+#endif
+
+        public byte[] Buffer { get; private set; } = new byte[InitialBufferSize];
+
+        public ArraySegment<byte> View { get; private set; } = EmptyView;
+
+        public DateTime? GeneratedAt { get; private set; }
+
+        public TimeSpan? GeneratedAtElapsed { get; private set; }
+
+        public bool TryExpandBuffer()
+        {
+            var newBufferSize = this.Buffer.Length * 2;
+
+            if (newBufferSize > MaxBufferSize)
+            {
+                return false;
+            }
+
+            var expanded = new byte[newBufferSize];
+            this.Buffer.CopyTo(expanded, 0);
+            this.Buffer = expanded;
+
+            return true;
+        }
+
+        public void ResetView() => this.View = EmptyView;
+
+        public void UpdateView(int cursor)
+            => this.View = new ArraySegment<byte>(this.Buffer, 0, cursor);
+
+        public void UpdateTimestamps(DateTime timestamp, TimeSpan elapsed)
+        {
+            this.GeneratedAt = timestamp;
+            this.GeneratedAtElapsed = elapsed;
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -11,23 +11,20 @@ internal sealed class PrometheusCollectionManager
 {
     private const int MaxCachedMetrics = 1024;
 
+    private readonly Dictionary<PrometheusProtocol, byte[]> buffers = [];
+    private readonly Dictionary<PrometheusProtocol, ArraySegment<byte>> previousViews = [];
+    private readonly Dictionary<PrometheusProtocol, DateTime> previouslyGeneratedAtUtc = [];
+    private readonly Dictionary<PrometheusProtocol, TimeSpan> previouslyGeneratedAtElapsed = [];
+
     private readonly PrometheusExporter exporter;
     private readonly TimeSpan scrapeResponseCacheDuration;
     private readonly long baseTimestamp = Stopwatch.GetTimestamp();
     private readonly PrometheusExporter.ExportFunc onCollectRef;
     private readonly Dictionary<Metric, PrometheusMetric> metricsCache;
     private int metricsCacheCount;
-    private byte[] plainTextBuffer = new byte[85000]; // encourage the object to live in LOH (large object heap)
-    private byte[] openMetricsBuffer = new byte[85000]; // encourage the object to live in LOH (large object heap)
     private int plainTextTargetInfoBufferLength = -1;
     private int openMetricsTargetInfoBufferLength = -1;
-    private ArraySegment<byte> previousPlainTextDataView;
-    private ArraySegment<byte> previousOpenMetricsDataView;
     private int globalLockState;
-    private DateTime? previousPlainTextDataViewGeneratedAtUtc;
-    private DateTime? previousOpenMetricsDataViewGeneratedAtUtc;
-    private TimeSpan previousPlainTextDataViewGeneratedAtElapsed;
-    private TimeSpan previousOpenMetricsDataViewGeneratedAtElapsed;
     private int readerCount;
     private bool collectionRunning;
     private TaskCompletionSource<CollectionResponse>? collectionTcs;
@@ -46,33 +43,29 @@ internal sealed class PrometheusCollectionManager
     internal Func<TimeSpan> GetElapsedTime { get; set; }
 
 #if NET
-    public ValueTask<CollectionResponse> EnterCollect(bool openMetricsRequested)
+    public ValueTask<CollectionResponse> EnterCollect(PrometheusProtocol protocol)
 #else
-    public Task<CollectionResponse> EnterCollect(bool openMetricsRequested)
+    public Task<CollectionResponse> EnterCollect(PrometheusProtocol protocol)
 #endif
     {
         this.EnterGlobalLock();
 
-        DateTime? previousDataViewGeneratedAtUtc;
-
         try
         {
-            previousDataViewGeneratedAtUtc = openMetricsRequested
-                ? this.previousOpenMetricsDataViewGeneratedAtUtc
-                : this.previousPlainTextDataViewGeneratedAtUtc;
-
-            var previousDataViewGeneratedAtElapsed = openMetricsRequested
-                ? this.previousOpenMetricsDataViewGeneratedAtElapsed
-                : this.previousPlainTextDataViewGeneratedAtElapsed;
-
-            if (previousDataViewGeneratedAtUtc.HasValue
-                && this.scrapeResponseCacheDuration > TimeSpan.Zero
-                && this.GetElapsedTime() - previousDataViewGeneratedAtElapsed < this.scrapeResponseCacheDuration)
+            // If we are within {ScrapeResponseCacheDurationMilliseconds} of the
+            // last successful collect, return the previous view.
+            if (this.previouslyGeneratedAtUtc.TryGetValue(protocol, out var timestamp) &&
+                this.previouslyGeneratedAtElapsed.TryGetValue(protocol, out var elapsed) &&
+                this.scrapeResponseCacheDuration > TimeSpan.Zero &&
+                this.GetElapsedTime() - elapsed < this.scrapeResponseCacheDuration)
             {
+                var view = this.previousViews[protocol];
+                var collectionResponse = new CollectionResponse(view, timestamp, fromCache: true);
+
 #if NET
-                return new ValueTask<CollectionResponse>(new CollectionResponse(this.previousOpenMetricsDataView, this.previousPlainTextDataView, previousDataViewGeneratedAtUtc.Value, fromCache: true));
+                return new ValueTask<CollectionResponse>(collectionResponse);
 #else
-                return Task.FromResult(new CollectionResponse(this.previousOpenMetricsDataView, this.previousPlainTextDataView, previousDataViewGeneratedAtUtc.Value, fromCache: true));
+                return Task.FromResult(collectionResponse);
 #endif
             }
 
@@ -93,14 +86,8 @@ internal sealed class PrometheusCollectionManager
             // Start a collection on the current thread.
             this.collectionRunning = true;
 
-            if (openMetricsRequested)
-            {
-                this.previousOpenMetricsDataViewGeneratedAtUtc = null;
-            }
-            else
-            {
-                this.previousPlainTextDataViewGeneratedAtUtc = null;
-            }
+            this.previouslyGeneratedAtUtc.Remove(protocol);
+            this.previouslyGeneratedAtElapsed.Remove(protocol);
         }
         finally
         {
@@ -109,28 +96,26 @@ internal sealed class PrometheusCollectionManager
         }
 
         CollectionResponse response;
-        var result = this.ExecuteCollect(openMetricsRequested);
+        var result = this.ExecuteCollect(protocol);
+
         if (result)
         {
             var generatedAt = this.UtcNow();
             var generatedAtElapsed = this.GetElapsedTime();
 
-            if (openMetricsRequested)
+            this.previouslyGeneratedAtUtc[protocol] = generatedAt;
+            this.previouslyGeneratedAtElapsed[protocol] = generatedAtElapsed;
+
+            if (!this.previousViews.TryGetValue(protocol, out var view))
             {
-                this.previousOpenMetricsDataViewGeneratedAtUtc = generatedAt;
-                this.previousOpenMetricsDataViewGeneratedAtElapsed = generatedAtElapsed;
-            }
-            else
-            {
-                this.previousPlainTextDataViewGeneratedAtUtc = generatedAt;
-                this.previousPlainTextDataViewGeneratedAtElapsed = generatedAtElapsed;
+#if NET
+                view = ArraySegment<byte>.Empty;
+#else
+                view = new ArraySegment<byte>([], 0, 0);
+#endif
             }
 
-            previousDataViewGeneratedAtUtc = openMetricsRequested
-                ? this.previousOpenMetricsDataViewGeneratedAtUtc
-                : this.previousPlainTextDataViewGeneratedAtUtc;
-
-            response = new CollectionResponse(this.previousOpenMetricsDataView, this.previousPlainTextDataView, previousDataViewGeneratedAtUtc!.Value, fromCache: false);
+            response = new CollectionResponse(view, generatedAt, fromCache: false);
         }
         else
         {
@@ -214,13 +199,13 @@ internal sealed class PrometheusCollectionManager
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ExecuteCollect(bool openMetricsRequested)
+    private bool ExecuteCollect(PrometheusProtocol protocol)
     {
         this.exporter.OnExport = this.onCollectRef;
-        this.exporter.OpenMetricsRequested = openMetricsRequested;
 
         try
         {
+            this.exporter.Protocol = protocol;
             return this.exporter.Collect!(Timeout.Infinite);
         }
         finally
@@ -231,13 +216,21 @@ internal sealed class PrometheusCollectionManager
 
     private ExportResult OnCollect(in Batch<Metric> metrics)
     {
+        const int InitialBufferSize = 85_000; // Encourage the object to live in LOH (large object heap)
+
         var cursor = 0;
-        ref var buffer = ref (this.exporter.OpenMetricsRequested ? ref this.openMetricsBuffer : ref this.plainTextBuffer);
+        var protocol = this.exporter.Protocol;
+
+        if (!this.buffers.TryGetValue(protocol, out var buffer))
+        {
+            this.buffers[protocol] = buffer = new byte[InitialBufferSize];
+        }
+
         try
         {
-            cursor = this.WriteTargetInfo(ref buffer);
+            cursor = this.WriteTargetInfo(protocol, ref buffer);
 
-            var metricStates = this.GetMetricStates(metrics, this.exporter.OpenMetricsRequested);
+            var metricStates = this.GetMetricStates(metrics, protocol.IsOpenMetrics);
 
             foreach (var metricState in metricStates)
             {
@@ -250,7 +243,7 @@ internal sealed class PrometheusCollectionManager
                             cursor,
                             metricState.Metric,
                             metricState.PrometheusMetric,
-                            this.exporter.OpenMetricsRequested,
+                            protocol.IsOpenMetrics,
                             metricState.WriteType,
                             metricState.WriteUnit,
                             metricState.WriteHelp,
@@ -285,27 +278,17 @@ internal sealed class PrometheusCollectionManager
                 }
             }
 
-            if (this.exporter.OpenMetricsRequested)
-            {
-                this.previousOpenMetricsDataView = new ArraySegment<byte>(buffer, 0, cursor);
-            }
-            else
-            {
-                this.previousPlainTextDataView = new ArraySegment<byte>(buffer, 0, cursor);
-            }
+            this.previousViews[protocol] = new ArraySegment<byte>(buffer, 0, cursor);
 
             return ExportResult.Success;
         }
         catch (Exception ex)
         {
-            if (this.exporter.OpenMetricsRequested)
-            {
-                this.previousOpenMetricsDataView = new ArraySegment<byte>([], 0, 0);
-            }
-            else
-            {
-                this.previousPlainTextDataView = new ArraySegment<byte>([], 0, 0);
-            }
+#if NET
+            this.previousViews[protocol] = ArraySegment<byte>.Empty;
+#else
+            this.previousViews[protocol] = new ArraySegment<byte>([], 0, 0);
+#endif
 
             PrometheusExporterEventSource.Log.FailedExport(ex);
 
@@ -313,9 +296,9 @@ internal sealed class PrometheusCollectionManager
         }
     }
 
-    private int WriteTargetInfo(ref byte[] buffer)
+    private int WriteTargetInfo(PrometheusProtocol protocol, ref byte[] buffer)
     {
-        ref var targetInfoBufferLength = ref this.exporter.OpenMetricsRequested
+        ref var targetInfoBufferLength = ref protocol.IsOpenMetrics
             ? ref this.openMetricsTargetInfoBufferLength
             : ref this.plainTextTargetInfoBufferLength;
 
@@ -325,7 +308,7 @@ internal sealed class PrometheusCollectionManager
             {
                 try
                 {
-                    targetInfoBufferLength = PrometheusSerializer.WriteTargetInfo(buffer, 0, this.exporter.Resource, this.exporter.OpenMetricsRequested);
+                    targetInfoBufferLength = PrometheusSerializer.WriteTargetInfo(buffer, 0, this.exporter.Resource, protocol.IsOpenMetrics);
                     break;
                 }
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
@@ -460,17 +443,14 @@ internal sealed class PrometheusCollectionManager
 
     public readonly struct CollectionResponse
     {
-        public CollectionResponse(ArraySegment<byte> openMetricsView, ArraySegment<byte> plainTextView, DateTime generatedAtUtc, bool fromCache)
+        public CollectionResponse(ArraySegment<byte> view, DateTime generatedAtUtc, bool fromCache)
         {
-            this.OpenMetricsView = openMetricsView;
-            this.PlainTextView = plainTextView;
+            this.View = view;
             this.GeneratedAtUtc = generatedAtUtc;
             this.FromCache = fromCache;
         }
 
-        public readonly ArraySegment<byte> OpenMetricsView { get; }
-
-        public readonly ArraySegment<byte> PlainTextView { get; }
+        public readonly ArraySegment<byte> View { get; }
 
         public readonly DateTime GeneratedAtUtc { get; }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
@@ -46,7 +46,7 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
 
     internal bool DisableTotalNameSuffixForCounters { get; }
 
-    internal bool OpenMetricsRequested { get; set; }
+    internal PrometheusProtocol Protocol { get; set; }
 
     internal Resource Resource
     {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
@@ -46,8 +46,6 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
 
     internal bool DisableTotalNameSuffixForCounters { get; }
 
-    internal PrometheusProtocol Protocol { get; set; }
-
     internal Resource Resource
     {
         get => field ??= this.ParentProvider.GetResource();

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusProtocol.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusProtocol.cs
@@ -1,6 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if DEBUG
+using System.Diagnostics;
+#endif
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 #if NET8_0_OR_GREATER
@@ -13,7 +17,7 @@ using SupportedVersions = System.Collections.Generic.HashSet<System.Version>;
 
 namespace OpenTelemetry.Exporter.Prometheus;
 
-internal readonly struct PrometheusProtocol
+internal readonly struct PrometheusProtocol : IEquatable<PrometheusProtocol>
 {
     public const string AllowUtf8Escaping = "allow-utf-8";
     public const string UnderscoresEscaping = "underscores";
@@ -21,12 +25,12 @@ internal readonly struct PrometheusProtocol
     public const string OpenMetricsMediaType = "application/openmetrics-text";
     public const string PrometheusTextMediaType = "text/plain";
 
-    public static readonly Version PrometheusVersion0 = new(0, 0, 4);
-    public static readonly Version PrometheusVersion1 = new(1, 0, 0);
+    public static readonly Version PrometheusV0 = new(0, 0, 4);
+    public static readonly Version PrometheusV1 = new(1, 0, 0);
     public static readonly Version OpenMetricsV0 = new(0, 0, 1);
     public static readonly Version OpenMetricsV1 = new(1, 0, 0);
 
-    public static readonly PrometheusProtocol Fallback = new(PrometheusTextMediaType, null, PrometheusVersion0, false);
+    public static readonly PrometheusProtocol Fallback = new(PrometheusTextMediaType, null, PrometheusV0, false);
 
     // TODO Support other escaping schemes, including at least "allow-utf-8".
     // See https://github.com/open-telemetry/opentelemetry-dotnet/issues/7246.
@@ -43,8 +47,8 @@ internal readonly struct PrometheusProtocol
 
     internal static readonly SupportedVersions SupportedPrometheusVersions =
     [
-        PrometheusVersion0,
-        PrometheusVersion1,
+        PrometheusV0,
+        PrometheusV1,
     ];
 
     public PrometheusProtocol(string mediaType, string? escaping, Version version, bool isOpenMetrics)
@@ -78,5 +82,42 @@ internal readonly struct PrometheusProtocol
         }
 
         return builder.ToString();
+    }
+
+    public bool Equals(PrometheusProtocol other)
+        => this.IsOpenMetrics == other.IsOpenMetrics &&
+           this.MediaType == other.MediaType &&
+           this.Escaping == other.Escaping &&
+           this.Version == other.Version;
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is PrometheusProtocol other && this.Equals(other);
+
+    public override int GetHashCode()
+    {
+#if NET
+        return HashCode.Combine(this.MediaType, this.Escaping, this.IsOpenMetrics, this.Version);
+#else
+        var hashCode = this.MediaType.GetHashCode();
+
+        hashCode = (hashCode * 397) ^ (this.Escaping?.GetHashCode() ?? 0);
+        hashCode = (hashCode * 397) ^ this.IsOpenMetrics.GetHashCode();
+        hashCode = (hashCode * 397) ^ this.Version.GetHashCode();
+
+        return hashCode;
+#endif
+    }
+
+    public override string ToString() => GetContentType(this);
+
+    [Conditional("DEBUG")]
+    public void Validate()
+    {
+        // The values used to create a PrometheusProtocol should all be known and fixed values, not arbitrary values.
+        // Otherwise the number of different buffers used to write metrics to could be unbounded, which could lead to
+        // excessive memory usage when used to key the buffer dictionaries used in PrometheusCollectionManager.
+        Debug.Assert(this.MediaType is OpenMetricsMediaType or PrometheusTextMediaType, "The specified media type is not a known value.");
+        Debug.Assert(this.Escaping is null || SupportedEscapingSchemes.Contains(this.Escaping), "The specified escaping is not a known value.");
+        Debug.Assert(SupportedOpenMetricsVersions.Contains(this.Version) || SupportedPrometheusVersions.Contains(this.Version), "The specified version is not a known value.");
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusProtocol.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusProtocol.cs
@@ -1,9 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if DEBUG
 using System.Diagnostics;
-#endif
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -269,7 +269,7 @@ internal sealed class PrometheusHttpListener : IDisposable
 
             var protocol = Negotiate(context.Request);
 
-            var collectionResponse = await this.exporter.CollectionManager.EnterCollect(protocol.IsOpenMetrics).ConfigureAwait(false);
+            var collectionResponse = await this.exporter.CollectionManager.EnterCollect(protocol).ConfigureAwait(false);
 
             try
             {
@@ -277,7 +277,7 @@ internal sealed class PrometheusHttpListener : IDisposable
 
                 context.Response.Headers.Add("Server", string.Empty);
 
-                var dataView = protocol.IsOpenMetrics ? collectionResponse.OpenMetricsView : collectionResponse.PlainTextView;
+                var dataView = collectionResponse.View;
 
                 if (dataView.Count > 0)
                 {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -310,7 +310,7 @@ internal sealed class PrometheusHttpListener : IDisposable
             }
             finally
             {
-                this.exporter.CollectionManager.ExitCollect();
+                this.exporter.CollectionManager.ExitCollect(protocol);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Shared/Shims/Lock.cs
+++ b/src/Shared/Shims/Lock.cs
@@ -12,7 +12,5 @@ namespace OpenTelemetry;
 // sees it used. It is in OpenTelemetry namespace and not OpenTelemetry.Internal
 // namespace so that code should be able to use it without the presence of a
 // dedicated "using OpenTelemetry.Internal" just for the shim.
-internal sealed class Lock
-{
-}
+internal sealed class Lock;
 #endif

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Prometheus.HttpListener.Tests\PrometheusCollection.cs" Link="Includes\PrometheusCollection.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Prometheus.HttpListener.Tests\PrometheusCollectionManagerTests.cs" Link="Includes\PrometheusCollectionManagerTests.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Prometheus.HttpListener.Tests\PrometheusFixture.cs" Link="Includes\PrometheusFixture.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Prometheus.HttpListener.Tests\PrometheusProtocolTests.cs" Link="Includes\PrometheusProtocolTests.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Prometheus.HttpListener.Tests\PrometheusSerializerTests.cs" Link="Includes\PrometheusSerializerTests.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Prometheus.HttpListener.Tests\PromToolCollection.cs" Link="Includes\PromToolCollection.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Exporter.Prometheus.HttpListener.Tests\PromToolFixture.cs" Link="Includes\PromToolFixture.cs" />

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -353,11 +353,14 @@ public sealed class PrometheusCollectionManagerTests
 
         await firstCollectStarted.Task;
 
+#pragma warning disable CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
         var secondCollectTask = Task.Run(async () =>
         {
+            var collectTask = EnterCollectAsync(exporter, secondProtocol);
             secondCollectStarted.SetResult(true);
-            return await EnterCollectAsync(exporter, secondProtocol);
+            return await collectTask;
         });
+#pragma warning restore CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
 
         await secondCollectStarted.Task;
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -91,7 +91,7 @@ public sealed class PrometheusCollectionManagerTests
             }
             finally
             {
-                exporter.CollectionManager.ExitCollect();
+                exporter.CollectionManager.ExitCollect(protocol);
             }
         }
 
@@ -151,10 +151,9 @@ public sealed class PrometheusCollectionManagerTests
 
         counter.Add(100);
 
+        var protocol = GetProtocol(openMetricsRequested);
         try
         {
-            var protocol = GetProtocol(openMetricsRequested);
-
             // This should use the cache and ignore the second counter update.
             var task = exporter.CollectionManager.EnterCollect(protocol);
 
@@ -176,7 +175,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
 
         if (cacheEnabled)
@@ -259,7 +258,7 @@ public sealed class PrometheusCollectionManagerTests
                 }
                 finally
                 {
-                    exporter.CollectionManager.ExitCollect();
+                    exporter.CollectionManager.ExitCollect(protocol);
                 }
             });
 
@@ -276,7 +275,7 @@ public sealed class PrometheusCollectionManagerTests
 
             Assert.Equal(1, collectCount);
 
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
             firstCollectExited = true;
 
             var secondTimeout = TimeSpan.FromSeconds(5);
@@ -297,7 +296,7 @@ public sealed class PrometheusCollectionManagerTests
         {
             if (!firstCollectExited)
             {
-                exporter.CollectionManager.ExitCollect();
+                exporter.CollectionManager.ExitCollect(protocol);
             }
         }
     }
@@ -398,8 +397,8 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(firstProtocol);
+            exporter.CollectionManager.ExitCollect(secondProtocol);
         }
     }
 
@@ -454,7 +453,7 @@ public sealed class PrometheusCollectionManagerTests
             }
             finally
             {
-                exporter.CollectionManager.ExitCollect();
+                exporter.CollectionManager.ExitCollect(protocol);
             }
         });
 
@@ -469,7 +468,7 @@ public sealed class PrometheusCollectionManagerTests
             }
             finally
             {
-                exporter.CollectionManager.ExitCollect();
+                exporter.CollectionManager.ExitCollect(protocol);
             }
         });
 
@@ -527,7 +526,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 
@@ -567,7 +566,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 
@@ -608,7 +607,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 
@@ -649,7 +648,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 
@@ -690,7 +689,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 
@@ -731,7 +730,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 
@@ -770,7 +769,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 
@@ -812,7 +811,7 @@ public sealed class PrometheusCollectionManagerTests
         }
         finally
         {
-            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect(protocol);
         }
     }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -305,7 +305,7 @@ public sealed class PrometheusCollectionManagerTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task EnterCollectRunsDifferentProtocolsSeparately(bool firstOpenMetricsRequested)
+    public async Task EnterCollectSharesActiveCollectionAcrossProtocols(bool firstOpenMetricsRequested)
     {
         using var meter = CreateMeter();
 #if PROMETHEUS_HTTP_LISTENER
@@ -326,6 +326,7 @@ public sealed class PrometheusCollectionManagerTests
 
         var collectCount = 0;
         var firstCollectStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondCollectStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var allowFirstCollectToContinue = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var originalCollect = exporter.Collect;
         exporter.Collect = (timeout) =>
@@ -353,63 +354,142 @@ public sealed class PrometheusCollectionManagerTests
 
         await firstCollectStarted.Task;
 
-        var secondCollectTask = Task.Run(async () => await EnterCollectAsync(exporter, secondProtocol));
+        var secondCollectTask = Task.Run(async () =>
+        {
+            secondCollectStarted.SetResult(true);
+            return await EnterCollectAsync(exporter, secondProtocol);
+        });
+
+        await secondCollectStarted.Task;
 
         Assert.False(secondCollectTask.IsCompleted, "Second collection completed while the first protocol was still collecting.");
 
         allowFirstCollectToContinue.SetResult(true);
 
+        var timeout = TimeSpan.FromSeconds(5);
+
+        using (var cts = new CancellationTokenSource(timeout))
+        {
+            var all = Task.WhenAll(firstCollectTask, secondCollectTask);
+            var completion = await Task.WhenAny(all, Task.Delay(timeout, cts.Token));
+            Assert.Same(all, completion);
+        }
+
         var firstResponse = await firstCollectTask;
-        var firstCollectExited = false;
+        var secondResponse = await secondCollectTask;
 
         try
         {
-            var timeout = TimeSpan.FromSeconds(1);
+            Assert.Equal(1, collectCount);
+            Assert.Equal(firstResponse.GeneratedAtUtc, secondResponse.GeneratedAtUtc);
 
-            using (var cts = new CancellationTokenSource(timeout))
+            var firstPayload = Encoding.UTF8.GetString(firstResponse.View.Array!, firstResponse.View.Offset, firstResponse.View.Count);
+            var secondPayload = Encoding.UTF8.GetString(secondResponse.View.Array!, secondResponse.View.Offset, secondResponse.View.Count);
+
+            Assert.NotEqual(firstPayload, secondPayload);
+
+            var openMetricsPayload = firstOpenMetricsRequested ? firstPayload : secondPayload;
+            var prometheusPayload = firstOpenMetricsRequested ? secondPayload : firstPayload;
+
+            Assert.Contains("# TYPE counter_int counter", openMetricsPayload, StringComparison.Ordinal);
+            Assert.Contains("counter_int_created", openMetricsPayload, StringComparison.Ordinal);
+            Assert.Contains("# TYPE counter_int_total counter", prometheusPayload, StringComparison.Ordinal);
+            Assert.DoesNotContain("counter_int_created", prometheusPayload, StringComparison.Ordinal);
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect();
+            exporter.CollectionManager.ExitCollect();
+        }
+    }
+
+    [Fact]
+    public async Task EnterCollectRetriesAfterFailedSharedCollection()
+    {
+        using var meter = CreateMeter();
+#if PROMETHEUS_HTTP_LISTENER
+        using var provider = CreateMeterProviderWithRandomPort(meter);
+#elif PROMETHEUS_ASPNETCORE
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 0)
+            .Build();
+#endif
+
+#pragma warning disable CA2000 // MeterProvider owns exporter lifecycle
+        if (!provider.TryFindExporter(out PrometheusExporter? exporter))
+#pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
+        {
+            throw new InvalidOperationException("PrometheusExporter could not be found on MeterProvider.");
+        }
+
+        var collectCount = 0;
+        var firstCollectStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowFirstCollectToComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var originalCollect = exporter.Collect;
+        exporter.Collect = (timeout) =>
+        {
+            var currentCollectCount = Interlocked.Increment(ref collectCount);
+
+            if (currentCollectCount == 1)
             {
-                var completion = await Task.WhenAny(secondCollectTask, Task.Delay(timeout, cts.Token));
-                Assert.NotSame(secondCollectTask, completion);
-                Assert.False(secondCollectTask.IsCompleted);
+                firstCollectStarted.SetResult(true);
+                Assert.True(allowFirstCollectToComplete.Task.Wait(TimeSpan.FromSeconds(5)), "First collection did not resume.");
+                return false;
             }
 
-            Assert.Equal(1, collectCount);
+            return originalCollect!(timeout);
+        };
 
-            exporter.CollectionManager.ExitCollect();
-            firstCollectExited = true;
+        meter.CreateCounter<int>("counter_int").Add(100);
 
-            var secondResponse = await secondCollectTask;
+        var protocol = GetProtocol(openMetricsRequested: false);
 
+        var firstCollectTask = Task.Run(async () =>
+        {
+            var response = await EnterCollectAsync(exporter, protocol);
             try
             {
-                Assert.Equal(2, collectCount);
-                Assert.True(firstResponse.GeneratedAtUtc < secondResponse.GeneratedAtUtc);
-
-                var firstPayload = Encoding.UTF8.GetString(firstResponse.View.Array!, firstResponse.View.Offset, firstResponse.View.Count);
-                var secondPayload = Encoding.UTF8.GetString(secondResponse.View.Array!, secondResponse.View.Offset, secondResponse.View.Count);
-
-                Assert.NotEqual(firstPayload, secondPayload);
-
-                var openMetricsPayload = firstOpenMetricsRequested ? firstPayload : secondPayload;
-                var prometheusPayload = firstOpenMetricsRequested ? secondPayload : firstPayload;
-
-                Assert.Contains("# TYPE counter_int counter", openMetricsPayload, StringComparison.Ordinal);
-                Assert.Contains("counter_int_created", openMetricsPayload, StringComparison.Ordinal);
-                Assert.Contains("# TYPE counter_int_total counter", prometheusPayload, StringComparison.Ordinal);
-                Assert.DoesNotContain("counter_int_created", prometheusPayload, StringComparison.Ordinal);
+                return response;
             }
             finally
             {
                 exporter.CollectionManager.ExitCollect();
             }
-        }
-        finally
+        });
+
+        await firstCollectStarted.Task;
+
+        var secondCollectTask = Task.Run(async () =>
         {
-            if (!firstCollectExited)
+            var response = await EnterCollectAsync(exporter, protocol);
+            try
+            {
+                return response;
+            }
+            finally
             {
                 exporter.CollectionManager.ExitCollect();
             }
+        });
+
+        allowFirstCollectToComplete.SetResult(true);
+
+        var timeout = TimeSpan.FromSeconds(5);
+
+        using (var cts = new CancellationTokenSource(timeout))
+        {
+            var all = Task.WhenAll(firstCollectTask, secondCollectTask);
+            var completion = await Task.WhenAny(all, Task.Delay(timeout, cts.Token));
+            Assert.Same(all, completion);
         }
+
+        var firstResponse = await firstCollectTask;
+        var secondResponse = await secondCollectTask;
+
+        Assert.Equal(2, collectCount);
+        Assert.Equal(0, firstResponse.View.Count);
+        Assert.True(secondResponse.View.Count > 0);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -302,6 +302,116 @@ public sealed class PrometheusCollectionManagerTests
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EnterCollectRunsDifferentProtocolsSeparately(bool firstOpenMetricsRequested)
+    {
+        using var meter = CreateMeter();
+#if PROMETHEUS_HTTP_LISTENER
+        using var provider = CreateMeterProviderWithRandomPort(meter);
+#elif PROMETHEUS_ASPNETCORE
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 0)
+            .Build();
+#endif
+
+#pragma warning disable CA2000 // MeterProvider owns exporter lifecycle
+        if (!provider.TryFindExporter(out PrometheusExporter? exporter))
+#pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
+        {
+            throw new InvalidOperationException("PrometheusExporter could not be found on MeterProvider.");
+        }
+
+        var collectCount = 0;
+        var firstCollectStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowFirstCollectToContinue = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var originalCollect = exporter.Collect;
+        exporter.Collect = (timeout) =>
+        {
+            var currentCollectCount = Interlocked.Increment(ref collectCount);
+
+            if (currentCollectCount == 1)
+            {
+                firstCollectStarted.SetResult(true);
+
+                var completed = allowFirstCollectToContinue.Task.Wait(TimeSpan.FromSeconds(5));
+                Assert.True(completed, "First collection did not resume.");
+            }
+
+            return originalCollect!(timeout);
+        };
+
+        var counter = meter.CreateCounter<int>("counter_int");
+        counter.Add(100);
+
+        var firstProtocol = GetProtocol(firstOpenMetricsRequested);
+        var secondProtocol = GetProtocol(!firstOpenMetricsRequested);
+
+        var firstCollectTask = Task.Run(async () => await EnterCollectAsync(exporter, firstProtocol));
+
+        await firstCollectStarted.Task;
+
+        var secondCollectTask = Task.Run(async () => await EnterCollectAsync(exporter, secondProtocol));
+
+        Assert.False(secondCollectTask.IsCompleted, "Second collection completed while the first protocol was still collecting.");
+
+        allowFirstCollectToContinue.SetResult(true);
+
+        var firstResponse = await firstCollectTask;
+        var firstCollectExited = false;
+
+        try
+        {
+            var timeout = TimeSpan.FromSeconds(1);
+
+            using (var cts = new CancellationTokenSource(timeout))
+            {
+                var completion = await Task.WhenAny(secondCollectTask, Task.Delay(timeout, cts.Token));
+                Assert.NotSame(secondCollectTask, completion);
+                Assert.False(secondCollectTask.IsCompleted);
+            }
+
+            Assert.Equal(1, collectCount);
+
+            exporter.CollectionManager.ExitCollect();
+            firstCollectExited = true;
+
+            var secondResponse = await secondCollectTask;
+
+            try
+            {
+                Assert.Equal(2, collectCount);
+                Assert.True(firstResponse.GeneratedAtUtc < secondResponse.GeneratedAtUtc);
+
+                var firstPayload = Encoding.UTF8.GetString(firstResponse.View.Array!, firstResponse.View.Offset, firstResponse.View.Count);
+                var secondPayload = Encoding.UTF8.GetString(secondResponse.View.Array!, secondResponse.View.Offset, secondResponse.View.Count);
+
+                Assert.NotEqual(firstPayload, secondPayload);
+
+                var openMetricsPayload = firstOpenMetricsRequested ? firstPayload : secondPayload;
+                var prometheusPayload = firstOpenMetricsRequested ? secondPayload : firstPayload;
+
+                Assert.Contains("# TYPE counter_int counter", openMetricsPayload, StringComparison.Ordinal);
+                Assert.Contains("counter_int_created", openMetricsPayload, StringComparison.Ordinal);
+                Assert.Contains("# TYPE counter_int_total counter", prometheusPayload, StringComparison.Ordinal);
+                Assert.DoesNotContain("counter_int_created", prometheusPayload, StringComparison.Ordinal);
+            }
+            finally
+            {
+                exporter.CollectionManager.ExitCollect();
+            }
+        }
+        finally
+        {
+            if (!firstCollectExited)
+            {
+                exporter.CollectionManager.ExitCollect();
+            }
+        }
+    }
+
     [Fact]
     public async Task OpenMetricsDoesNotEmitScopeInfoMetricFamily()
     {
@@ -631,6 +741,13 @@ public sealed class PrometheusCollectionManagerTests
         escaping: PrometheusProtocol.UnderscoresEscaping,
         version: openMetricsRequested ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV1,
         isOpenMetrics: openMetricsRequested);
+
+    private static Task<PrometheusCollectionManager.CollectionResponse> EnterCollectAsync(PrometheusExporter exporter, PrometheusProtocol protocol) =>
+#if NET
+        exporter.CollectionManager.EnterCollect(protocol).AsTask();
+#else
+        exporter.CollectionManager.EnterCollect(protocol);
+#endif
 
     private static Meter CreateMeter([CallerMemberName] string name = "") => new(name);
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -78,13 +78,15 @@ public sealed class PrometheusCollectionManagerTests
                 utcNow = utcNow.AddMilliseconds(1);
             }
 
-            var response = await exporter.CollectionManager.EnterCollect(openMetricsRequested);
+            var protocol = GetProtocol(openMetricsRequested);
+            var response = await exporter.CollectionManager.EnterCollect(protocol);
+
             try
             {
                 return new()
                 {
                     CollectionResponse = response,
-                    ViewPayload = openMetricsRequested ? [.. response.OpenMetricsView] : [.. response.PlainTextView],
+                    ViewPayload = [.. response.View],
                 };
             }
             finally
@@ -151,8 +153,11 @@ public sealed class PrometheusCollectionManagerTests
 
         try
         {
+            var protocol = GetProtocol(openMetricsRequested);
+
             // This should use the cache and ignore the second counter update.
-            var task = exporter.CollectionManager.EnterCollect(openMetricsRequested);
+            var task = exporter.CollectionManager.EnterCollect(protocol);
+
             Assert.True(task.IsCompleted, "Collection did not complete.");
             var response = await task;
 
@@ -235,7 +240,9 @@ public sealed class PrometheusCollectionManagerTests
         var counter = meter.CreateCounter<int>("counter_int");
         counter.Add(100);
 
-        var firstResponse = await exporter.CollectionManager.EnterCollect(openMetricsRequested: false);
+        var protocol = GetProtocol(openMetricsRequested: false);
+
+        var firstResponse = await exporter.CollectionManager.EnterCollect(protocol);
         var firstCollectExited = false;
         try
         {
@@ -245,7 +252,7 @@ public sealed class PrometheusCollectionManagerTests
             var secondCollectTask = Task.Run(async () =>
             {
                 secondCollectStarted.SetResult(true);
-                var response = await exporter.CollectionManager.EnterCollect(openMetricsRequested: false);
+                var response = await exporter.CollectionManager.EnterCollect(protocol);
                 try
                 {
                     return response;
@@ -316,13 +323,15 @@ public sealed class PrometheusCollectionManagerTests
 
         meter.CreateCounter<int>("counter_1").Add(1);
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: true);
+        var protocol = GetProtocol(openMetricsRequested: true);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
             var output = Encoding.UTF8.GetString(
-                response.OpenMetricsView.Array!,
-                response.OpenMetricsView.Offset,
-                response.OpenMetricsView.Count);
+                response.View.Array!,
+                response.View.Offset,
+                response.View.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
         }
@@ -354,13 +363,15 @@ public sealed class PrometheusCollectionManagerTests
         meter.CreateObservableGauge("otel.scope", () => 1);
         meter.CreateObservableGauge("otel.scope.info", () => 2);
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: true);
+        var protocol = GetProtocol(openMetricsRequested: true);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
             var output = Encoding.UTF8.GetString(
-                response.OpenMetricsView.Array!,
-                response.OpenMetricsView.Offset,
-                response.OpenMetricsView.Count);
+                response.View.Array!,
+                response.View.Offset,
+                response.View.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
         }
@@ -395,10 +406,12 @@ public sealed class PrometheusCollectionManagerTests
         counter1.Add(1, [new("source", "a")]);
         counter2.Add(2, [new("source", "b")]);
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        var protocol = GetProtocol(openMetricsRequested: false);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
-            var view = response.PlainTextView;
+            var view = response.View;
             var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
@@ -434,10 +447,12 @@ public sealed class PrometheusCollectionManagerTests
         counter1.Add(1, [new("source", "a")]);
         counter2.Add(2, [new("source", "b")]);
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        var protocol = GetProtocol(openMetricsRequested: false);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
-            var view = response.PlainTextView;
+            var view = response.View;
             var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
@@ -473,10 +488,12 @@ public sealed class PrometheusCollectionManagerTests
         counter1.Add(1, [new("source", "a")]);
         counter2.Add(2, [new("source", "b")]);
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        var protocol = GetProtocol(openMetricsRequested: false);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
-            var view = response.PlainTextView;
+            var view = response.View;
             var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
@@ -512,10 +529,12 @@ public sealed class PrometheusCollectionManagerTests
         counter1.Add(1, [new("source", "a")]);
         counter2.Add(2, [new("source", "b")]);
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: false);
+        var protocol = GetProtocol(openMetricsRequested: false);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
-            var view = response.PlainTextView;
+            var view = response.View;
             var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
@@ -549,10 +568,12 @@ public sealed class PrometheusCollectionManagerTests
         meter.CreateObservableGauge("test-metric", () => 1);
         counter.Add(1);
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: true);
+        var protocol = GetProtocol(openMetricsRequested: true);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
-            var view = response.OpenMetricsView;
+            var view = response.View;
             var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
@@ -589,10 +610,12 @@ public sealed class PrometheusCollectionManagerTests
         meter1.CreateObservableGauge("other.metric", () => 3, description: "Other help");
         meter2.CreateObservableGauge("test-metric", () => 2, description: "Test help");
 
-        var response = await exporter!.CollectionManager.EnterCollect(openMetricsRequested: true);
+        var protocol = GetProtocol(openMetricsRequested: true);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
         try
         {
-            var view = response.OpenMetricsView;
+            var view = response.View;
             var output = Encoding.UTF8.GetString(view.Array!, view.Offset, view.Count);
 
             await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
@@ -602,6 +625,12 @@ public sealed class PrometheusCollectionManagerTests
             exporter.CollectionManager.ExitCollect();
         }
     }
+
+    private static PrometheusProtocol GetProtocol(bool openMetricsRequested) => new(
+        mediaType: openMetricsRequested ? PrometheusProtocol.OpenMetricsMediaType : PrometheusProtocol.PrometheusTextMediaType,
+        escaping: PrometheusProtocol.UnderscoresEscaping,
+        version: openMetricsRequested ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV1,
+        isOpenMetrics: openMetricsRequested);
 
     private static Meter CreateMeter([CallerMemberName] string name = "") => new(name);
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusProtocolTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusProtocolTests.cs
@@ -1,0 +1,714 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter.Prometheus.Tests;
+
+public class PrometheusProtocolTests
+{
+    [Fact]
+    public void Equals_ReturnsTrueForIdenticalInstances()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.True(first.Equals(second));
+        Assert.True(second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_ReturnsTrueForSameInstance()
+    {
+        var protocol = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        Assert.True(protocol.Equals(protocol));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForDifferentMediaType()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            true);
+
+        Assert.False(first.Equals(second));
+        Assert.False(second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForDifferentEscaping()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(first.Equals(second));
+        Assert.False(second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForDifferentVersion()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(first.Equals(second));
+        Assert.False(second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForDifferentIsOpenMetrics()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            true);
+
+        Assert.False(first.Equals(second));
+        Assert.False(second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_ReturnsTrueForIdenticalInstancesWithNullEscaping()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        Assert.True(first.Equals(second));
+        Assert.True(second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_Object_ReturnsTrueForIdenticalInstances()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        object second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.True(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_Object_ReturnsFalseForNull()
+    {
+        var protocol = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(protocol.Equals(null));
+    }
+
+    [Fact]
+    public void Equals_Object_ReturnsFalseForDifferentType()
+    {
+        var protocol = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(protocol.Equals("not a PrometheusProtocol"));
+        Assert.False(protocol.Equals(42));
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsSameValueForEqualInstances()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsSameValueForSameInstance()
+    {
+        var protocol = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        var hash1 = protocol.GetHashCode();
+        var hash2 = protocol.GetHashCode();
+
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsSameValueForIdenticalInstancesWithNullEscaping()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentForDifferentMediaType()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        // Hash codes should be different (but technically could collide)
+        // We're just verifying they don't throw and are consistent
+        var hash1 = first.GetHashCode();
+        var hash2 = second.GetHashCode();
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentForDifferentEscaping()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var hash1 = first.GetHashCode();
+        var hash2 = second.GetHashCode();
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentForDifferentVersion()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var hash1 = first.GetHashCode();
+        var hash2 = second.GetHashCode();
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentForDifferentIsOpenMetrics()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            true);
+
+        var hash1 = first.GetHashCode();
+        var hash2 = second.GetHashCode();
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void Equals_WorksWithFallbackConstant()
+    {
+        var fallback1 = PrometheusProtocol.Fallback;
+        var fallback2 = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        Assert.True(fallback1.Equals(fallback2));
+        Assert.True(fallback2.Equals(fallback1));
+        Assert.Equal(fallback1.GetHashCode(), fallback2.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData(PrometheusProtocol.PrometheusTextMediaType, null, false)]
+    [InlineData(PrometheusProtocol.PrometheusTextMediaType, "underscores", false)]
+    [InlineData(PrometheusProtocol.OpenMetricsMediaType, null, true)]
+    [InlineData(PrometheusProtocol.OpenMetricsMediaType, "underscores", true)]
+    public void Equals_EqualsOperator_ConsistentWithEquals(string mediaType, string? escaping, bool isOpenMetrics)
+    {
+        var version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV1;
+
+        var first = new PrometheusProtocol(mediaType, escaping, version, isOpenMetrics);
+        var second = new PrometheusProtocol(mediaType, escaping, version, isOpenMetrics);
+
+        // For structs, == operator needs to be implemented separately, but Equals should work
+        Assert.True(first.Equals(second));
+    }
+
+    [Fact]
+    public void CanBeUsedAsDictionaryKey()
+    {
+        var dictionary = new Dictionary<PrometheusProtocol, string>();
+
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        dictionary[first] = "prometheus";
+        dictionary[second] = "openmetrics";
+
+        Assert.Equal("prometheus", dictionary[first]);
+        Assert.Equal("openmetrics", dictionary[second]);
+        Assert.Equal(2, dictionary.Count);
+    }
+
+    [Fact]
+    public void CanBeUsedInHashSet()
+    {
+        var hashSet = new HashSet<PrometheusProtocol>();
+
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var third = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        Assert.True(hashSet.Add(first));
+        Assert.False(hashSet.Add(second)); // Should be considered duplicate
+        Assert.True(hashSet.Add(third));
+
+        Assert.Equal(2, hashSet.Count);
+        Assert.Contains(first, hashSet);
+        Assert.Contains(second, hashSet); // Should find first
+        Assert.Contains(third, hashSet);
+    }
+
+    // Tests for short-circuit evaluation in Equals method
+    [Fact]
+    public void Equals_ShortCircuitsOnIsOpenMetrics()
+    {
+        // Test that if IsOpenMetrics differs, other properties don't matter
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            true);
+
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_ShortCircuitsOnMediaType()
+    {
+        // Test that if IsOpenMetrics matches but MediaType differs, other properties don't matter
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_ShortCircuitsOnEscaping()
+    {
+        // Test that if IsOpenMetrics and MediaType match but Escaping differs, Version doesn't matter
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_ChecksAllPropertiesWhenPreviousMatch()
+    {
+        // Ensure all properties are checked (Version is last)
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForMultipleDifferentProperties()
+    {
+        // Test when multiple properties differ
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        Assert.False(first.Equals(second));
+        Assert.False(second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_HandlesEscapingNullVsEmptyString()
+    {
+        // Test null vs empty string for Escaping property
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            string.Empty,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        // null and empty string should be treated as different
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_HandlesBothEscapingNonNull()
+    {
+        // Test both with non-null escaping but different values
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.AllowUtf8Escaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.False(first.Equals(second));
+    }
+
+    [Fact]
+    public void GetHashCode_IsConsistentAcrossMultipleCalls()
+    {
+        var protocol = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var hash1 = protocol.GetHashCode();
+        var hash2 = protocol.GetHashCode();
+        var hash3 = protocol.GetHashCode();
+
+        Assert.Equal(hash1, hash2);
+        Assert.Equal(hash2, hash3);
+    }
+
+    [Fact]
+    public void GetHashCode_HandlesNullEscaping()
+    {
+        // Ensure GetHashCode handles null escaping without throwing
+        var protocol = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var hash = protocol.GetHashCode();
+
+        // Should not throw and should be consistent
+        Assert.Equal(hash, protocol.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentForNullVsEmptyStringEscaping()
+    {
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            string.Empty,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var hash1 = first.GetHashCode();
+        var hash2 = second.GetHashCode();
+
+        // Hash codes should differ for null vs empty string
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void Equals_Symmetry()
+    {
+        // Test symmetry: if x.Equals(y), then y.Equals(x)
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        Assert.Equal(first.Equals(second), second.Equals(first));
+    }
+
+    [Fact]
+    public void Equals_Transitivity()
+    {
+        // Test transitivity: if x.Equals(y) and y.Equals(z), then x.Equals(z)
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        var second = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        var protocol3 = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        Assert.True(first.Equals(second));
+        Assert.True(second.Equals(protocol3));
+        Assert.True(first.Equals(protocol3));
+    }
+
+    [Fact]
+    public void GetHashCode_DifferentVersionsProduceDifferentHashes()
+    {
+        // Test all version combinations
+        var prometheusV0 = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV0,
+            false);
+
+        var prometheusV1 = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            null,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        var openMetricsV0 = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV0,
+            true);
+
+        var openMetricsV1 = new PrometheusProtocol(
+            PrometheusProtocol.OpenMetricsMediaType,
+            null,
+            PrometheusProtocol.OpenMetricsV1,
+            true);
+
+        var hashes = new[]
+        {
+            prometheusV0.GetHashCode(),
+            prometheusV1.GetHashCode(),
+            openMetricsV0.GetHashCode(),
+            openMetricsV1.GetHashCode(),
+        };
+
+        // All hash codes should be different
+        Assert.Equal(4, hashes.Distinct().Count());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Equals_HandlesIsOpenMetricsCorrectly(bool isOpenMetrics)
+    {
+        var mediaType = isOpenMetrics ? PrometheusProtocol.OpenMetricsMediaType : PrometheusProtocol.PrometheusTextMediaType;
+        var version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV1;
+
+        var first = new PrometheusProtocol(mediaType, null, version, isOpenMetrics);
+        var second = new PrometheusProtocol(mediaType, null, version, isOpenMetrics);
+
+        Assert.True(first.Equals(second));
+    }
+
+    [Fact]
+    public void Equals_Object_BoxingScenario()
+    {
+        // Test boxing scenario where struct is cast to object
+        var first = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        object boxed1 = first;
+        object boxed2 = new PrometheusProtocol(
+            PrometheusProtocol.PrometheusTextMediaType,
+            PrometheusProtocol.UnderscoresEscaping,
+            PrometheusProtocol.PrometheusV1,
+            false);
+
+        Assert.True(boxed1.Equals(boxed2));
+        Assert.True(boxed2.Equals(boxed1));
+    }
+}


### PR DESCRIPTION
## Changes

- Instead of maintaining separate fields for reviews and timestamps for scrape responses, key on the `PrometheusProtocol` to support multiple formats and simplify passing options that affect the serializer around in the future (e.g. for #7156 and #7159).
- Consolidate the buffer and view into a single state object, rather than storing across four dictionaries.
- Rename version properties for consistency to `V{number}`.

Changes are about ~2% regression for the scrape endpoint, but that's still massively improved compared to before #7279.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
