### PR TITLE
[OTLP] Fix %2C in header values being treated as pair separator

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,13 +7,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-## 1.16.0
-
-Released 2026-Jun-10
-
-## 1.16.0-rc.1
-
-Released 2026-Jun-10
+* Fixed `OtlpExporterOptions.Headers` parsing to correctly handle URL-encoded
+  commas (`%2C`) in header values. Previously the entire header string was
+  URL-decoded before splitting, causing `%2C` to be treated as a pair separator
+  instead of a value character.
+  ([#6510](https://github.com/open-telemetry/opentelemetry-dotnet/issues/6510))
 
 * Fixed `NullReferenceException` when exporting logs if the scope key is null.
   ([#7186](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7186))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -8,9 +8,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Fixed `OtlpExporterOptions.Headers` parsing to correctly handle URL-encoded
-  commas (`%2C`) in header values. Previously the entire header string was
-  URL-decoded before splitting, causing `%2C` to be treated as a pair separator
-  instead of a value character.
+  commas (`%2C`) in header values.
   ([#6510](https://github.com/open-telemetry/opentelemetry-dotnet/issues/6510))
 
 * Fixed `NullReferenceException` when exporting logs if the scope key is null.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -11,6 +11,14 @@ Notes](../../RELEASENOTES.md).
   commas (`%2C`) in header values.
   ([#6510](https://github.com/open-telemetry/opentelemetry-dotnet/issues/6510))
 
+## 1.16.0
+
+Released 2026-Jun-10
+
+## 1.16.0-rc.1
+
+Released 2026-Jun-10
+
 * Fixed `NullReferenceException` when exporting logs if the scope key is null.
   ([#7186](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7186))
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -30,7 +30,8 @@ internal static class OtlpExporterOptionsExtensions
         if (!string.IsNullOrEmpty(optionHeaders))
         {
             // According to the specification, URL-encoded headers must be supported.
-            optionHeaders = Uri.UnescapeDataString(optionHeaders);
+            // We split on raw commas first so that %2C within a value is not mistaken
+            // for a pair separator, then URL-decode each key and value individually.
             var headersSpan = optionHeaders.AsSpan();
 
             while (!headersSpan.IsEmpty)
@@ -54,8 +55,8 @@ internal static class OtlpExporterOptionsExtensions
                     throw new ArgumentException("Headers provided in an invalid format.");
                 }
 
-                var key = pair.Slice(0, equalIndex).Trim().ToString();
-                var value = pair.Slice(equalIndex + 1).Trim().ToString();
+                var key = Uri.UnescapeDataString(pair.Slice(0, equalIndex).Trim().ToString());
+                var value = Uri.UnescapeDataString(pair.Slice(equalIndex + 1).Trim().ToString());
                 addHeader(headers, key, value);
             }
         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -55,8 +55,10 @@ internal static class OtlpExporterOptionsExtensions
                     throw new ArgumentException("Headers provided in an invalid format.");
                 }
 
-                var key = Uri.UnescapeDataString(pair.Slice(0, equalIndex).Trim().ToString());
-                var value = Uri.UnescapeDataString(pair.Slice(equalIndex + 1).Trim().ToString());
+                var keySpan = pair.Slice(0, equalIndex).Trim();
+                var valueSpan = pair.Slice(equalIndex + 1).Trim();
+                var key = keySpan.Contains('%') ? Uri.UnescapeDataString(keySpan.ToString()) : keySpan.ToString();
+                var value = valueSpan.Contains('%') ? Uri.UnescapeDataString(valueSpan.ToString()) : valueSpan.ToString();
                 addHeader(headers, key, value);
             }
         }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -54,10 +54,41 @@ public class OtlpExporterOptionsExtensionsTests
     [InlineData("key1= value with spaces ,key2=another value", "key1=value with spaces,key2=another value")]
     [InlineData("=value1", "=value1")]
     [InlineData("key1=", "key1=")]
-    [InlineData("key1=value1%2Ckey2=value2", "key1=value1,key2=value2")]
-    [InlineData("key1=value1%2Ckey2=value2%2Ckey3=value3", "key1=value1,key2=value2,key3=value3")]
     public void GetHeaders_ValidAndUrlEncodedHeaders_ReturnsCorrectHeaders(string inputOptionHeaders, string expectedNormalizedOptional)
         => VerifyHeaders(inputOptionHeaders, expectedNormalizedOptional);
+
+    [Fact]
+    public void GetHeaders_UrlEncodedCommaInValue_TreatedAsValueNotSeparator()
+    {
+        // Regression test for https://github.com/open-telemetry/opentelemetry-dotnet/issues/6510
+        // %2C in a value must remain a comma within that value, not act as a pair separator.
+        var options = new OtlpExporterOptions
+        {
+            Headers = "VL-Stream-Fields=service.name%2Cservice.environment,Authorization=Bearer token",
+        };
+
+        var headers = options.GetHeaders<Dictionary<string, string>>((d, k, v) => d.Add(k, v));
+
+        Assert.True(headers.TryGetValue("VL-Stream-Fields", out var streamFields));
+        Assert.Equal("service.name,service.environment", streamFields);
+
+        Assert.True(headers.TryGetValue("Authorization", out var auth));
+        Assert.Equal("Bearer token", auth);
+    }
+
+    [Fact]
+    public void GetHeaders_UrlEncodedEqualsInValue_ParsedCorrectly()
+    {
+        var options = new OtlpExporterOptions
+        {
+            Headers = "Authorization=Basic dXNlcjpwYXNz%3D%3D",
+        };
+
+        var headers = options.GetHeaders<Dictionary<string, string>>((d, k, v) => d.Add(k, v));
+
+        Assert.True(headers.TryGetValue("Authorization", out var auth));
+        Assert.Equal("Basic dXNlcjpwYXNz==", auth);
+    }
 
     [Theory]
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning


### PR DESCRIPTION
 Fix URL-encoded comma (`%2C`) in OTLP header values being incorrectly split as a key-value pair separator.

  The fix splits on raw commas only, then URL-decodes each key and value individually. To avoid an unnecessary allocation in the common case, `Uri.UnescapeDataString` is only called when the span actually
  contains a `%` character.

  Fixes #6510