### PR TITLE
[release] Core stable release 1.16.0 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <OTelLatestStableVer>1.15.3</OTelLatestStableVer>
+    <OTelLatestStableVer>1.16.0</OTelLatestStableVer>
   </PropertyGroup>
 
   <!--

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -500,7 +500,7 @@ function GetCoreDependenciesForProjects {
     foreach ($project in $projects)
     {
         # Note: dotnet restore may fail if the core packages aren't available yet but that is fine, we just want to generate project.assets.json for these projects.
-        dotnet restore $project -p:RunningDotNetPack=true
+        dotnet restore $project -p:RunningDotNetPack=true | Out-Null
 
         $projectDir = $project | Split-Path -Parent
         $projectDirName = $projectDir | Split-Path -Leaf

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -92,6 +92,9 @@ Notes](../../RELEASENOTES.md).
 * Drop conflicting scope attributes named `name`, `version`, and `schema_url`.
   ([#7237](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7237))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#52](https://github.com/open-telemetry/opentelemetry-dotnet/pull/52))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -103,6 +103,9 @@ Notes](../../RELEASENOTES.md).
 * Drop conflicting scope attributes named `name`, `version`, and `schema_url`.
   ([#7237](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7237))
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#52](https://github.com/open-telemetry/opentelemetry-dotnet/pull/52))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.16.0`.
+  ([#52](https://github.com/open-telemetry/opentelemetry-dotnet/pull/52))
+
 ## 1.15.3-beta.1
 
 Released 2026-Apr-21


### PR DESCRIPTION
## Changes

- Sets `OTelLatestStableVer` in `Directory.Packages.props` to `1.16.0`.
- Update CHANGELOGs.
- Fix issue that cause automatic PR generation to fail.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
