### PR TITLE
[OpenTelemetry] Fix metricpoint race on ARM

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed a metric point reclaim data race on CPU ARM architectures.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -7,7 +7,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Fixed a metric point reclaim data race on CPU ARM architectures.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7401](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7401))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -239,16 +239,19 @@ internal sealed class AggregatorStore
                     // and update the MetricPoint, thereby, setting its status to `CollectPending`. Note that the ReferenceCount would be 0 after the update.
                     // If the Collect thread now wakes up, it would be able to set the ReferenceCount to `int.MinValue`, thereby, marking the MetricPoint
                     // invalid for newer updates. In such cases, the MetricPoint, should not be reclaimed before taking its Snapshot.
-
-#pragma warning disable CA1508 // Avoid dead conditional code - see previous comment
-                    if (metricPoint.MetricPointStatus == MetricPointStatus.NoCollectPending)
-#pragma warning restore CA1508 // Avoid dead conditional code - see previous comment
+                    //
+                    // The MetricPoint is now exclusively claimed (ReferenceCount == int.MinValue), so no concurrent Update can be in progress. Decide
+                    // whether it is safe to reclaim from the authoritative running value (see MetricPoint.HasUnexportedData) rather than the
+                    // MetricPointStatus flag. The status flag is written by both Update and Snapshot without a common lock; on weak memory models
+                    // (e.g. Arm/.NET Framework) an Update's `CollectPending` write can be lost against the snapshot's `NoCollectPending` write, which
+                    // would otherwise let a MetricPoint that still holds an unexported measurement be reclaimed (losing the measurement).
+                    if (!metricPoint.HasUnexportedData())
                     {
                         this.ReclaimMetricPoint(ref metricPoint, i);
                     }
                     else
                     {
-                        // MetricPoint's ReferenceCount is `int.MinValue` but it still has a collect pending. Take the MetricPoint's Snapshot
+                        // The MetricPoint still has an unexported measurement. Take its Snapshot
                         // and mark it to be reclaimed in the next Collect cycle.
 
                         metricPoint.LookupData.DeferredReclaim = true;

--- a/src/OpenTelemetry/Metrics/MetricPoint/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint/MetricPoint.cs
@@ -633,20 +633,17 @@ public struct MetricPoint
                 {
                     if (outputDelta)
                     {
-                        // Clear the collect-pending flag *before* reading the running value.
-                        // Any concurrent Update that bumps the running value after our read is
-                        // then guaranteed to re-set the flag to CollectPending *after* this clear
-                        // (the Interlocked.Read below and the Interlocked barriers in Update form
-                        // a full-barrier ordering). Clearing the flag *after* the read and patching
-                        // it with a second read is not safe on weak memory models (e.g. Arm): the
-                        // Update's CollectPending write can lose the race with this NoCollectPending
-                        // write, leaving an unexported measurement on a point that then looks drained
-                        // and gets reclaimed (lost). See CompleteUpdate.
-                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
-
                         var initValue = Interlocked.Read(ref this.runningValue.AsLong);
                         this.snapshotValue.AsLong = initValue - this.deltaLastValue.AsLong;
                         this.deltaLastValue.AsLong = initValue;
+                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                        // Check again if value got updated, if yes reset status.
+                        // This ensures no Updates get Lost.
+                        if (initValue != Interlocked.Read(ref this.runningValue.AsLong))
+                        {
+                            this.MetricPointStatus = MetricPointStatus.CollectPending;
+                        }
                     }
                     else
                     {
@@ -668,14 +665,17 @@ public struct MetricPoint
                 {
                     if (outputDelta)
                     {
-                        // Clear the collect-pending flag *before* reading the running value so a
-                        // concurrent Update cannot be stranded on a point that then looks drained
-                        // and gets reclaimed. See the LongSum case above and CompleteUpdate.
-                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
-
                         var initValue = InterlockedHelper.Read(ref this.runningValue.AsDouble);
                         this.snapshotValue.AsDouble = initValue - this.deltaLastValue.AsDouble;
                         this.deltaLastValue.AsDouble = initValue;
+                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                        // Check again if value got updated, if yes reset status.
+                        // This ensures no Updates get Lost.
+                        if (initValue != InterlockedHelper.Read(ref this.runningValue.AsDouble))
+                        {
+                            this.MetricPointStatus = MetricPointStatus.CollectPending;
+                        }
                     }
                     else
                     {
@@ -694,24 +694,30 @@ public struct MetricPoint
 
             case AggregationType.LongGauge:
                 {
-                    // Clear the collect-pending flag *before* reading the running value so a
-                    // concurrent Update that records a newer value after our read re-flags the
-                    // point afterwards instead of being stranded (and potentially reclaimed).
-                    // See the LongSum case above and CompleteUpdate.
+                    this.snapshotValue.AsLong = Interlocked.Read(ref this.runningValue.AsLong);
                     this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
-                    this.snapshotValue.AsLong = Interlocked.Read(ref this.runningValue.AsLong);
+                    // Check again if value got updated, if yes reset status.
+                    // This ensures no Updates get Lost.
+                    if (this.snapshotValue.AsLong != Interlocked.Read(ref this.runningValue.AsLong))
+                    {
+                        this.MetricPointStatus = MetricPointStatus.CollectPending;
+                    }
 
                     break;
                 }
 
             case AggregationType.DoubleGauge:
                 {
-                    // Clear the collect-pending flag *before* reading the running value. See the
-                    // LongGauge/LongSum cases above and CompleteUpdate.
+                    this.snapshotValue.AsDouble = InterlockedHelper.Read(ref this.runningValue.AsDouble);
                     this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
-                    this.snapshotValue.AsDouble = InterlockedHelper.Read(ref this.runningValue.AsDouble);
+                    // Check again if value got updated, if yes reset status.
+                    // This ensures no Updates get Lost.
+                    if (this.snapshotValue.AsDouble != InterlockedHelper.Read(ref this.runningValue.AsDouble))
+                    {
+                        this.MetricPointStatus = MetricPointStatus.CollectPending;
+                    }
 
                     break;
                 }
@@ -875,6 +881,49 @@ public struct MetricPoint
         this.TakeSnapshot(outputDelta);
 
         this.mpComponents!.Exemplars = this.mpComponents.ExemplarReservoir!.Collect();
+    }
+
+    /// <summary>
+    /// Determines whether this MetricPoint has measurements that have been recorded since the
+    /// last collection but not yet exported (i.e. it is not safe to reclaim).
+    /// </summary>
+    /// <remarks>
+    /// This must only be called by the collection thread after it has exclusively claimed the
+    /// MetricPoint for reclaim (<see cref="ReferenceCount"/> == <see cref="int.MinValue"/>). At
+    /// that point no <c>Update</c> can be in progress and the <c>CompareExchange</c> that set the
+    /// claim establishes an acquire barrier, so the running value reflects all completed updates.
+    /// The decision is derived from the authoritative running value rather than the
+    /// <see cref="MetricPointStatus"/> flag: that flag is written by both <c>Update</c> and
+    /// <c>Snapshot</c> without a common lock, so on weak memory models (e.g. Arm/.NET Framework)
+    /// an <c>Update</c>'s <see cref="MetricPointStatus.CollectPending"/> write can be lost against
+    /// the snapshot's <see cref="MetricPointStatus.NoCollectPending"/> write, which would otherwise
+    /// allow a MetricPoint that still has an unexported measurement to be reclaimed (losing it).
+    /// </remarks>
+    /// <returns><see langword="true"/> if there is unexported data; otherwise, <see langword="false"/>.</returns>
+    internal bool HasUnexportedData()
+    {
+        switch (this.aggType)
+        {
+            case AggregationType.LongSumIncomingDelta:
+            case AggregationType.LongSumIncomingCumulative:
+                return Interlocked.Read(ref this.runningValue.AsLong) != this.deltaLastValue.AsLong;
+
+            case AggregationType.DoubleSumIncomingDelta:
+            case AggregationType.DoubleSumIncomingCumulative:
+                return InterlockedHelper.Read(ref this.runningValue.AsDouble) != this.deltaLastValue.AsDouble;
+
+            case AggregationType.LongGauge:
+                return Interlocked.Read(ref this.runningValue.AsLong) != this.snapshotValue.AsLong;
+
+            case AggregationType.DoubleGauge:
+                return InterlockedHelper.Read(ref this.runningValue.AsDouble) != this.snapshotValue.AsDouble;
+
+            default:
+                // Histogram aggregations reset the running count to zero on each delta snapshot, so
+                // a non-zero running count means measurements have been recorded since the last
+                // collection. (Reclaim only runs for delta temporality.)
+                return Interlocked.Read(ref this.runningValue.AsLong) != 0;
+        }
     }
 
     /// <summary>

--- a/src/OpenTelemetry/Metrics/MetricPoint/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint/MetricPoint.cs
@@ -633,17 +633,20 @@ public struct MetricPoint
                 {
                     if (outputDelta)
                     {
+                        // Clear the collect-pending flag *before* reading the running value.
+                        // Any concurrent Update that bumps the running value after our read is
+                        // then guaranteed to re-set the flag to CollectPending *after* this clear
+                        // (the Interlocked.Read below and the Interlocked barriers in Update form
+                        // a full-barrier ordering). Clearing the flag *after* the read and patching
+                        // it with a second read is not safe on weak memory models (e.g. Arm): the
+                        // Update's CollectPending write can lose the race with this NoCollectPending
+                        // write, leaving an unexported measurement on a point that then looks drained
+                        // and gets reclaimed (lost). See CompleteUpdate.
+                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
                         var initValue = Interlocked.Read(ref this.runningValue.AsLong);
                         this.snapshotValue.AsLong = initValue - this.deltaLastValue.AsLong;
                         this.deltaLastValue.AsLong = initValue;
-                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
-
-                        // Check again if value got updated, if yes reset status.
-                        // This ensures no Updates get Lost.
-                        if (initValue != Interlocked.Read(ref this.runningValue.AsLong))
-                        {
-                            this.MetricPointStatus = MetricPointStatus.CollectPending;
-                        }
                     }
                     else
                     {
@@ -665,17 +668,14 @@ public struct MetricPoint
                 {
                     if (outputDelta)
                     {
+                        // Clear the collect-pending flag *before* reading the running value so a
+                        // concurrent Update cannot be stranded on a point that then looks drained
+                        // and gets reclaimed. See the LongSum case above and CompleteUpdate.
+                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
                         var initValue = InterlockedHelper.Read(ref this.runningValue.AsDouble);
                         this.snapshotValue.AsDouble = initValue - this.deltaLastValue.AsDouble;
                         this.deltaLastValue.AsDouble = initValue;
-                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
-
-                        // Check again if value got updated, if yes reset status.
-                        // This ensures no Updates get Lost.
-                        if (initValue != InterlockedHelper.Read(ref this.runningValue.AsDouble))
-                        {
-                            this.MetricPointStatus = MetricPointStatus.CollectPending;
-                        }
                     }
                     else
                     {
@@ -694,30 +694,24 @@ public struct MetricPoint
 
             case AggregationType.LongGauge:
                 {
-                    this.snapshotValue.AsLong = Interlocked.Read(ref this.runningValue.AsLong);
+                    // Clear the collect-pending flag *before* reading the running value so a
+                    // concurrent Update that records a newer value after our read re-flags the
+                    // point afterwards instead of being stranded (and potentially reclaimed).
+                    // See the LongSum case above and CompleteUpdate.
                     this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
-                    // Check again if value got updated, if yes reset status.
-                    // This ensures no Updates get Lost.
-                    if (this.snapshotValue.AsLong != Interlocked.Read(ref this.runningValue.AsLong))
-                    {
-                        this.MetricPointStatus = MetricPointStatus.CollectPending;
-                    }
+                    this.snapshotValue.AsLong = Interlocked.Read(ref this.runningValue.AsLong);
 
                     break;
                 }
 
             case AggregationType.DoubleGauge:
                 {
-                    this.snapshotValue.AsDouble = InterlockedHelper.Read(ref this.runningValue.AsDouble);
+                    // Clear the collect-pending flag *before* reading the running value. See the
+                    // LongGauge/LongSum cases above and CompleteUpdate.
                     this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
-                    // Check again if value got updated, if yes reset status.
-                    // This ensures no Updates get Lost.
-                    if (this.snapshotValue.AsDouble != InterlockedHelper.Read(ref this.runningValue.AsDouble))
-                    {
-                        this.MetricPointStatus = MetricPointStatus.CollectPending;
-                    }
+                    this.snapshotValue.AsDouble = InterlockedHelper.Read(ref this.runningValue.AsDouble);
 
                     break;
                 }

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -7,20 +7,6 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
-/*
-BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
-Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK 8.0.100
-  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
-  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
-
-
-| Method  | UseWithRef | Mean     | Error    | StdDev   | Allocated |
-|-------- |----------- |---------:|---------:|---------:|----------:|
-| Collect | False      | 21.03 us | 0.148 us | 0.361 us |      96 B |
-| Collect | True       | 20.37 us | 0.399 us | 0.559 us |      96 B |
-*/
-
 namespace Benchmarks.Metrics;
 
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
@@ -29,8 +15,11 @@ public class MetricCollectBenchmarks
 {
     private readonly string[] dimensionValues = ["DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10"];
 
-    // TODO: Confirm if this needs to be thread-safe
+#if NET
+    private readonly Random random = Random.Shared;
+#else
     private readonly Random random = new();
+#endif
     private Counter<double>? counter;
     private MeterProvider? provider;
     private Meter? meter;
@@ -40,6 +29,9 @@ public class MetricCollectBenchmarks
 
     [Params(false, true)]
     public bool UseWithRef { get; set; }
+
+    [Params(MetricReaderTemporalityPreference.Cumulative, MetricReaderTemporalityPreference.Delta)]
+    public MetricReaderTemporalityPreference TemporalityPreference { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -74,7 +66,7 @@ public class MetricCollectBenchmarks
 
         this.reader = new BaseExportingMetricReader(metricExporter)
         {
-            TemporalityPreference = MetricReaderTemporalityPreference.Cumulative,
+            TemporalityPreference = this.TemporalityPreference,
         };
 
         this.meter = new Meter(Utils.GetCurrentMethodName());

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
@@ -187,9 +187,127 @@ public class MetricPointReclaimTests
         Assert.Equal(sum, exporter.Sum);
     }
 
+    // Regression test for a metric point reclaim data race where a measurement recorded
+    // concurrently with a snapshot could be stranded on a metric point that then looked
+    // "drained" and was reclaimed, permanently losing the value.
+    //
+    // The race is between AggregatorStore.SnapshotDeltaWithMetricPointReclaim (which clears a
+    // point's CollectPending flag) and MetricPoint.Update/CompleteUpdate (which sets it). Before
+    // the fix, the snapshot cleared the flag *after* reading the running value; on a weak memory
+    // model (e.g. Arm) the update's CollectPending write could lose the race with the snapshot's
+    // NoCollectPending write, leaving the running value unexported on a point that is then
+    // reclaimed in the next collect cycle.
+    //
+    // This is a stress test: it asserts that the total exported value always equals the total
+    // recorded value (no measurement is ever lost). On strongly-ordered architectures (x86/x64)
+    // it passes regardless of the fix; on weak-memory hardware it reliably fails without the fix
+    // and passes with it.
+    [Fact]
+    public void MeasurementsAreNotLostWhenReclaimRacesWithUpdates()
+    {
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+        var counter = meter.CreateCounter<long>("MyFruitCounter");
+
+        long recordedSum = 0;
+        long exportedSum = 0;
+
+        // A small limit relative to the number of distinct tag values forces continuous
+        // reclaim of metric points, maximizing the window for the snapshot/update race.
+        const int MaxMetricPointsPerMetricStream = 10;
+        const int NumberOfUpdateThreads = 8;
+        const int DistinctTagValues = 500;
+        const int MeasurementsPerThread = 100_000;
+
+        using var exporter = new SumCapturingExporter(value => Interlocked.Add(ref exportedSum, value));
+        using var metricReader = new BaseExportingMetricReader(exporter)
+        {
+            TemporalityPreference = MetricReaderTemporalityPreference.Delta,
+        };
+
+        using (var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .SetMaxMetricPointsPerMetricStream(MaxMetricPointsPerMetricStream)
+            .AddReader(metricReader)
+            .Build())
+        {
+            var stopCollecting = 0;
+
+            // Collect as aggressively as possible to drive reclaim churn and interleave snapshots
+            // with in-flight updates.
+            var collector = new Thread(() =>
+            {
+                while (Volatile.Read(ref stopCollecting) == 0)
+                {
+                    metricReader.Collect();
+                }
+            });
+            collector.Start();
+
+            var threads = new Thread[NumberOfUpdateThreads];
+            for (var t = 0; t < threads.Length; t++)
+            {
+                var seed = t + 1;
+                threads[t] = new Thread(() =>
+                {
+                    var random = new Random(seed);
+                    for (var i = 0; i < MeasurementsPerThread; i++)
+                    {
+#pragma warning disable CA5394 // Insecure randomness is fine for a stress test
+                        long value = random.Next(1, 100);
+                        var tagValue = random.Next(DistinctTagValues);
+#pragma warning restore CA5394
+                        counter.Add(value, new KeyValuePair<string, object?>("key", tagValue));
+                        Interlocked.Add(ref recordedSum, value);
+                    }
+                });
+                threads[t].Start();
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+            Volatile.Write(ref stopCollecting, 1);
+            collector.Join();
+
+            Assert.True(meterProvider.ForceFlush());
+        }
+
+        Assert.Equal(Interlocked.Read(ref recordedSum), Interlocked.Read(ref exportedSum));
+    }
+
     private sealed class ThreadArguments
     {
         public int Counter;
+    }
+
+    private sealed class SumCapturingExporter : BaseExporter<Metric>
+    {
+        private readonly Action<long> onSum;
+
+        public SumCapturingExporter(Action<long> onSum)
+        {
+            this.onSum = onSum;
+        }
+
+        public override ExportResult Export(in Batch<Metric> batch)
+        {
+            foreach (var metric in batch)
+            {
+                if (!metric.MetricType.IsSum())
+                {
+                    continue;
+                }
+
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
+                {
+                    this.onSum(metricPoint.GetSumLong());
+                }
+            }
+
+            return ExportResult.Success;
+        }
     }
 
     private sealed class CustomExporter : BaseExporter<Metric>

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
@@ -199,9 +199,7 @@ public class MetricPointReclaimTests
     // reclaimed in the next collect cycle.
     //
     // This is a stress test: it asserts that the total exported value always equals the total
-    // recorded value (no measurement is ever lost). On strongly-ordered architectures (x86/x64)
-    // it passes regardless of the fix; on weak-memory hardware it reliably fails without the fix
-    // and passes with it.
+    // recorded value (no measurement is ever lost).
     [Fact]
     public void MeasurementsAreNotLostWhenReclaimRacesWithUpdates()
     {


### PR DESCRIPTION
## Changes

Fix flaky read on ARM that Claude code suggests is the root cause for test flakiness due to its weaker memory model in `MetricPointReclaimTests` found while working on #7400.

I can't validate this either way locally, so I told Claude to assume it was true and write a test to prove it in CI.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
