### PR TITLE
[Infra] Avoid failed jobs from coverage upload

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -116,11 +116,13 @@ jobs:
     - name: Upload code coverage ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       continue-on-error: true # Note: Don't fail for upload failures
+      timeout-minutes: 5
       env:
         OS: ${{ matrix.os }}
         TFM: ${{ matrix.version }}
       with:
         disable_search: true
+        disable_telem: true
         env_vars: OS,TFM
         files: TestResults/Cobertura.xml
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
@@ -131,8 +133,11 @@ jobs:
     - name: Upload test results ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
       if: ${{ !cancelled() && hashFiles('./TestResults/junit.xml') != '' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      continue-on-error: true # Note: Don't fail for upload failures
+      timeout-minutes: 5
       with:
         disable_search: true
+        disable_telem: true
         env_vars: OS,TFM
         files: TestResults/junit.xml
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}


### PR DESCRIPTION
## Changes

Avoid CI failures caused by the codecov action hanging on shutdown after upload completes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
