### PR TITLE
[Infra] Fix new code analysis warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -156,6 +156,12 @@ dotnet_diagnostic.IDE0002.severity = warning
 # IDE0005: Remove unnecessary import
 dotnet_diagnostic.IDE0005.severity = warning
 
+# IDE0045: if statement can be simplified
+dotnet_diagnostic.IDE0045.severity = silent
+
+# IDE0046: if statement can be simplified
+dotnet_diagnostic.IDE0046.severity = silent
+
 # RS0041: Public members should not use oblivious types
 dotnet_diagnostic.RS0041.severity = suggestion
 

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -252,11 +252,7 @@ public readonly struct Baggage : IEquatable<Baggage>
         return new Baggage(
             new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.Ordinal)
             {
-#if NET
                 [name] = value,
-#else
-                [name] = value!,
-#endif
             });
     }
 
@@ -310,11 +306,7 @@ public readonly struct Baggage : IEquatable<Baggage>
                 }
 
                 newBaggage ??= new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.Ordinal);
-#if NET
                 newBaggage[item.Key] = item.Value;
-#else
-                newBaggage[item.Key] = item.Value!;
-#endif
             }
         }
         while (enumerator.MoveNext());

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -267,8 +267,6 @@ public class BaggagePropagator : TextMapPropagator
         return result;
     }
 
-    private static string EncodeKey(ReadOnlySpan<char> key) => Encode(key, isKey: true);
-
     private static string EncodeValue(ReadOnlySpan<char> value) => Encode(value, isKey: false);
 
     private static string Encode(ReadOnlySpan<char> value, bool isKey)
@@ -337,7 +335,7 @@ public class BaggagePropagator : TextMapPropagator
                 // Non-BMP pair: encode both chars as one UTF-8 sequence.
                 // Passing the pair to Encoding.UTF8 produces the correct 4-byte result
                 // rather than two replacement characters.
-                foreach (var b in Encoding.UTF8.GetBytes(new string(new[] { c, value[i + 1] })))
+                foreach (var b in Encoding.UTF8.GetBytes(new string([c, value[i + 1]])))
                 {
                     AppendPercentEncoded(sb, b);
                 }

--- a/src/OpenTelemetry.Api/Logs/LogRecordData.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordData.cs
@@ -124,7 +124,7 @@ internal
     public DateTime ObservedTimestamp
     {
         readonly get => this.ObservedTimestampBacking;
-        set { this.ObservedTimestampBacking = value.Kind == DateTimeKind.Local ? value.ToUniversalTime() : value; }
+        set => this.ObservedTimestampBacking = value.Kind == DateTimeKind.Local ? value.ToUniversalTime() : value;
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -12,7 +12,11 @@ internal static class ProtobufOtlpResourceSerializer
     private const int ReserveSizeForLength = 4;
     private const int InitialBufferSize = 2048;
 
+#if NETFRAMEWORK || NETSTANDARD2_0
     private static readonly ConditionalWeakTable<Resource, byte[]> CachedResourceBytes = new();
+#else
+    private static readonly ConditionalWeakTable<Resource, byte[]> CachedResourceBytes = [];
+#endif
 
     private static ReadOnlySpan<byte> EmptyResourceBytes => [0x0A, 0x80, 0x80, 0x80, 0x00];
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -253,17 +253,15 @@ internal static class ProtobufSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int WriteStringWithTag(byte[] buffer, int writePosition, int fieldNumber, string value)
     {
-        Debug.Assert(value != null, "value was null");
-
-        var numberOfUtf8CharsInString = GetNumberOfUtf8CharsInString(value!);
-        return WriteStringWithTag(buffer, writePosition, fieldNumber, numberOfUtf8CharsInString, value!);
+        var numberOfUtf8CharsInString = GetNumberOfUtf8CharsInString(value);
+        return WriteStringWithTag(buffer, writePosition, fieldNumber, numberOfUtf8CharsInString, value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int GetNumberOfUtf8CharsInString(string value)
     {
         Debug.Assert(value != null, "value was null");
-        return Utf8Encoding.GetByteCount(value!);
+        return Utf8Encoding.GetByteCount(value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusSerializer.cs
@@ -830,27 +830,7 @@ internal static partial class PrometheusSerializer
         return cursor + value.Length;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int WriteUnicodeScalar(byte[] buffer, int cursor, string value, ref int index)
-    {
-        // Strings MUST only consist of valid UTF-8 characters.
-        // See https://prometheus.io/docs/specs/om/open_metrics_spec/#strings.
-        var current = value[index];
-
-        if (!char.IsSurrogate(current))
-        {
-            return WriteUnicodeNoEscape(buffer, cursor, current);
-        }
-
-        if (char.IsHighSurrogate(current) && index < value.Length - 1 && char.IsLowSurrogate(value[index + 1]))
-        {
-            index++;
-            return WriteUnicodeNoEscape(buffer, cursor, char.ConvertToUtf32(current, value[index]));
-        }
-
-        return WriteUnicodeNoEscape(buffer, cursor, 0xFFFD);
-    }
-
+#if NET
     private static int GetUnicodeOrdinal(ReadOnlySpan<char> value, out int charsConsumed)
     {
         const int UnicodeReplacementCharacter = 0xFFFD;
@@ -878,6 +858,28 @@ internal static partial class PrometheusSerializer
         charsConsumed = 1;
         return character;
     }
+#else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int WriteUnicodeScalar(byte[] buffer, int cursor, string value, ref int index)
+    {
+        // Strings MUST only consist of valid UTF-8 characters.
+        // See https://prometheus.io/docs/specs/om/open_metrics_spec/#strings.
+        var current = value[index];
+
+        if (!char.IsSurrogate(current))
+        {
+            return WriteUnicodeNoEscape(buffer, cursor, current);
+        }
+
+        if (char.IsHighSurrogate(current) && index < value.Length - 1 && char.IsLowSurrogate(value[index + 1]))
+        {
+            index++;
+            return WriteUnicodeNoEscape(buffer, cursor, char.ConvertToUtf32(current, value[index]));
+        }
+
+        return WriteUnicodeNoEscape(buffer, cursor, 0xFFFD);
+    }
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int WriteSanitizedLabel(byte[] buffer, int cursor, object? labelValue)
@@ -1004,8 +1006,10 @@ internal static partial class PrometheusSerializer
             Debug.Assert(orderedKeys != null, $"{nameof(orderedKeys)} should not be null.");
             Debug.Assert(labelsBySanitizedKey != null, $"{nameof(labelsBySanitizedKey)} should not be null.");
 
+#pragma warning disable IDE0370 // Remove unnecessary suppression
             var orderedOutputKeys = orderedKeys!;
             var groupedLabels = labelsBySanitizedKey!;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
             foreach (var key in orderedOutputKeys)
             {
@@ -1148,7 +1152,7 @@ internal static partial class PrometheusSerializer
                 : FormatFixedAndTrim(destination, value, Math.Max(1, -exponent));
         }
 
-        char symbol = absoluteValue >= 1e6 || absoluteValue < 1e-4 ? 'e' : 'G';
+        var symbol = absoluteValue is >= 1e6 or < 1e-4 ? 'e' : 'G';
 
         return TryFormat(destination, value, new(symbol, 17));
 
@@ -1254,7 +1258,7 @@ internal static partial class PrometheusSerializer
                 : FormatFixedAndTrim(value, Math.Max(1, -exponent));
         }
 
-        return value.ToString(absoluteValue >= 1e6 || absoluteValue < 1e-4 ? "e17" : "G17", CultureInfo.InvariantCulture);
+        return value.ToString(absoluteValue is >= 1e6 or < 1e-4 ? "e17" : "G17", CultureInfo.InvariantCulture);
 
         static string FormatFixedAndTrim(double value, int decimalPlaces)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusSerializerExt.cs
@@ -247,7 +247,7 @@ internal static partial class PrometheusSerializer
         // the scrape immediately rather than repeatedly re-entering this allocation.
         var newBufferSize = currentBufferSize * 2;
 
-        return newBufferSize <= 0 || newBufferSize > MaxSerializedTagsBufferSize
+        return newBufferSize is <= 0 or > MaxSerializedTagsBufferSize
             ? throw new InvalidOperationException("The serialized Prometheus tag set exceeded the maximum supported size.")
             : newBufferSize;
     }

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -164,11 +164,6 @@ internal abstract class TagWriter<TTagState, TArrayState>
         string tagKey,
         string tagValueTypeFullName);
 
-    private static ReadOnlySpan<char> TruncateString(ReadOnlySpan<char> value, int? maxLength)
-        => maxLength.HasValue && value.Length > maxLength
-           ? value.Slice(0, maxLength.Value)
-           : value;
-
     private void WriteCharTag(ref TTagState state, string key, char value)
     {
         Span<char> destination = [value];

--- a/test/Benchmarks/Metrics/HistogramExplicitBoundsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/HistogramExplicitBoundsBenchmarks.cs
@@ -26,7 +26,7 @@ public class HistogramExplicitBoundsBenchmarks
         var finite = CreateBounds(this.BoundCount, this.Layout);
         var infinite = CreateInfiniteBounds(finite);
 
-        this.emptyBounds = new(Array.Empty<double>());
+        this.emptyBounds = new([]);
         this.finiteBounds = new(finite);
         this.infiniteBounds = new(infinite);
 

--- a/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/EnvironmentVariableCarrierFuzzTests.cs
+++ b/test/OpenTelemetry.Api.FuzzTests/Context/Propagation/EnvironmentVariableCarrierFuzzTests.cs
@@ -94,10 +94,6 @@ public class EnvironmentVariableCarrierFuzzTests
         expected.TraceFlags == actual.TraceFlags &&
         expected.TraceState == actual.TraceState;
 
-    private static bool DictionariesEqual(Dictionary<string, string> expected, IReadOnlyDictionary<string, string> actual) =>
-        expected.Count == actual.Count &&
-        expected.All(pair => actual.TryGetValue(pair.Key, out var value) && value == pair.Value);
-
     private static bool IsValidEnvironmentCharacter(char value) =>
         value is (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '_';
 


### PR DESCRIPTION
## Changes

- Cherry-pick changes from #6899 to fix new code analysis warnings, such as unused code or using collection expressions.
- Disable IDE0045 and IDE0046 as they generate noisy suggestions that create hard-to-read code.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
