### PR TITLE
[Api] Fix empty tracestate extraction

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed `TraceContextPropagator` to normalize empty `tracestate` header values
+  to `null` when extracting trace context.
+  ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407))
+
 ## 1.16.0
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -69,8 +69,8 @@ public class TraceContextPropagator : TextMapPropagator
             }
 
             string? tracestate = null;
-            TryExtractTracestate(getter(carrier, TraceState), out var extractedTracestate, out var hasTraceState);
-            if (hasTraceState)
+            var extracted = TryExtractTracestate(getter(carrier, TraceState), out var extractedTracestate, out var hasTraceState);
+            if (hasTraceState && (!extracted || extractedTracestate.Length > 0))
             {
                 tracestate = extractedTracestate;
             }

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
@@ -154,6 +154,24 @@ public class TraceContextPropagatorTests
         Assert.Null(context.ActivityContext.TraceState);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(" ,  ")]
+    public void TracestateToStringEmptyHeaderValue(string traceState)
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { TraceParent, $"00-{TraceId}-{SpanId}-01" },
+            { TraceState, traceState },
+        };
+
+        var propagator = new TraceContextPropagator();
+        var context = propagator.Extract(default, headers, Getter);
+
+        Assert.Null(context.ActivityContext.TraceState);
+    }
+
     [Fact]
     public void TracestateToString()
     {


### PR DESCRIPTION
Broader fix of https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4503

## Changes

Normalize valid empty `tracestate` header values to `null` when extracting W3C trace context with `TraceContextPropagator`.

The W3C Trace Context specification requires vendors to accept empty `tracestate` headers, while recommending that senders avoid producing them:
https://www.w3.org/TR/trace-context/#tracestate-header-field-values

Before this change, a present-but-empty `tracestate` header extracted as `ActivityContext.TraceState == ""`, while an absent `tracestate` header extracted as `null`. Both represent no trace state, but the observable difference can cause downstream code comparing OpenTelemetry-extracted context with runtime-created `Activity` context to treat them as different parents.

This change keeps malformed non-empty `tracestate` behavior unchanged, but normalizes valid empty or whitespace-only `tracestate` values to `null`.

## Tests

Added coverage for present empty/whitespace `tracestate` values:

- `tracestate: ""`
- `tracestate: " "`
- `tracestate: " ,  "`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
