### PR TITLE
[Infra] Pin .NET Framework dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,8 +75,8 @@
         an upgrade might introduce breaking changes. For example see:
         https://devblogs.microsoft.com/dotnet/system-text-json-in-dotnet-7/#breaking-changes.
     -->
-    <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />
-    <PackageVersion Include="System.Text.Json" Version="4.7.2" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="[4.7.2,)" />
+    <PackageVersion Include="System.Text.Json" Version="[4.7.2,)" />
 
     <!-- Mitigate https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485. -->
     <!-- Newer NETCoreApp runtimes need to be redirected to safe versions. -->


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet/pull/7416

## Changes

Pin `System.Text.Encodings.Web` and `System.Text.Json` to `4.7.2` for .NET Framework to avoid renovate updates.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
