### PR TITLE
[infra] Avoid NuGet API keys in process arguments

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -83,11 +83,12 @@ jobs:
         EXPECTED_COMMENT_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-login }}
         COMMENT_USER_NAME: ${{ github.event.comment.user.login }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
-        NUGET_TOKEN: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        NUGET_SYMBOL_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
         Import-Module .\build\scripts\post-release.psm1
 
-        $HasToken = -Not [string]::IsNullOrEmpty($env:NUGET_TOKEN)
+        $HasToken = -Not [string]::IsNullOrEmpty($env:NUGET_API_KEY)
         PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullRequest `
           -gitRepository ${env:GITHUB_REPOSITORY} `
           -pullRequestNumber ${env:ISSUE_NUMBER} `

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -84,7 +84,6 @@ jobs:
         COMMENT_USER_NAME: ${{ github.event.comment.user.login }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-        NUGET_SYMBOL_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
         Import-Module .\build\scripts\post-release.psm1
 

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -195,11 +195,11 @@ jobs:
       working-directory: ./artifacts/package/release
       env:
         MYGET_TOKEN_EXISTS: ${{ secrets.MYGET_TOKEN != '' }}
-        API_KEY: ${{ secrets.MYGET_TOKEN }}
+        NUGET_API_KEY: ${{ secrets.MYGET_TOKEN }}
         SOURCE: https://www.myget.org/F/opentelemetry/api/v3/index.json
       if: env.MYGET_TOKEN_EXISTS == 'true' # Skip MyGet publish if run on a fork without the secret
       shell: pwsh
-      run: dotnet nuget push *.nupkg --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
+      run: dotnet nuget push *.nupkg --skip-duplicate --source ${env:SOURCE}
 
   post-build:
     name: Post build release tasks

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -182,7 +182,6 @@ Maintainers (admins) are needed to merge PRs and for the push to NuGet.**
        ```powershell
        $nugetApiKey = Read-Host -Prompt 'NuGet API key' -AsSecureString
        $env:NUGET_API_KEY = [System.Net.NetworkCredential]::new('', $nugetApiKey).Password
-       $env:NUGET_SYMBOL_API_KEY = $env:NUGET_API_KEY
 
        Get-ChildItem -Recurse | Where-Object { $_.Extension -eq ".nupkg" } | ForEach-Object { .\nuget.exe push $_.FullName -Source https://api.nuget.org/v3/index.json }
        ```

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -185,6 +185,7 @@ Maintainers (admins) are needed to merge PRs and for the push to NuGet.**
 
        Get-ChildItem -Recurse -Filter "*.nupkg" | ForEach-Object {
          dotnet nuget push $_.FullName `
+           --skip-duplicate `
            --source https://api.nuget.org/v3/index.json
        }
        ```

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -169,8 +169,8 @@ Maintainers (admins) are needed to merge PRs and for the push to NuGet.**
 
     4. Extract the artifacts from the archive (`.zip`) into a local folder.
 
-    5. Download latest [nuget.exe](https://www.nuget.org/downloads) into the
-       same folder from step 4.
+    5. Ensure the .NET SDK version specified in `global.json` (or newer) is
+       installed.
 
     6. Create or regenerate an API key from nuget.org (only maintainers have
        access). When creating API keys make sure it is set to expire in 1 day or
@@ -183,7 +183,10 @@ Maintainers (admins) are needed to merge PRs and for the push to NuGet.**
        $nugetApiKey = Read-Host -Prompt 'NuGet API key' -AsSecureString
        $env:NUGET_API_KEY = [System.Net.NetworkCredential]::new('', $nugetApiKey).Password
 
-       Get-ChildItem -Recurse | Where-Object { $_.Extension -eq ".nupkg" } | ForEach-Object { .\nuget.exe push $_.FullName -Source https://api.nuget.org/v3/index.json }
+       Get-ChildItem -Recurse -Filter "*.nupkg" | ForEach-Object {
+         dotnet nuget push $_.FullName `
+           --source https://api.nuget.org/v3/index.json
+       }
        ```
 
     8. Validate that the package(s) are uploaded. Packages are available

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -180,9 +180,11 @@ Maintainers (admins) are needed to merge PRs and for the push to NuGet.**
        4:
 
        ```powershell
-       .\nuget.exe setApiKey <actual api key>
+       $nugetApiKey = Read-Host -Prompt 'NuGet API key' -AsSecureString
+       $env:NUGET_API_KEY = [System.Net.NetworkCredential]::new('', $nugetApiKey).Password
+       $env:NUGET_SYMBOL_API_KEY = $env:NUGET_API_KEY
 
-       get-childitem -Recurse | where {$_.extension -eq ".nupkg"} | foreach ($_) {.\nuget.exe push $_.fullname -Source https://api.nuget.org/v3/index.json}
+       Get-ChildItem -Recurse | Where-Object { $_.Extension -eq ".nupkg" } | ForEach-Object { .\nuget.exe push $_.FullName -Source https://api.nuget.org/v3/index.json }
        ```
 
     8. Validate that the package(s) are uploaded. Packages are available

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -245,7 +245,7 @@ function PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullReques
       --body "I am uploading the packages for ``$tag`` to NuGet and then I will publish the release."
     gh pr lock $pullRequestNumber
 
-    dotnet nuget push "$artifactDownloadPath/**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key "$env:NUGET_TOKEN" --symbol-api-key "$env:NUGET_TOKEN"
+    dotnet nuget push "$artifactDownloadPath/**/*.nupkg" --source https://api.nuget.org/v3/index.json
 
     if ($LASTEXITCODE -gt 0)
     {


### PR DESCRIPTION
Propagate changes from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4525

## Changes

[infra] Avoid NuGet API keys in process arguments

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
