### PR TITLE
[infra] Document native secret scanning

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,5 +1,5 @@
 header:
-  last-reviewed: '2026-04-24'
+  last-reviewed: '2026-06-18'
   last-updated: '2026-06-18'
   schema-version: 2.0.0
   url: https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet/main/.github/security-insights.yml

--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -155,7 +155,7 @@ repository:
           ci: false
           release: false
         rulesets:
-          - https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns
+          - https://docs.github.com/code-security/secret-scanning/introduction/supported-secret-scanning-patterns
         type: secret-scanning
       - name: Renovate
         comment: |

--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,6 +1,6 @@
 header:
   last-reviewed: '2026-04-24'
-  last-updated: '2026-04-24'
+  last-updated: '2026-06-18'
   schema-version: 2.0.0
   url: https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet/main/.github/security-insights.yml
   comment: |
@@ -146,6 +146,17 @@ repository:
         rulesets:
           - default
         type: fuzzing
+      - name: GitHub Secret Scanning
+        comment: |
+          GitHub native Secret Scanning and Push Protection are enabled for
+          the repository via the OpenTelemetry admin Terraform configuration.
+        integration:
+          adhoc: true
+          ci: false
+          release: false
+        rulesets:
+          - https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns
+        type: secret-scanning
       - name: Renovate
         comment: |
           Automated dependency updates.


### PR DESCRIPTION
Towards https://insights.linuxfoundation.org/project/opentelemetry/repository/open-telemetry_opentelemetry-dotnet/security
## Changes

Requirement ID: OSPS-BR-07.01

Ensure that sensitive data is not disclosed, compromised or misused leading to security vulnerabilities or supply chain compromise.

Reason

Secret scanning is not enabled

Recommendation

Configure .gitignore or equivalent to exclude files that may contain sensitive information. Use pre-commit hooks and automated scanning tools to detect and prevent the inclusion of sensitive data in commits.

Should be merged after https://github.com/open-telemetry/admin/pull/718

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
