### PR TITLE
[API] Normalize empty environment variable names

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -17,6 +17,10 @@ Notes](../../RELEASENOTES.md).
   normalize to the requested key.
   ([#7410](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7410))
 
+* **Experimental (pre-release builds only):** Updated `EnvironmentVariableCarrier`
+  key normalization to replace an empty key with a single underscore (`_`).
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -19,7 +19,7 @@ Notes](../../RELEASENOTES.md).
 
 * **Experimental (pre-release builds only):** Updated `EnvironmentVariableCarrier`
   key normalization to replace an empty key with a single underscore (`_`).
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7424](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7424))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Api/Context/Propagation/EnvironmentVariableCarrier.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/EnvironmentVariableCarrier.cs
@@ -17,7 +17,8 @@ namespace OpenTelemetry.Context.Propagation;
 /// normalization follows the OpenTelemetry environment carrier specification by
 /// uppercasing ASCII letters, replacing non-ASCII letters, non-digits, and
 /// non-underscore characters with underscores, prefixing an underscore when
-/// a normalized key would otherwise start with a digit.
+/// a normalized key would otherwise start with a digit, and replacing an empty
+/// key with a single underscore.
 /// </remarks>
 [System.Diagnostics.CodeAnalysis.Experimental(DiagnosticDefinitions.EnvironmentVariableContextPropagationExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 public
@@ -167,9 +168,10 @@ static class EnvironmentVariableCarrier
 
     private static bool IsAlreadyNormalized(string key)
     {
+        // An empty key is non-normalized and normalizes to a single underscore.
         if (key.Length == 0 || char.IsAsciiDigit(key[0]))
         {
-            return key.Length == 0;
+            return false;
         }
 
         foreach (var ch in key)
@@ -185,6 +187,11 @@ static class EnvironmentVariableCarrier
 
     private static string CreateNormalizedKey(string key)
     {
+        if (key.Length == 0)
+        {
+            return "_";
+        }
+
         var prefixLength = char.IsAsciiDigit(key[0]) ? 1 : 0;
         int length = key.Length + prefixLength;
 

--- a/src/OpenTelemetry.Api/Context/Propagation/EnvironmentVariableCarrier.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/EnvironmentVariableCarrier.cs
@@ -17,7 +17,7 @@ namespace OpenTelemetry.Context.Propagation;
 /// normalization follows the OpenTelemetry environment carrier specification by
 /// uppercasing ASCII letters, replacing non-ASCII letters, non-digits, and
 /// non-underscore characters with underscores, prefixing an underscore when
-/// a normalized key would otherwise start with a digit, and replacing an empty
+/// a key would otherwise start with a digit, and replacing an empty
 /// key with a single underscore.
 /// </remarks>
 [System.Diagnostics.CodeAnalysis.Experimental(DiagnosticDefinitions.EnvironmentVariableContextPropagationExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/EnvironmentVariableCarrierTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/EnvironmentVariableCarrierTests.cs
@@ -15,6 +15,7 @@ public class EnvironmentVariableCarrierTests
     [InlineData("otel-baggage-key", "OTEL_BAGGAGE_KEY")]
     [InlineData("123trace", "_123TRACE")]
     [InlineData("M\u00f6j Baga\u017c", "M_J_BAGA_")]
+    [InlineData("", "_")]
     public void NormalizeKey_CompliesWithSpecification(string key, string expected)
         => Assert.Equal(expected, EnvironmentVariableCarrier.NormalizeKey(key));
 


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/pull/5163.

## Changes

Normalize an empty value to `_`.

/cc @pellared

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
