### PR TITLE
[Infra] Only check changed files for dotnet format

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -5,13 +5,69 @@ name: Lint - dotnet format
 on:
   workflow_call:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  run-dotnet-format-stable:
-    name: Run dotnet format (stable)
+  check-dotnet-format:
+    name: Check for changes
+    runs-on: ubuntu-24.04
+
+    outputs:
+      include-args: ${{ steps.check.outputs.include-args }}
+      run-format: ${{ steps.check.outputs.run-format }}
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+        show-progress: false
+
+    - name: Check changed files
+      id: check
+      shell: pwsh
+      run: |
+        $baseRef = if (${env:GITHUB_BASE_REF}) { "origin/${env:GITHUB_BASE_REF}" } else { "HEAD~1" }
+        $changedFiles = git diff --name-only "$baseRef...HEAD"
+
+        if ($changedFiles -contains 'global.json') {
+          Write-Output "global.json was changed - checking all files."
+          "run-format=true" >> ${env:GITHUB_OUTPUT}
+          "include-args=" >> ${env:GITHUB_OUTPUT}
+        } else {
+          $csFiles = $changedFiles | Where-Object { $_ -match '\.cs$' }
+
+          if (-not $csFiles) {
+            Write-Output "No C# files changed."
+            "run-format=false" >> ${env:GITHUB_OUTPUT}
+          } else {
+            Write-Output "Checking: $csFiles"
+            "run-format=true" >> ${env:GITHUB_OUTPUT}
+            "include-args=$($csFiles -join ' ')" >> ${env:GITHUB_OUTPUT}
+          }
+        }
+
+  run-dotnet-format:
+    name: 'Run dotnet format (${{ matrix.name }})'
+    needs: [check-dotnet-format]
     runs-on: windows-2025
+    if: ${{ needs.check-dotnet-format.outputs.run-format == 'true' }}
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: stable
+            expose-experimental-features: false
+          - name: unstable
+            expose-experimental-features: true
 
     steps:
     - name: Checkout code
@@ -28,29 +84,20 @@ jobs:
       run: dotnet restore OpenTelemetry.slnx
 
     - name: dotnet format
-      run: dotnet format OpenTelemetry.slnx --no-restore --verify-no-changes # Note: .proj files are currently not supported by dotnet format
+      shell: pwsh
       env:
-        ExposeExperimentalFeatures: false
+        ExposeExperimentalFeatures: ${{ matrix.expose-experimental-features }}
+        INCLUDE_FILES: ${{ needs.check-dotnet-format.outputs.include-args }}
+      run: |
+        # Note: .proj files are currently not supported by dotnet format
+        $formatArgs = @(
+          'OpenTelemetry.slnx',
+          '--no-restore',
+          '--verify-no-changes'
+        )
 
-  run-dotnet-format-experimental:
-    name: Run dotnet format (experimental)
-    runs-on: windows-2025
+        if (${env:INCLUDE_FILES}) {
+          $formatArgs += @('--include') + ${env:INCLUDE_FILES}.Split(' ')
+        }
 
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        filter: 'tree:0'
-        persist-credentials: false
-        show-progress: false
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
-
-    - name: dotnet restore
-      run: dotnet restore OpenTelemetry.slnx
-
-    - name: dotnet format
-      run: dotnet format OpenTelemetry.slnx --no-restore --verify-no-changes # Note: .proj files are currently not supported by dotnet format
-      env:
-        ExposeExperimentalFeatures: true
+        dotnet format $formatArgs

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -10,6 +10,8 @@ using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
 using OpenTelemetry.Internal;
 
+// TODO Temporary comment to validate this PR
+
 namespace OpenTelemetry.Logs;
 
 /// <summary>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -10,8 +10,6 @@ using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
 using OpenTelemetry.Internal;
 
-// TODO Temporary comment to validate this PR
-
 namespace OpenTelemetry.Logs;
 
 /// <summary>


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4529

## Changes

- Only run `dotnet format` if the .NET SDK was updated or if any C# files were changed. In the latter case, only check the files that were changed.
- Scope permissions to individual jobs.
- Use matrix to avoid duplication.

Most testing in the linked PR, but repo-specific testing:

- [main](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/27749431568/job/82095912138) - ~6m 19s + ~6m 43s
- [No changes](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/27751677307/job/82103464619?pr=7425) - ~6s
- [C# only changes](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/27751746994/job/82103706683?pr=7425) - ~11s + ~3m 53s + ~3m 41s

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
