### PR TITLE
[Exporter.Prometheus] Log when metric ignored

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -7,6 +7,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added a verbose-level diagnostic event for ignored metrics.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Added a verbose-level diagnostic event for ignored metrics.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7429](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7429))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -7,6 +7,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added a verbose-level diagnostic event for ignored metrics.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Added a verbose-level diagnostic event for ignored metrics.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7429](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7429))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -515,8 +515,10 @@ internal sealed class PrometheusCollectionManager
 
         foreach (var metric in metrics)
         {
-            if (!TextFormatSerializer.CanWriteMetric(metric))
+            if (metric.MetricType == MetricType.ExponentialHistogram)
             {
+                // Exponential histograms are not yet supported by Prometheus.
+                PrometheusExporterEventSource.Log.MetricIgnored(metric);
                 continue;
             }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
@@ -92,7 +92,7 @@ internal sealed class PrometheusExporterEventSource : EventSource, IConfiguratio
         => this.WriteEvent(9, scrapeTimeoutSeconds);
 
     [NonEvent]
-    public void MetricIgnored(OpenTelemetry.Metrics.Metric metric)
+    public void MetricIgnored(Metrics.Metric metric)
     {
         if (this.IsEnabled(EventLevel.Verbose, EventKeywords.All))
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
@@ -90,4 +90,17 @@ internal sealed class PrometheusExporterEventSource : EventSource, IConfiguratio
     [Event(9, Message = "Metrics scrape request timed out after {0} seconds.", Level = EventLevel.Warning)]
     public void ScrapeTimedOut(double scrapeTimeoutSeconds)
         => this.WriteEvent(9, scrapeTimeoutSeconds);
+
+    [NonEvent]
+    public void MetricIgnored(OpenTelemetry.Metrics.Metric metric)
+    {
+        if (this.IsEnabled(EventLevel.Verbose, EventKeywords.All))
+        {
+            this.MetricIgnored(metric.Name, metric.MetricType.ToString());
+        }
+    }
+
+    [Event(10, Message = "Metric '{0}' ignored as metrics of type '{1}' are not supported by Prometheus.", Level = EventLevel.Verbose)]
+    public void MetricIgnored(string metricName, string metricType)
+        => this.WriteEvent(10, metricName, metricType);
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
@@ -125,18 +125,6 @@ internal abstract class TextFormatSerializer
         },
     };
 
-    public static bool CanWriteMetric(Metric metric)
-    {
-        if (metric.MetricType == MetricType.ExponentialHistogram)
-        {
-            // Exponential histograms are not yet supported by Prometheus.
-            // They are ignored for now.
-            return false;
-        }
-
-        return true;
-    }
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteEof(byte[] buffer, int cursor)
     {

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
@@ -121,6 +121,63 @@ public class PrometheusIntegrationTests(PromToolFixture promtool, ITestOutputHel
         Assert.EndsWith("# EOF\n", content, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task ExponentialHistogramsAreIgnored()
+    {
+        // Arrange
+        using var meter = new Meter(nameof(this.ExponentialHistogramsAreIgnored));
+
+        var builder = WebApplication.CreateBuilder();
+
+        // Listen on any available port
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+        builder.Services
+            .AddOpenTelemetry()
+            .ConfigureResource((p) => p.AddAttributes([new("service.name", "prometheus")]))
+            .WithMetrics((builder) =>
+            {
+                builder.AddMeter(meter.Name)
+                       .AddView(instrument => new Base2ExponentialBucketHistogramConfiguration())
+                       .AddPrometheusExporter();
+            });
+
+        using var app = builder.Build();
+
+        app.MapPrometheusScrapingEndpoint();
+
+        await app.StartAsync();
+
+        var counter = meter.CreateCounter<double>("test_counter");
+        counter.Add(1);
+        counter.Add(42);
+
+        var histogram = meter.CreateHistogram<double>("test_histogram");
+        histogram.Record(18);
+        histogram.Record(100);
+
+        var provider = app.Services.GetRequiredService<MeterProvider>();
+        provider.ForceFlush();
+
+        var server = app.Services.GetRequiredService<IServer>();
+        var addresses = server.Features.Get<IServerAddressesFeature>();
+
+        var baseAddress = addresses!.Addresses
+            .Select((p) => new Uri(p))
+            .Last();
+
+        using var httpClient = new HttpClient();
+        using var response = await httpClient.GetAsync(new Uri(baseAddress, "metrics"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(response.Content);
+
+        var output = await response.Content.ReadAsStringAsync();
+
+        await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
+    }
+
     [EnabledOnDockerPlatformTheory(DockerPlatform.Linux)]
     [InlineData("")]
     [InlineData("OpenMetricsText0.0.1")]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -584,28 +584,6 @@ public sealed partial class PrometheusSerializerTests
     }
 
     [Fact]
-    public void ExponentialHistogramIsIgnoredForNow()
-    {
-        var buffer = new byte[85000];
-        var metrics = new List<Metric>();
-
-        using var meter = CreateMeter();
-        using var provider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter(meter.Name)
-            .AddView(instrument => new Base2ExponentialBucketHistogramConfiguration())
-            .AddInMemoryExporter(metrics)
-            .Build();
-
-        var histogram = meter.CreateHistogram<double>("test_histogram");
-        histogram.Record(18);
-        histogram.Record(100);
-
-        provider.ForceFlush();
-
-        Assert.False(TextFormatSerializer.CanWriteMetric(metrics[0]));
-    }
-
-    [Fact]
     public async Task SumWithOpenMetricsFormat()
     {
         var buffer = new byte[85000];

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.ExponentialHistogramsAreIgnored.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.ExponentialHistogramsAreIgnored.verified.txt
@@ -1,0 +1,6 @@
+﻿# TYPE target_info gauge
+# HELP target_info Target metadata
+target_info{service_name="prometheus",telemetry_sdk_name="opentelemetry",telemetry_sdk_language="dotnet",telemetry_sdk_version="<VERSION>"} 1
+# TYPE test_counter_total counter
+test_counter_total{otel_scope_name="ExponentialHistogramsAreIgnored"} 43
+# EOF


### PR DESCRIPTION
## Changes

Log a verbose message to the event log when a metric is ignored.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
