### PR TITLE
[API] Handle null tracestate values

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -8,7 +8,8 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed `TraceContextPropagator` to normalize empty `tracestate` header values
   to `null` when extracting trace context.
-  ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407))
+  ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407),
+  [#7433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7433))
 
 * **Experimental (pre-release builds only):** Updated `EnvironmentVariableCarrier.Get`
   to read only the normalized environment variable name, following the updated

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -9,11 +9,6 @@ Notes](../../RELEASENOTES.md).
 * The library is now marked as trim and AOT compatible.
   ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
 
-* Fixed `TraceContextPropagator` to normalize empty `tracestate` header values
-  to `null` when extracting trace context.
-  ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407),
-  [#7433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7433))
-
 * **Experimental (pre-release builds only):** Updated `EnvironmentVariableCarrier.Get`
   to read only the normalized environment variable name, following the updated
   [environment variable carrier specification](https://github.com/open-telemetry/opentelemetry-specification/pull/5144).
@@ -24,6 +19,11 @@ Notes](../../RELEASENOTES.md).
 * **Experimental (pre-release builds only):** Updated `EnvironmentVariableCarrier`
   key normalization to replace an empty key with a single underscore (`_`).
   ([#7424](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7424))
+
+* Fixed `TraceContextPropagator` to normalize empty `tracestate` header values
+  to `null` when extracting trace context.
+  ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407),
+  [#7433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7433))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed `TraceContextPropagator` to normalize empty `tracestate` header values
+  to `null` when extracting trace context.
+  ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407),
+  [#7433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7433))
+
 * The library is now marked as trim and AOT compatible.
   ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
 
@@ -19,11 +24,6 @@ Notes](../../RELEASENOTES.md).
 * **Experimental (pre-release builds only):** Updated `EnvironmentVariableCarrier`
   key normalization to replace an empty key with a single underscore (`_`).
   ([#7424](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7424))
-
-* Fixed `TraceContextPropagator` to normalize empty `tracestate` header values
-  to `null` when extracting trace context.
-  ([#7407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7407),
-  [#7433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7433))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -469,7 +469,7 @@ public class TraceContextPropagator : TextMapPropagator
     {
         tracestateResult = string.Empty;
 
-        if (tracestate.Length == 0)
+        if (tracestate is not { Length: > 0 })
         {
             return true;
         }

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -381,6 +381,11 @@ public class TraceContextPropagator : TextMapPropagator
 
         foreach (var tracestateEntry in tracestateCollection)
         {
+            if (tracestateEntry is not { Length: > 0 })
+            {
+                continue;
+            }
+
             var tracestate = tracestateEntry.AsSpan();
             var begin = 0;
             while (begin < tracestate.Length)

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -470,7 +470,7 @@ public class TraceContextPropagator : TextMapPropagator
         return true;
     }
 
-    private static bool TryExtractSingleTracestate(string tracestate, out string tracestateResult)
+    private static bool TryExtractSingleTracestate(string? tracestate, out string tracestateResult)
     {
         tracestateResult = string.Empty;
 

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
@@ -337,6 +337,27 @@ public class TraceContextPropagatorTests
     }
 
     [Fact]
+    public void ExtractHandlesNullValue()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { TraceParent, $"00-{TraceId}-{SpanId}-01" },
+        };
+
+        var propagator = new TraceContextPropagator();
+        var context = propagator.Extract(default, headers, (_, name) => headers.TryGetValue(name, out var value) ? [value] : [null!]);
+
+        Assert.Equal(ActivityTraceId.CreateFromString(TraceId.AsSpan()), context.ActivityContext.TraceId);
+        Assert.Equal(ActivitySpanId.CreateFromString(SpanId.AsSpan()), context.ActivityContext.SpanId);
+
+        Assert.True(context.ActivityContext.IsRemote);
+        Assert.True(context.ActivityContext.IsValid());
+        Assert.NotEqual(0, (int)(context.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded));
+
+        Assert.Null(context.ActivityContext.TraceState);
+    }
+
+    [Fact]
     public void Inject_NoTracestate()
     {
         var traceId = ActivityTraceId.CreateRandom();

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
@@ -337,7 +337,7 @@ public class TraceContextPropagatorTests
     }
 
     [Fact]
-    public void ExtractHandlesNullValue()
+    public void Extract_HandlesNullTracestateValue()
     {
         var headers = new Dictionary<string, string>
         {
@@ -346,6 +346,27 @@ public class TraceContextPropagatorTests
 
         var propagator = new TraceContextPropagator();
         var context = propagator.Extract(default, headers, (_, name) => headers.TryGetValue(name, out var value) ? [value] : [null!]);
+
+        Assert.Equal(ActivityTraceId.CreateFromString(TraceId.AsSpan()), context.ActivityContext.TraceId);
+        Assert.Equal(ActivitySpanId.CreateFromString(SpanId.AsSpan()), context.ActivityContext.SpanId);
+
+        Assert.True(context.ActivityContext.IsRemote);
+        Assert.True(context.ActivityContext.IsValid());
+        Assert.NotEqual(0, (int)(context.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded));
+
+        Assert.Null(context.ActivityContext.TraceState);
+    }
+
+    [Fact]
+    public void Extract_HandlesNullTracestateValues()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { TraceParent, $"00-{TraceId}-{SpanId}-01" },
+        };
+
+        var propagator = new TraceContextPropagator();
+        var context = propagator.Extract(default, headers, (_, name) => headers.TryGetValue(name, out var value) ? [value] : [string.Empty, null!]);
 
         Assert.Equal(ActivityTraceId.CreateFromString(TraceId.AsSpan()), context.ActivityContext.TraceId);
         Assert.Equal(ActivitySpanId.CreateFromString(SpanId.AsSpan()), context.ActivityContext.SpanId);


### PR DESCRIPTION
Fixes #7432.

## Changes

Handle `tracestate` values that are returned as `null` from the getter in `TraceContextPropagator`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
