### PR TITLE
[OTLP] Extend OtlpExporterHelperExtensionsTests

### DIFF
--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterHelperExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterHelperExtensionsTests.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -56,6 +56,7 @@ public class OtlpExporterOptionsExtensionsTests
     [InlineData("key1=", "key1=")]
     [InlineData("key1=value1%2Ckey2=value2", "key1=value1,key2=value2")]
     [InlineData("key1=value1%2Ckey2=value2%2Ckey3=value3", "key1=value1,key2=value2,key3=value3")]
+    [InlineData("Authorization=Basic Zm9vOmJhcg==", "Authorization=Basic Zm9vOmJhcg==")]
     public void GetHeaders_ValidAndUrlEncodedHeaders_ReturnsCorrectHeaders(string inputOptionHeaders, string expectedNormalizedOptional)
         => VerifyHeaders(inputOptionHeaders, expectedNormalizedOptional);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
@@ -21,7 +21,7 @@ public sealed class OtlpExporterOptionsTests : IDisposable
     {
         var options = new OtlpExporterOptions();
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultHttpEndpoint), options.Endpoint);
 #else
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultGrpcEndpoint), options.Endpoint);
@@ -115,7 +115,7 @@ public sealed class OtlpExporterOptionsTests : IDisposable
             "TimeoutWithInvalidValue",
             "CompressionWithInvalidValue");
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultHttpEndpoint), options.Endpoint);
 #else
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultGrpcEndpoint), options.Endpoint);
@@ -206,7 +206,7 @@ public sealed class OtlpExporterOptionsTests : IDisposable
     {
         var options = new OtlpExporterOptions();
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultHttpEndpoint), options.Endpoint);
 #else
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultGrpcEndpoint), options.Endpoint);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
@@ -35,7 +35,7 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
 
         var exporterOptions = sp.GetRequiredService<IOptionsMonitor<OtlpExporterBuilderOptions>>().CurrentValue;
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultHttpEndpoint), exporterOptions.DefaultOptions.Endpoint);
 #else
         Assert.Equal(new Uri(OtlpExporterOptions.DefaultGrpcEndpoint), exporterOptions.DefaultOptions.Endpoint);
@@ -381,7 +381,5 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
         Assert.Equal(1002, activityProcessorOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds);
     }
 
-    private sealed class TestLogRecordProcessor : BaseProcessor<LogRecord>
-    {
-    }
+    private sealed class TestLogRecordProcessor : BaseProcessor<LogRecord>;
 }


### PR DESCRIPTION
Relates to #7430.

## Changes

- Add a test case for a header containing a base64 string.
- Remove redundant `#if`s from tests.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
