### PR TITLE
[Prometheus.HttpListener] Remove UriPrefixes

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
@@ -5,8 +5,6 @@ OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Port.get -> int
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Port.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.get -> bool
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.set -> void
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.UriPrefixes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.UriPrefixes.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.PrometheusHttpListenerOptions() -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeEndpointPath.get -> string?
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeEndpointPath.set -> void

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -11,7 +11,7 @@ Notes](../../RELEASENOTES.md).
   ([#7429](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7429))
 
 * Removed the `PrometheusHttpListenerOptions.UriPrefixes` option.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7435](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7435))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -10,6 +10,9 @@ Notes](../../RELEASENOTES.md).
 * Added a verbose-level diagnostic event for ignored metrics.
   ([#7429](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7429))
 
+* Removed the `PrometheusHttpListenerOptions.UriPrefixes` option.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -52,25 +52,11 @@ internal sealed class PrometheusHttpListener : IDisposable
             path = $"{path}/";
         }
 
-        if (!options.UriPrefixesExplicitlySet)
-        {
-            var uriBuilder = new UriBuilder(Uri.UriSchemeHttp, options.Host, options.Port) { Path = path };
-            this.httpListener.Prefixes.Add(uriBuilder.Uri.AbsoluteUri);
-        }
-        else
-        {
-            // TODO: Remove this branch (along with UriPrefixesExplicitlySet, the
-            // obsolete UriPrefixes property, and this pragma) prior to the stable
-            // release. Kept during the prerelease transition window so existing
-            // consumers of UriPrefixes continue to work.
-            // Tracking issue: https://github.com/open-telemetry/opentelemetry-dotnet/issues/7107
-#pragma warning disable CS0618 // Type or member is obsolete
-            foreach (var uriPrefix in options.UriPrefixes)
-            {
-                this.httpListener.Prefixes.Add($"{uriPrefix.TrimEnd('/')}{path}");
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-        }
+        var uriBuilder = new UriBuilder(Uri.UriSchemeHttp, options.Host, options.Port) { Path = path };
+        this.httpListener.Prefixes.Add(uriBuilder.Uri.AbsoluteUri);
+
+        // Hook for testing
+        options.ConfigureHttpListener?.Invoke(options, this.httpListener);
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -87,26 +87,5 @@ public class PrometheusHttpListenerOptions
         }
     }
 
-    /// <summary>
-    /// Gets or sets the URI (Uniform Resource Identifier) prefixes to use for the http listener.
-    /// Default value: <c>["http://localhost:9464/"]</c>.
-    /// </summary>
-    [Obsolete("UriPrefixes is deprecated. Use Host and Port. This will be removed in a future stable release.")]
-    public IReadOnlyCollection<string> UriPrefixes
-    {
-        get => field ?? ["http://localhost:9464/"];
-        set
-        {
-            Guard.ThrowIfNull(value);
-            if (value.Count == 0)
-            {
-                throw new ArgumentException("Empty list provided.", nameof(value));
-            }
-
-            field = value;
-            this.UriPrefixesExplicitlySet = true;
-        }
-    }
-
-    internal bool UriPrefixesExplicitlySet { get; private set; }
+    internal Action<PrometheusHttpListenerOptions, System.Net.HttpListener>? ConfigureHttpListener { get; set; }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -18,42 +18,9 @@ public class PrometheusHttpListenerTests
 {
     private const string MeterVersion = "1.0.1";
 
-    private const string UriPrefixesObsoleteMessage = "Tests the obsolete UriPrefixes property.";
-
     private static readonly string MeterName = Utils.GetCurrentMethodName();
 
     private static readonly ConcurrentDictionary<int, int> ConsumedPorts = [];
-
-    [Theory]
-    [InlineData("http://+:9464")]
-    [InlineData("http://*:9464")]
-    [InlineData("http://+:9464/")]
-    [InlineData("http://*:9464/")]
-    [InlineData("https://example.com")]
-    [InlineData("http://127.0.0.1")]
-    [InlineData("http://example.com", "https://example.com", "http://127.0.0.1")]
-    [InlineData("http://example.com")]
-    [Obsolete(UriPrefixesObsoleteMessage)]
-    public void UriPrefixesPositiveTest(params string[] uriPrefixes)
-    {
-        var options = TestPrometheusHttpListenerUriPrefixOptions(uriPrefixes);
-        Assert.Equivalent(uriPrefixes, options.UriPrefixes);
-    }
-
-    [Fact]
-    [Obsolete(UriPrefixesObsoleteMessage)]
-    public void UriPrefixesNull() =>
-        Assert.Throws<ArgumentNullException>(() => TestPrometheusHttpListenerUriPrefixOptions(null!));
-
-    [Fact]
-    [Obsolete(UriPrefixesObsoleteMessage)]
-    public void UriPrefixesEmptyList() =>
-        Assert.Throws<ArgumentException>(() => TestPrometheusHttpListenerUriPrefixOptions([]));
-
-    [Fact]
-    [Obsolete(UriPrefixesObsoleteMessage)]
-    public void UriPrefixesInvalid() =>
-        Assert.Throws<ArgumentException>(() => TestPrometheusHttpListenerUriPrefixOptions(["ftp://example.com"]));
 
     [Fact]
     public async Task PrometheusExporterHttpServerIntegration()
@@ -165,31 +132,6 @@ public class PrometheusHttpListenerTests
     }
 
     [Fact]
-    public async Task HostAndPort_Used_When_UriPrefixesNotSet()
-    {
-        using var meter = new Meter(MeterName, MeterVersion);
-
-        var host = "localhost";
-        var port = GetRandomPort();
-
-        using var context = CreateMeterProvider(meter, configureListener: (options) =>
-        {
-            options.Host = host;
-            options.Port = port;
-
-            return port;
-        });
-
-        Assert.Equal(host, context.BaseAddress.Host);
-        Assert.Equal(port, context.Port);
-
-        using var client = new HttpClient { BaseAddress = context.BaseAddress };
-        using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-    }
-
-    [Fact]
     public async Task PortOnly_Set_HostDefaultsToLocalhost()
     {
         using var meter = new Meter(MeterName, MeterVersion);
@@ -233,35 +175,6 @@ public class PrometheusHttpListenerTests
         });
 
         Assert.Equal(9464, context.Port);
-
-        using var client = new HttpClient { BaseAddress = context.BaseAddress };
-        using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-    }
-
-    [Fact]
-    [Obsolete(UriPrefixesObsoleteMessage)]
-    public async Task ExplicitUriPrefixes_TakePrecedence_Over_HostPort()
-    {
-        using var meter = new Meter(MeterName, MeterVersion);
-
-        var port = 0;
-
-        using var context = CreateMeterProvider(meter, configureListener: (options) =>
-        {
-            options.Host = "prometheus.local";
-            options.Port = 9999;
-
-            port = GetRandomPort();
-
-            options.UriPrefixes = [$"http://localhost:{port}"];
-
-            return port;
-        });
-
-        Assert.Equal(port, context.Port);
-        Assert.Equal($"http://localhost:{port}/", context.BaseAddress.ToString());
 
         using var client = new HttpClient { BaseAddress = context.BaseAddress };
         using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
@@ -713,22 +626,6 @@ public class PrometheusHttpListenerTests
             exporter.Dispose();
             throw;
         }
-    }
-
-    [Obsolete("Supports tests for the obsolete UriPrefixes property.")]
-    private static PrometheusHttpListenerOptions TestPrometheusHttpListenerUriPrefixOptions(string[] uriPrefixes)
-    {
-        var options = new PrometheusHttpListenerOptions
-        {
-            UriPrefixes = uriPrefixes,
-        };
-
-        using var exporter = new PrometheusExporter(new());
-        using var listener = new PrometheusHttpListener(
-            exporter,
-            options);
-
-        return options;
     }
 
     internal sealed class MeterProviderTestContext(MeterProvider provider, int port) : IDisposable

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusIntegrationTests.cs
@@ -65,17 +65,13 @@ public class PrometheusIntegrationTests(PromToolFixture fixture, ITestOutputHelp
             {
                 int port = TcpPortProvider.GetOpenPort();
 
+                options.Port = port;
+
                 // On Linux we need to bind to all available hosts to reach the
                 // Prometheus listener from promtool using Docker's internal host.
                 if (OperatingSystem.IsLinux())
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    options.UriPrefixes = [$"http://*:{port}/"];
-#pragma warning restore CS0618 // Type or member is obsolete
-                }
-                else
-                {
-                    options.Port = port;
+                    options.ConfigureHttpListener = static (options, listener) => listener.Prefixes.Add($"http://*:{options.Port}/");
                 }
 
                 return port;


### PR DESCRIPTION
Fixes #7153

## Changes

- Remove the `UriPrefixes` option.
- Add internal `ConfigureHttpListener` property for configuring `HttpListener`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
