### PR TITLE
[Infra] Enable VerifyReferenceAotCompatibility

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -12,7 +12,7 @@
 
   <PropertyGroup Label="TrimAndAotCompatibility" Condition="'$(IsAotCompatible)' == '' AND $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
-    <VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
+    <VerifyReferenceAotCompatibility Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</VerifyReferenceAotCompatibility>
   </PropertyGroup>
 
   <PropertyGroup Label="PackageProperties">

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -12,6 +12,7 @@
 
   <PropertyGroup Label="TrimAndAotCompatibility" Condition="'$(IsAotCompatible)' == '' AND $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
+    <VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
   </PropertyGroup>
 
   <PropertyGroup Label="PackageProperties">


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441#issuecomment-4764935199

## Changes

Enable `VerifyReferenceAotCompatibility=true` for production code when targeting .NET 10+.

~~We may have to condition it to `net10.0`+:~~

> ~~The `IsAotCompatible` assembly metadata was introduced in .NET 10. Libraries that were published targeting earlier versions of .NET won't have this attribute, even if they were built with `<IsAotCompatible>true</IsAotCompatible>`.~~

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
