### PR TITLE
[OTLP] Fix data loss from disk storage on retry

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -15,6 +15,11 @@ Notes](../../RELEASENOTES.md).
 * The library is now marked as trim and AOT compatible.
   ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
 
+* Fixed the OTLP exporter dropping retryable data instead of saving it to disk
+  when persistent storage retry is enabled and an export exceeds the configured
+  timeout.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -18,7 +18,7 @@ Notes](../../RELEASENOTES.md).
 * Fixed the OTLP exporter dropping retryable data instead of saving it to disk
   when persistent storage retry is enabled and an export exceeds the configured
   timeout.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7447](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7447))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpRetry.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpRetry.cs
@@ -59,14 +59,11 @@ internal static class OtlpRetry
         }
         else
         {
-            if (ShouldHandleHttpRequestException(response.Exception))
+            var delay = TimeSpan.FromMilliseconds(GetRandomNumber(0, retryDelayInMilliSeconds));
+            if (!WouldExceedDeadline(response.DeadlineUtc, delay))
             {
-                var delay = TimeSpan.FromMilliseconds(GetRandomNumber(0, retryDelayInMilliSeconds));
-                if (!WouldExceedDeadline(response.DeadlineUtc, delay))
-                {
-                    retryResult = new RetryResult(false, delay, CalculateNextRetryDelay(retryDelayInMilliSeconds));
-                    return true;
-                }
+                retryResult = new RetryResult(false, delay, CalculateNextRetryDelay(retryDelayInMilliSeconds));
+                return true;
             }
 
             retryResult = default;
@@ -74,9 +71,44 @@ internal static class OtlpRetry
         }
     }
 
-#pragma warning disable IDE0060 // Remove unused parameter
-    public static bool ShouldHandleHttpRequestException(Exception? exception) => true; // TODO: Handle specific exceptions.
-#pragma warning restore IDE0060 // Remove unused parameter
+    /// <summary>
+    /// Determines whether a failed gRPC export response represents a transient
+    /// failure that is eligible to be retried, ignoring any deadline.
+    /// </summary>
+    /// <param name="response">The <see cref="ExportClientGrpcResponse" /> to check.</param>
+    /// <returns>
+    /// <returns>
+    /// <see langword="true" /> if the failure is retryable; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsRetryable(ExportClientGrpcResponse response)
+    {
+        if (response.Status == null)
+        {
+            return false;
+        }
+
+        var throttleDelay = GrpcStatusDeserializer.TryGetGrpcRetryDelay(response.GrpcStatusDetailsHeader);
+        return IsGrpcStatusCodeRetryable(response.Status.Value.StatusCode, throttleDelay.HasValue);
+    }
+
+    /// <summary>
+    /// Determines whether a failed HTTP export response represents a transient
+    /// failure that is eligible to be retried, ignoring any deadline.
+    /// </summary>
+    /// <param name="response">The <see cref="ExportClientHttpResponse" /> to check.</param>
+    /// <returns>
+    /// <see langword="true" /> if the failure is retryable; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsRetryable(ExportClientHttpResponse response)
+    {
+        if (response.StatusCode is { } statusCode)
+        {
+            var throttleDelay = TryGetHttpRetryDelay(statusCode, response.Headers);
+            return IsHttpStatusCodeRetryable(statusCode, throttleDelay.HasValue);
+        }
+
+        return true;
+    }
 
     public static bool TryGetGrpcRetryResult(ExportClientGrpcResponse response, int retryDelayMilliseconds, out RetryResult retryResult)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpRetry.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpRetry.cs
@@ -77,8 +77,7 @@ internal static class OtlpRetry
     /// </summary>
     /// <param name="response">The <see cref="ExportClientGrpcResponse" /> to check.</param>
     /// <returns>
-    /// <returns>
-    /// <see langword="true" /> if the failure is retryable; otherwise, <see langword="false" />.
+    /// <see langword="true"/> if the failure is retryable; otherwise, <see langword="false"/>.
     /// </returns>
     public static bool IsRetryable(ExportClientGrpcResponse response)
     {
@@ -95,9 +94,9 @@ internal static class OtlpRetry
     /// Determines whether a failed HTTP export response represents a transient
     /// failure that is eligible to be retried, ignoring any deadline.
     /// </summary>
-    /// <param name="response">The <see cref="ExportClientHttpResponse" /> to check.</param>
+    /// <param name="response">The <see cref="ExportClientHttpResponse"/> to check.</param>
     /// <returns>
-    /// <see langword="true" /> if the failure is retryable; otherwise, <see langword="false" />.
+    /// <see langword="true"/> if the failure is retryable; otherwise, <see langword="false"/>.
     /// </returns>
     public static bool IsRetryable(ExportClientHttpResponse response)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -51,7 +51,11 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
     {
         Debug.Assert(contentLength >= 0 && contentLength <= request.Length, "contentLength was invalid");
 
-        if (!RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out _))
+        // Note: The deadline is intentionally ignored here. The deadline governs
+        // the in-memory retry loop; for persistent storage the request is saved to
+        // disk and retried later on a background thread, so an exceeded deadline
+        // must not cause otherwise-retryable data to be dropped.
+        if (!RetryHelper.ShouldRetryRequest(response))
         {
             return false;
         }
@@ -128,7 +132,13 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
                     if (blob.TryLease((int)this.TimeoutMilliseconds) && blob.TryRead(out var data))
                     {
                         var deadlineUtc = DateTime.UtcNow.AddMilliseconds(this.TimeoutMilliseconds);
-                        if (this.TryRetryRequest(data, data.Length, deadlineUtc, out var response) || !RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out var retryInfo))
+
+                        // Note: The deadline is intentionally ignored when deciding whether to keep
+                        // the blob. A retry attempt that exhausts the deadline should not cause the
+                        // stored data to be deleted if the failure is otherwise retryable; it should
+                        // remain on disk to be retried again later.
+                        if (this.TryRetryRequest(data, data.Length, deadlineUtc, out var response) ||
+                            !RetryHelper.ShouldRetryRequest(response))
                         {
                             blob.TryDelete();
                         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterTransmissionHandler.cs
@@ -26,8 +26,9 @@ internal class OtlpExporterTransmissionHandler : IDisposable
     /// </summary>
     /// <param name="request">The request to send to the server.</param>
     /// <param name="contentLength">length of content.</param>
-    /// <returns> <see langword="true" /> if the request is sent successfully; otherwise, <see
-    /// langword="false" />.
+    /// <returns>
+    /// <see langword="true"/> if the request is sent successfully;
+    /// otherwise, <see langword="false"/>.
     /// </returns>
     public bool TrySubmitRequest(byte[] request, int contentLength)
     {
@@ -51,11 +52,10 @@ internal class OtlpExporterTransmissionHandler : IDisposable
     /// </summary>
     /// <param name="timeoutMilliseconds">
     /// The number (non-negative) of milliseconds to wait, or
-    /// <c>Timeout.Infinite</c> to wait indefinitely.
+    /// <see cref="Timeout.Infinite"/> to wait indefinitely.
     /// </param>
     /// <returns>
-    /// Returns <see langword="true" /> if shutdown succeeded; otherwise, <see
-    /// langword="false" />.
+    /// Returns <see langword="true"/> if shutdown succeeded; otherwise, <see langword="false"/>.
     /// </returns>
     public bool Shutdown(int timeoutMilliseconds)
     {
@@ -97,8 +97,9 @@ internal class OtlpExporterTransmissionHandler : IDisposable
     /// <param name="request">The request that was attempted to send to the server.</param>
     /// <param name="contentLength">Length of content.</param>
     /// <param name="response"><see cref="ExportClientResponse" />.</param>
-    /// <returns><see langword="true" /> If the request is resubmitted and succeeds; otherwise, <see
-    /// langword="false" />.</returns>
+    /// <returns>
+    /// <see langword="true"/> If the request is resubmitted and succeeds; otherwise, <see langword="false"/>.
+    /// </returns>
     protected virtual bool OnSubmitRequestFailure(byte[] request, int contentLength, ExportClientResponse response) => false;
 
     /// <summary>
@@ -108,8 +109,9 @@ internal class OtlpExporterTransmissionHandler : IDisposable
     /// <param name="contentLength">Length of content.</param>
     /// <param name="deadlineUtc">The deadline time in utc for export request to finish.</param>
     /// <param name="response"><see cref="ExportClientResponse" />.</param>
-    /// <returns><see langword="true" /> If the retry succeeds; otherwise, <see
-    /// langword="false" />.</returns>
+    /// <returns>
+    /// <see langword="true"/> If the retry succeeds; otherwise, <see langword="false"/>.
+    /// </returns>
     protected bool TryRetryRequest(byte[] request, int contentLength, DateTime deadlineUtc, out ExportClientResponse response)
     {
         response = this.ExportClient.SendExportRequest(request, contentLength, deadlineUtc);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/RetryHelper.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/RetryHelper.cs
@@ -32,10 +32,10 @@ internal static class RetryHelper
     /// Determines whether a failed export response represents a transient
     /// failure that is eligible to be retried, ignoring any deadline.
     /// </summary>
-    /// <param name="response">The <see cref="ExportClientResponse" /> to check.</param>
+    /// <param name="response">The <see cref="ExportClientResponse"/> to check.</param>
     /// <returns>
-    /// <see langword="true" /> if the failure is retryable;
-    /// otherwise, <see langword="false" />.
+    /// <see langword="true"/> if the failure is retryable;
+    /// otherwise, <see langword="false"/>.
     /// </returns>
     internal static bool ShouldRetryRequest(ExportClientResponse response) => response switch
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/RetryHelper.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/RetryHelper.cs
@@ -27,4 +27,20 @@ internal static class RetryHelper
         retryResult = default;
         return false;
     }
+
+    /// <summary>
+    /// Determines whether a failed export response represents a transient
+    /// failure that is eligible to be retried, ignoring any deadline.
+    /// </summary>
+    /// <param name="response">The <see cref="ExportClientResponse" /> to check.</param>
+    /// <returns>
+    /// <see langword="true" /> if the failure is retryable;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    internal static bool ShouldRetryRequest(ExportClientResponse response) => response switch
+    {
+        ExportClientGrpcResponse grpcResponse => OtlpRetry.IsRetryable(grpcResponse),
+        ExportClientHttpResponse httpResponse => OtlpRetry.IsRetryable(httpResponse),
+        _ => false,
+    };
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
@@ -18,11 +18,7 @@ public class OtlpExporterPersistentStorageTransmissionHandlerTests
         var exportClient = new FailingExportClient();
         var persistentBlobProvider = new CapturingBlobProvider();
 
-        // The timeout must be comfortably larger than OtlpRetry.InitialBackoffMilliseconds (1000ms).
-        // Otherwise the random retry backoff (drawn from [0, InitialBackoffMilliseconds)) can exceed
-        // the remaining deadline budget, in which case the failure is treated as non-retryable, the
-        // request is not persisted, and the test flakes with Assert.True(result) returning False.
-        using var transmissionHandler = new OtlpExporterPersistentStorageTransmissionHandler(persistentBlobProvider, exportClient, timeoutMilliseconds: 100_000);
+        using var transmissionHandler = new OtlpExporterPersistentStorageTransmissionHandler(persistentBlobProvider, exportClient, timeoutMilliseconds: 10_000);
 
         byte[] request = [1, 2, 3, 4, 9, 9, 9];
         var result = transmissionHandler.TrySubmitRequest(request, contentLength: 4);
@@ -32,14 +28,58 @@ public class OtlpExporterPersistentStorageTransmissionHandlerTests
         Assert.Equal([1, 2, 3, 4], persistentBlobProvider.LastBuffer);
     }
 
+    [Fact]
+    public void TrySubmitRequest_PersistsWhenDeadlineAlreadyExceeded()
+    {
+        // Regression test for https://github.com/open-telemetry/opentelemetry-dotnet/issues/7444.
+        // A retryable failure must still be persisted to disk even when the export deadline
+        // has already been exceeded by the time the request fails. Otherwise the data is
+        // dropped instead of being saved for a later retry.
+        var exportClient = new FailingExportClient(deadlineExceeded: true);
+        var persistentBlobProvider = new CapturingBlobProvider();
+
+        using var transmissionHandler = new OtlpExporterPersistentStorageTransmissionHandler(persistentBlobProvider, exportClient, timeoutMilliseconds: 10_000);
+
+        byte[] request = [1, 2, 3, 4, 9, 9, 9];
+        var result = transmissionHandler.TrySubmitRequest(request, contentLength: 4);
+
+        Assert.True(result);
+        Assert.NotNull(persistentBlobProvider.LastBuffer);
+        Assert.Equal([1, 2, 3, 4], persistentBlobProvider.LastBuffer);
+    }
+
+    [Fact]
+    public void TrySubmitRequest_DoesNotPersistNonRetryableFailure()
+    {
+        var exportClient = new FailingExportClient(statusCode: HttpStatusCode.BadRequest);
+        var persistentBlobProvider = new CapturingBlobProvider();
+
+        using var transmissionHandler = new OtlpExporterPersistentStorageTransmissionHandler(persistentBlobProvider, exportClient, timeoutMilliseconds: 10_000);
+
+        byte[] request = [1, 2, 3, 4, 9, 9, 9];
+        var result = transmissionHandler.TrySubmitRequest(request, contentLength: 4);
+
+        Assert.False(result);
+        Assert.Null(persistentBlobProvider.LastBuffer);
+    }
+
     private sealed class FailingExportClient : IExportClient
     {
+        private readonly HttpStatusCode statusCode;
+        private readonly bool deadlineExceeded;
+
+        public FailingExportClient(HttpStatusCode statusCode = HttpStatusCode.ServiceUnavailable, bool deadlineExceeded = false)
+        {
+            this.statusCode = statusCode;
+            this.deadlineExceeded = deadlineExceeded;
+        }
+
         public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default) =>
             new ExportClientHttpResponse(
                 success: false,
-                deadlineUtc: deadlineUtc,
+                deadlineUtc: this.deadlineExceeded ? DateTime.UtcNow.AddMilliseconds(-1) : deadlineUtc,
 #pragma warning disable CA2000 //  Dispose objects before losing scope
-                response: new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+                response: new HttpResponseMessage(this.statusCode),
 #pragma warning restore CA2000 //  Dispose objects before losing scope
                 exception: null);
 


### PR DESCRIPTION
Fixes #7444

## Changes

- Fix data being dropped from disk storage if the retry deadline is exceeded.
- Remove redundant code.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
