### PR TITLE
[Exporter.Prometheus] Fix flaky test

### DIFF
--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -395,6 +395,15 @@ public sealed class PrometheusExporterMiddlewareTests
     [InlineData("1")]
     public async Task PrometheusExporterMiddlewareInvokeAsync_WhenRequestDeadlineExceeded_Returns408(string value)
     {
+        // The scrape timeout is enforced via CancellationTokenSource.CancelAfter, whose
+        // cancellation callback is dispatched on the thread pool. The Collect callback below
+        // blocks a worker thread synchronously, and the middleware only checks the token once
+        // Collect returns. If the pool is saturated (e.g. by sibling tests in CI) the timer
+        // callback can be delayed past that point, leaving the token un-cancelled and producing
+        // a 200 instead of a 408. Guarantee a worker thread is available to run the timer
+        // callback promptly so the timeout is observed deterministically.
+        EnsureThreadPoolWorkerThreadsAvailable();
+
         using var exporter = new PrometheusExporter(new PrometheusExporterOptions());
 
         exporter.Collect = _ =>
@@ -439,6 +448,18 @@ public sealed class PrometheusExporterMiddlewareTests
         await middleware.InvokeAsync(context);
 
         Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+
+    private static void EnsureThreadPoolWorkerThreadsAvailable()
+    {
+        ThreadPool.GetMinThreads(out var workerThreads, out var completionPortThreads);
+
+        var desiredWorkerThreads = Math.Max(workerThreads, Environment.ProcessorCount * 2);
+
+        if (desiredWorkerThreads > workerThreads)
+        {
+            ThreadPool.SetMinThreads(desiredWorkerThreads, completionPortThreads);
+        }
     }
 
     private static async Task RunPrometheusExporterMiddlewareIntegrationTestWithBothFormats(

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -386,6 +386,15 @@ public class PrometheusHttpListenerTests
     [InlineData("1")]
     public async Task WhenRequestDeadlineExceeded_Returns408(string value)
     {
+        // The scrape timeout is enforced via CancellationTokenSource.CancelAfter, whose
+        // cancellation callback is dispatched on the thread pool. The Collect callback below
+        // blocks a worker thread synchronously, and the listener only checks the token once
+        // Collect returns. If the pool is saturated (e.g. by sibling tests in CI) the timer
+        // callback can be delayed past that point, leaving the token un-cancelled and producing
+        // a 200 instead of a 408. Guarantee a worker thread is available to run the timer
+        // callback promptly so the timeout is observed deterministically.
+        EnsureThreadPoolWorkerThreadsAvailable();
+
         using var context = CreateListener();
 
         context.Exporter.Collect = _ =>
@@ -470,6 +479,18 @@ public class PrometheusHttpListenerTests
         }
 
         throw new InvalidOperationException($"{nameof(MeterProvider)} could not be created within {maximumAttempts} attempts.");
+    }
+
+    private static void EnsureThreadPoolWorkerThreadsAvailable()
+    {
+        ThreadPool.GetMinThreads(out var workerThreads, out var completionPortThreads);
+
+        var desiredWorkerThreads = Math.Max(workerThreads, Environment.ProcessorCount * 2);
+
+        if (desiredWorkerThreads > workerThreads)
+        {
+            ThreadPool.SetMinThreads(desiredWorkerThreads, completionPortThreads);
+        }
     }
 
     private static async Task RunPrometheusExporterHttpServerIntegrationTest(


### PR DESCRIPTION
## Changes

Attempt to resolve [flaky test](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/28157778789/job/83390522834#step:7:64) by ensuring the thread pool has enough workers to ensure the request is cancelled and returns the right status code.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
