### PR TITLE
[OpenTelemetry] Use AlternateLookup

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -48,6 +48,10 @@ internal sealed class AggregatorStore
     // tags span, avoiding the copy of the tags into thread-static storage.
     // Only used for cumulative aggregation (the non-reclaim lookup path).
     private readonly ConcurrentDictionary<Tags, int>.AlternateLookup<ReadOnlySpan<KeyValuePair<string, object?>>> tagsToMetricPointIndexLookup;
+
+    // Alternate lookup over the delta-with-reclaim dictionary. Only valid (and
+    // only initialized) when OutputDelta is true.
+    private readonly ConcurrentDictionary<Tags, LookupData>.AlternateLookup<ReadOnlySpan<KeyValuePair<string, object?>>> tagsToMetricPointIndexLookupDelta;
 #endif
 
     private readonly string name;
@@ -130,10 +134,19 @@ internal sealed class AggregatorStore
             this.availableMetricPoints = new Queue<int>(cardinalityLimit);
 
             // There is no overload which only takes capacity as the parameter
-            // Using the DefaultConcurrencyLevel defined in the ConcurrentDictionary class: https://github.com/dotnet/runtime/blob/v7.0.5/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs#L2020
+            // Using the DefaultConcurrencyLevel defined in the ConcurrentDictionary class: https://github.com/dotnet/runtime/blob/v10.0.0/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs#L2054
             // We expect at the most (user provided cardinality limit) * 2 entries- one for sorted and one for unsorted input
-            this.TagsToMetricPointIndexDictionaryDelta =
-                new ConcurrentDictionary<Tags, LookupData>(concurrencyLevel: Environment.ProcessorCount, capacity: cardinalityLimit * 2);
+            var concurrencyLevel = Environment.ProcessorCount;
+            var capacity = cardinalityLimit * 2;
+
+#if NET9_0_OR_GREATER
+            this.TagsToMetricPointIndexDictionaryDelta = new(concurrencyLevel, capacity, comparer: TagsComparer.Instance);
+
+            this.tagsToMetricPointIndexLookupDelta =
+                this.TagsToMetricPointIndexDictionaryDelta.GetAlternateLookup<ReadOnlySpan<KeyValuePair<string, object?>>>();
+#else
+            this.TagsToMetricPointIndexDictionaryDelta = new(concurrencyLevel, capacity);
+#endif
 
             // Add all the indices except for the reserved ones to the queue so that threads have
             // readily available access to these MetricPoints for their use.
@@ -701,57 +714,69 @@ internal sealed class AggregatorStore
 
         // If the running thread created a new MetricPoint, then the Snapshot method cannot reclaim that MetricPoint because MetricPoint is initialized with a ReferenceCount of 1.
         // It can simply return the index.
-
         if (!newMetricPointCreated)
         {
-            // If the running thread did not create the MetricPoint, it could be working on an index that has been reclaimed by Snapshot method.
-            // This could happen if the thread get switched out by CPU after it retrieves the index but the Snapshot method reclaims it before the thread wakes up again.
+            index = this.ResolveExistingDeltaMetricPoint(lookupData, length);
+        }
 
-            ref var metricPointAtIndex = ref this.metricPoints[index];
-            var referenceCount = Interlocked.Increment(ref metricPointAtIndex.ReferenceCount);
+        return index;
+    }
 
-            if (referenceCount < 0)
-            {
-                // Rare case: Snapshot method had already marked the MetricPoint available for reuse as it has not been updated in last collect cycle.
+    // Increments the ReferenceCount for an existing (not newly created) delta MetricPoint
+    // resolved from the dictionary and validates that it is still the right one, retrying
+    // via the rare path if the Snapshot method reclaimed it in the meantime.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int ResolveExistingDeltaMetricPoint(LookupData lookupData, int length)
+    {
+        var index = lookupData.Index;
 
-                // Example scenario:
-                // Thread T1 wants to record a measurement for (k1,v1).
-                // Thread T1 creates a new MetricPoint at index 100 and adds an entry for (k1,v1) in the dictionary with the relevant LookupData value; ReferenceCount of the MetricPoint is 1 at this point.
-                // Thread T1 completes the update and decrements the ReferenceCount to 0.
-                // Later, another update thread (could be T1 as well) wants to record a measurement for (k1,v1)
-                // It looks up the dictionary and retrieves the index as 100. ReferenceCount for the MetricPoint is 0 at this point.
-                // This update thread gets switched out by the CPU.
-                // With the reclaim behavior, Snapshot method reclaims the index 100 as the MetricPoint for the index has NoCollectPending and has a ReferenceCount of 0.
-                // Snapshot thread sets the ReferenceCount to int.MinValue.
-                // The update thread wakes up and increments the ReferenceCount but finds the value to be negative.
+        // If the running thread did not create the MetricPoint, it could be working on an index that has been reclaimed by Snapshot method.
+        // This could happen if the thread get switched out by CPU after it retrieves the index but the Snapshot method reclaims it before the thread wakes up again.
 
-                // Retry attempt to get a MetricPoint.
-                index = this.RemoveStaleEntriesAndGetAvailableMetricPointRare(lookupData, length);
-            }
-            else if (metricPointAtIndex.LookupData != lookupData)
-            {
-                // Rare case: Another thread with different input tags could have reclaimed this MetricPoint if it was freed up by Snapshot method.
+        ref var metricPointAtIndex = ref this.metricPoints[index];
+        var referenceCount = Interlocked.Increment(ref metricPointAtIndex.ReferenceCount);
 
-                // Example scenario:
-                // Thread T1 wants to record a measurement for (k1,v1).
-                // Thread T1 creates a new MetricPoint at index 100 and adds an entry for (k1,v1) in the dictionary with the relevant LookupData value; ReferenceCount of the MetricPoint is 1 at this point.
-                // Thread T1 completes the update and decrements the ReferenceCount to 0.
-                // Later, another update thread T2 (could be T1 as well) wants to record a measurement for (k1,v1)
-                // It looks up the dictionary and retrieves the index as 100. ReferenceCount for the MetricPoint is 0 at this point.
-                // This update thread T2 gets switched out by the CPU.
-                // With the reclaim behavior, Snapshot method reclaims the index 100 as the MetricPoint for the index has NoCollectPending and has a ReferenceCount of 0.
-                // Snapshot thread sets the ReferenceCount to int.MinValue.
-                // An update thread T3 wants to record a measurement for (k2,v2).
-                // Thread T3 looks for an available index from the queue and finds index 100.
-                // Thread T3 creates a new MetricPoint at index 100 and adds an entry for (k2,v2) in the dictionary with the LookupData value for (k2,v2). ReferenceCount of the MetricPoint is 1 at this point.
-                // The update thread T2 wakes up and increments the ReferenceCount and finds the value to be positive but the LookupData value does not match the one for (k1,v1).
+        if (referenceCount < 0)
+        {
+            // Rare case: Snapshot method had already marked the MetricPoint available for reuse as it has not been updated in last collect cycle.
 
-                // Remove reference since its not the right MetricPoint.
-                Interlocked.Decrement(ref metricPointAtIndex.ReferenceCount);
+            // Example scenario:
+            // Thread T1 wants to record a measurement for (k1,v1).
+            // Thread T1 creates a new MetricPoint at index 100 and adds an entry for (k1,v1) in the dictionary with the relevant LookupData value; ReferenceCount of the MetricPoint is 1 at this point.
+            // Thread T1 completes the update and decrements the ReferenceCount to 0.
+            // Later, another update thread (could be T1 as well) wants to record a measurement for (k1,v1)
+            // It looks up the dictionary and retrieves the index as 100. ReferenceCount for the MetricPoint is 0 at this point.
+            // This update thread gets switched out by the CPU.
+            // With the reclaim behavior, Snapshot method reclaims the index 100 as the MetricPoint for the index has NoCollectPending and has a ReferenceCount of 0.
+            // Snapshot thread sets the ReferenceCount to int.MinValue.
+            // The update thread wakes up and increments the ReferenceCount but finds the value to be negative.
 
-                // Retry attempt to get a MetricPoint.
-                index = this.RemoveStaleEntriesAndGetAvailableMetricPointRare(lookupData, length);
-            }
+            // Retry attempt to get a MetricPoint.
+            index = this.RemoveStaleEntriesAndGetAvailableMetricPointRare(lookupData, length);
+        }
+        else if (metricPointAtIndex.LookupData != lookupData)
+        {
+            // Rare case: Another thread with different input tags could have reclaimed this MetricPoint if it was freed up by Snapshot method.
+
+            // Example scenario:
+            // Thread T1 wants to record a measurement for (k1,v1).
+            // Thread T1 creates a new MetricPoint at index 100 and adds an entry for (k1,v1) in the dictionary with the relevant LookupData value; ReferenceCount of the MetricPoint is 1 at this point.
+            // Thread T1 completes the update and decrements the ReferenceCount to 0.
+            // Later, another update thread T2 (could be T1 as well) wants to record a measurement for (k1,v1)
+            // It looks up the dictionary and retrieves the index as 100. ReferenceCount for the MetricPoint is 0 at this point.
+            // This update thread T2 gets switched out by the CPU.
+            // With the reclaim behavior, Snapshot method reclaims the index 100 as the MetricPoint for the index has NoCollectPending and has a ReferenceCount of 0.
+            // Snapshot thread sets the ReferenceCount to int.MinValue.
+            // An update thread T3 wants to record a measurement for (k2,v2).
+            // Thread T3 looks for an available index from the queue and finds index 100.
+            // Thread T3 creates a new MetricPoint at index 100 and adds an entry for (k2,v2) in the dictionary with the LookupData value for (k2,v2). ReferenceCount of the MetricPoint is 1 at this point.
+            // The update thread T2 wakes up and increments the ReferenceCount and finds the value to be positive but the LookupData value does not match the one for (k1,v1).
+
+            // Remove reference since its not the right MetricPoint.
+            Interlocked.Decrement(ref metricPointAtIndex.ReferenceCount);
+
+            // Retry attempt to get a MetricPoint.
+            index = this.RemoveStaleEntriesAndGetAvailableMetricPointRare(lookupData, length);
         }
 
         return index;
@@ -1050,14 +1075,23 @@ internal sealed class AggregatorStore
         }
 
 #if NET9_0_OR_GREATER
-        // Fast path: for cumulative aggregation, look up an existing MetricPoint
-        // directly from the incoming tags span. The dictionary stores keys in the
-        // given (unsorted) order too, so a previously-seen tag set in its original
-        // order resolves here without copying the tags into thread-static storage,
-        // constructing a Tags key, or sorting. Misses (new tag sets) and the
-        // delta-with-reclaim path fall through to the slower copy-and-add path below.
-        if (!this.OutputDelta
-            && this.tagsToMetricPointIndexLookup.TryGetValue(tags, out var existingIndex))
+        // Fast path: look up an existing MetricPoint directly from the incoming
+        // tags span. The dictionary stores keys in the given (unsorted) order too,
+        // so a previously-seen tag set in its original order resolves here without
+        // copying the tags into thread-static storage, constructing a Tags key, or
+        // sorting. Misses (new tag sets) fall through to the slower copy-and-add
+        // path below.
+        if (this.OutputDelta)
+        {
+            // For delta-with-reclaim a hit must still run the ReferenceCount
+            // bookkeeping (and possible reclaim retry), so resolve via the shared
+            // helper rather than returning the index directly.
+            if (this.tagsToMetricPointIndexLookupDelta.TryGetValue(tags, out var lookupData))
+            {
+                return this.ResolveExistingDeltaMetricPoint(lookupData, tagLength);
+            }
+        }
+        else if (this.tagsToMetricPointIndexLookup.TryGetValue(tags, out var existingIndex))
         {
             return existingIndex;
         }

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -37,7 +37,18 @@ internal sealed class AggregatorStore
     private readonly Queue<int>? availableMetricPoints;
 
     private readonly ConcurrentDictionary<Tags, int> tagsToMetricPointIndexDictionary =
+#if NET9_0_OR_GREATER
+        new(TagsComparer.Instance);
+#else
         new();
+#endif
+
+#if NET9_0_OR_GREATER
+    // Alternate lookup that resolves a MetricPoint directly from the incoming
+    // tags span, avoiding the copy of the tags into thread-static storage.
+    // Only used for cumulative aggregation (the non-reclaim lookup path).
+    private readonly ConcurrentDictionary<Tags, int>.AlternateLookup<ReadOnlySpan<KeyValuePair<string, object?>>> tagsToMetricPointIndexLookup;
+#endif
 
     private readonly string name;
     private readonly MetricPoint[] metricPoints;
@@ -107,6 +118,11 @@ internal sealed class AggregatorStore
         // Setting metricPointIndex to 1 as we would reserve the metricPoints[1] for overflow attribute.
         // Newer attributes should be added starting at the index: 2
         this.metricPointIndex = 1;
+
+#if NET9_0_OR_GREATER
+        this.tagsToMetricPointIndexLookup =
+            this.tagsToMetricPointIndexDictionary.GetAlternateLookup<ReadOnlySpan<KeyValuePair<string, object?>>>();
+#endif
 
         // Always reclaim unused MetricPoints for Delta aggregation temporality
         if (this.OutputDelta)
@@ -1032,6 +1048,20 @@ internal sealed class AggregatorStore
             this.InitializeZeroTagPointIfNotInitialized();
             return 0;
         }
+
+#if NET9_0_OR_GREATER
+        // Fast path: for cumulative aggregation, look up an existing MetricPoint
+        // directly from the incoming tags span. The dictionary stores keys in the
+        // given (unsorted) order too, so a previously-seen tag set in its original
+        // order resolves here without copying the tags into thread-static storage,
+        // constructing a Tags key, or sorting. Misses (new tag sets) and the
+        // delta-with-reclaim path fall through to the slower copy-and-add path below.
+        if (!this.OutputDelta
+            && this.tagsToMetricPointIndexLookup.TryGetValue(tags, out var existingIndex))
+        {
+            return existingIndex;
+        }
+#endif
 
         var storage = ThreadStaticStorage.GetStorage();
 

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Metrics;
@@ -37,14 +36,58 @@ internal readonly struct Tags : IEquatable<Tags>
             return true;
         }
 
-        var length = ourKvps.Length;
-
-        if (length != theirKvps.Length)
+        if (this.hashCode != other.hashCode)
         {
             return false;
         }
 
-        if (this.hashCode != other.hashCode)
+        return SequenceEqual(ourKvps, theirKvps);
+    }
+
+    public readonly bool Equals(ReadOnlySpan<KeyValuePair<string, object?>> other)
+        => SequenceEqual(this.KeyValuePairs, other);
+
+    public override readonly int GetHashCode() => this.hashCode;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int ComputeHashCode(ReadOnlySpan<KeyValuePair<string, object?>> keyValuePairs)
+    {
+#if NET || NETSTANDARD2_1_OR_GREATER
+        HashCode hashCode = default;
+
+        for (var i = 0; i < keyValuePairs.Length; i++)
+        {
+            ref readonly var item = ref keyValuePairs[i];
+            hashCode.Add(item.Key.GetHashCode(StringComparison.Ordinal));
+            hashCode.Add(item.Value);
+        }
+
+        return hashCode.ToHashCode();
+#else
+        var hash = 17;
+
+        for (var i = 0; i < keyValuePairs.Length; i++)
+        {
+            ref readonly var item = ref keyValuePairs[i];
+            unchecked
+            {
+                hash = (hash * 31) + item.Key.GetHashCode();
+                hash = (hash * 31) + (item.Value?.GetHashCode() ?? 0);
+            }
+        }
+
+        return hash;
+#endif
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool SequenceEqual(
+        ReadOnlySpan<KeyValuePair<string, object?>> ourKvps,
+        ReadOnlySpan<KeyValuePair<string, object?>> theirKvps)
+    {
+        var length = ourKvps.Length;
+
+        if (length != theirKvps.Length)
         {
             return false;
         }
@@ -118,41 +161,6 @@ internal readonly struct Tags : IEquatable<Tags>
 
                 return true;
         }
-    }
-
-    public override readonly int GetHashCode() => this.hashCode;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ComputeHashCode(KeyValuePair<string, object?>[] keyValuePairs)
-    {
-        Debug.Assert(keyValuePairs != null, "keyValuePairs was null");
-
-#if NET || NETSTANDARD2_1_OR_GREATER
-        HashCode hashCode = default;
-
-        for (var i = 0; i < keyValuePairs.Length; i++)
-        {
-            ref var item = ref keyValuePairs[i];
-            hashCode.Add(item.Key.GetHashCode(StringComparison.Ordinal));
-            hashCode.Add(item.Value);
-        }
-
-        return hashCode.ToHashCode();
-#else
-        var hash = 17;
-
-        for (var i = 0; i < keyValuePairs!.Length; i++)
-        {
-            ref var item = ref keyValuePairs[i];
-            unchecked
-            {
-                hash = (hash * 31) + item.Key.GetHashCode();
-                hash = (hash * 31) + (item.Value?.GetHashCode() ?? 0);
-            }
-        }
-
-        return hash;
-#endif
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Metrics/TagsComparer.cs
+++ b/src/OpenTelemetry/Metrics/TagsComparer.cs
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Equality comparer for <see cref="Tags"/>.
+/// </summary>
+internal sealed class TagsComparer :
+#if NET9_0_OR_GREATER
+    IAlternateEqualityComparer<ReadOnlySpan<KeyValuePair<string, object?>>, Tags>,
+#endif
+    IEqualityComparer<Tags>
+{
+    public static readonly TagsComparer Instance = new();
+
+    public bool Equals(Tags x, Tags y) => x.Equals(y);
+
+    public int GetHashCode(Tags obj) => obj.GetHashCode();
+
+#if NET9_0_OR_GREATER
+    public bool Equals(ReadOnlySpan<KeyValuePair<string, object?>> alternate, Tags other)
+        => other.Equals(alternate);
+
+    public int GetHashCode(ReadOnlySpan<KeyValuePair<string, object?>> alternate)
+        => Tags.ComputeHashCode(alternate);
+
+    public Tags Create(ReadOnlySpan<KeyValuePair<string, object?>> alternate)
+        => new(alternate.ToArray());
+#endif
+}

--- a/test/OpenTelemetry.Tests/Metrics/TagsComparerTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/TagsComparerTests.cs
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET9_0_OR_GREATER
+using System.Collections.Concurrent;
+#endif
+
+namespace OpenTelemetry.Metrics.Tests;
+
+public class TagsComparerTests
+{
+    [Fact]
+    public void Equals_And_GetHashCode_DelegateToTags()
+    {
+        var comparer = TagsComparer.Instance;
+
+        var tags1 = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        var tags2 = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        var different = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 456),
+        ]);
+
+        Assert.True(comparer.Equals(tags1, tags2));
+        Assert.Equal(comparer.GetHashCode(tags1), comparer.GetHashCode(tags2));
+        Assert.False(comparer.Equals(tags1, different));
+    }
+
+#if NET9_0_OR_GREATER
+    [Fact]
+    public void AlternateGetHashCode_Span_MatchesTagsHashCode()
+    {
+        var comparer = TagsComparer.Instance;
+
+        var tags = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        ReadOnlySpan<KeyValuePair<string, object?>> span =
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ];
+
+        Assert.Equal(tags.GetHashCode(), comparer.GetHashCode(span));
+    }
+
+    [Fact]
+    public void AlternateEquals_Span_MatchesContent()
+    {
+        var comparer = TagsComparer.Instance;
+
+        var tags = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        ReadOnlySpan<KeyValuePair<string, object?>> equal =
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ];
+
+        ReadOnlySpan<KeyValuePair<string, object?>> different =
+        [
+            new("key1", "value1"),
+            new("key2", 456),
+        ];
+
+        Assert.True(comparer.Equals(equal, tags));
+        Assert.False(comparer.Equals(different, tags));
+    }
+
+    [Fact]
+    public void Create_Span_ProducesEqualTags()
+    {
+        var comparer = TagsComparer.Instance;
+
+        ReadOnlySpan<KeyValuePair<string, object?>> span =
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ];
+
+        var created = comparer.Create(span);
+
+        var expected = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        Assert.True(created.Equals(expected));
+        Assert.Equal(expected.GetHashCode(), created.GetHashCode());
+    }
+
+    [Fact]
+    public void AlternateLookup_ResolvesEntryAddedAsTags()
+    {
+        // End-to-end: a ConcurrentDictionary keyed by Tags (using TagsComparer)
+        // must resolve a lookup performed with a tags span, mirroring how the
+        // metrics hot path resolves an existing MetricPoint.
+        var dictionary = new ConcurrentDictionary<Tags, int>(TagsComparer.Instance);
+
+        var key = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        dictionary[key] = 42;
+
+        var lookup = dictionary.GetAlternateLookup<ReadOnlySpan<KeyValuePair<string, object?>>>();
+
+        // A different backing array with identical contents must hit.
+        ReadOnlySpan<KeyValuePair<string, object?>> probe =
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ];
+
+        Assert.True(lookup.TryGetValue(probe, out var value));
+        Assert.Equal(42, value);
+
+        ReadOnlySpan<KeyValuePair<string, object?>> miss =
+        [
+            new("key1", "value1"),
+        ];
+
+        Assert.False(lookup.TryGetValue(miss, out _));
+    }
+#endif
+}

--- a/test/OpenTelemetry.Tests/Metrics/TagsTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/TagsTests.cs
@@ -59,4 +59,79 @@ public class TagsTests
 
         Assert.False(tag1.Equals(tag2));
     }
+
+    [Fact]
+    public void Equals_Span_ReturnsTrue_ForEqualContents()
+    {
+        var tags = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        // A different backing array with identical contents must be equal.
+        ReadOnlySpan<KeyValuePair<string, object?>> span =
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ];
+
+        Assert.True(tags.Equals(span));
+    }
+
+    [Fact]
+    public void Equals_Span_ReturnsFalse_ForDifferentValues()
+    {
+        var tags = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        ReadOnlySpan<KeyValuePair<string, object?>> span =
+        [
+            new("key1", "value1"),
+            new("key2", 456),
+        ];
+
+        Assert.False(tags.Equals(span));
+    }
+
+    [Fact]
+    public void Equals_Span_ReturnsFalse_ForDifferentLengths()
+    {
+        var tags = new Tags(
+        [
+            new("key1", "value1"),
+        ]);
+
+        ReadOnlySpan<KeyValuePair<string, object?>> span =
+        [
+            new("key1", "value1"),
+            new("key2", "value2"),
+        ];
+
+        Assert.False(tags.Equals(span));
+    }
+
+    [Fact]
+    public void ComputeHashCode_Span_MatchesInstanceHashCode()
+    {
+        // The span-based hash must exactly match the hash of an equivalent Tags
+        // instance; otherwise the metrics alternate lookup would silently miss
+        // and fall back to the slower path.
+        var tags = new Tags(
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ]);
+
+        ReadOnlySpan<KeyValuePair<string, object?>> span =
+        [
+            new("key1", "value1"),
+            new("key2", 123),
+        ];
+
+        Assert.Equal(tags.GetHashCode(), Tags.ComputeHashCode(span));
+    }
 }


### PR DESCRIPTION
Fixes #5777

## Changes

Optimize metrics tag using alternate lookup when targeting .NET 9+.

## Benchmarks

I got Claude to write a throwaway benchmark (I don't think it's worth committing as it's very focussed on this exact change). Claude's summary plus the benchmark's code are below.

### Summary

Avoids copying the incoming tags `ReadOnlySpan` into thread-static storage on the metrics hot path by looking the metric point up directly from the span via `ConcurrentDictionary.GetAlternateLookup` (net9.0+). Applies to both cumulative and the delta-with-reclaim lookup paths.

#### Benchmark: branch vs `main` baseline (`net10.0`)

`MetricsLookupBenchmarks.CounterHotPathExistingSeries` — recording into an already-existing time series (the steady-state lookup-hit path). Both runs executed on the same machine, sequentially, default job, `MemoryDiagnoser` enabled.

| Labels | Temporality | main (baseline) | branch (optimized) | Δ | Speed-up |
|---:|---|---:|---:|---:|---:|
| 1 | Cumulative | 35.01 ns | 23.65 ns | −11.4 ns | 32% |
| 2 | Cumulative | 49.55 ns | 36.39 ns | −13.2 ns | 27% |
| 3 | Cumulative | 67.01 ns | 44.99 ns | −22.0 ns | 33% |
| 5 | Cumulative | 82.87 ns | 64.73 ns | −18.1 ns | 22% |
| 7 | Cumulative | 110.20 ns | 84.28 ns | −25.9 ns | 24% |
| 1 | Delta | 46.49 ns | 30.23 ns | −16.3 ns | 35% |
| 2 | Delta | 62.51 ns | 43.41 ns | −19.1 ns | 31% |
| 3 | Delta | 87.72 ns | 53.50 ns | −34.2 ns | 39% |
| 5 | Delta | 115.56 ns | 73.52 ns | −42.0 ns | 36% |
| 7 | Delta | 153.14 ns | 93.50 ns | −59.6 ns | 39% |

**Allocated: `-` (zero) on both sides in every case** — the optimization is pure CPU; the hit path was already allocation-free (thread-static reuse), so this removes the per-tag array copy, not allocations.

#### Takeaways

- Consistent **~22–39% faster** on the lookup-hit hot path across tag counts and both temporalities.
- **Delta benefits more than Cumulative** (~31–39% vs ~22–33%): delta's baseline does the thread-static copy *plus* wraps a throwaway `Tags` and resolves `LookupData`, so skipping the copy is proportionally bigger; absolute savings reach −60 ns at 7 tags.
- Gains scale with label count, confirming the win is the avoided per-tag array copy (`SplitToKeysAndValues`).

#### Notes

- Only the lookup-**hit** path is changed; the miss/creation path is unchanged by design.
- Single-machine, single-run measurements — treat the percentages as solid directional evidence rather than ±1 ns precision.

#### Code

<details>

<summary>Expand to view</summary>

```csharp
// Copyright The OpenTelemetry Authors
// SPDX-License-Identifier: Apache-2.0

using System.Diagnostics.Metrics;
using BenchmarkDotNet.Attributes;
using OpenTelemetry;
using OpenTelemetry.Metrics;
using OpenTelemetry.Tests;

/*
This benchmark isolates the metrics lookup hot path for issue #5777.

It records measurements whose tag sets have already been seen (the common
steady-state), so every Add resolves to an existing MetricPoint. On .NET 9.0+
this exercises the ConcurrentDictionary alternate lookup that resolves the
MetricPoint directly from the incoming tags span (for both Cumulative and
Delta temporality), avoiding the copy of the tags into thread-static storage
and the construction of a Tags key.

Run on `main` and on the branch to compare.
*/

namespace Benchmarks.Metrics;

[MemoryDiagnoser]
#pragma warning disable CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
public class MetricsLookupBenchmarks
#pragma warning restore CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
{
    private readonly string[] dimensionValues = ["Value1", "Value2", "Value3", "Value4", "Value5"];
    private Counter<long>? counter;
    private MeterProvider? meterProvider;
    private Meter? meter;
    private KeyValuePair<string, object?>[]? tags;

    [Params(1, 2, 3, 5, 7)]
    public int LabelsCount { get; set; }

    [Params(MetricReaderTemporalityPreference.Cumulative, MetricReaderTemporalityPreference.Delta)]
    public MetricReaderTemporalityPreference AggregationTemporality { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        this.meter = new Meter(Utils.GetCurrentMethodName());

        var exportedItems = new List<Metric>();
        this.meterProvider = Sdk.CreateMeterProviderBuilder()
            .AddMeter(this.meter.Name)
            .AddInMemoryExporter(exportedItems, metricReaderOptions =>
            {
                metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 1000;
                metricReaderOptions.TemporalityPreference = this.AggregationTemporality;
            })
            .Build();

        this.counter = this.meter.CreateCounter<long>("counter");

        // A single, fixed tag set so every recorded measurement hits an
        // existing MetricPoint (the lookup-hit fast path).
        this.tags = new KeyValuePair<string, object?>[this.LabelsCount];
        for (var i = 0; i < this.LabelsCount; i++)
        {
            this.tags[i] = new KeyValuePair<string, object?>($"DimName{i + 1}", this.dimensionValues[i % this.dimensionValues.Length]);
        }

        // Prime the time series so the first measured Add already resolves to
        // an existing MetricPoint.
        this.counter.Add(1, this.tags);
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        this.meter?.Dispose();
        this.meterProvider?.Dispose();
    }

    [Benchmark]
    public void CounterHotPathExistingSeries()
    {
        this.counter!.Add(100, this.tags!);
    }
}
```

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
