### PR TITLE
[OpenTelemetry] Support Schema URL for resources

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -10,7 +10,7 @@ Notes](../../RELEASENOTES.md).
   ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
 
 * The `Resource` Schema URL is now printed alongside the resource attributes.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7472](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7472))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -9,6 +9,9 @@ Notes](../../RELEASENOTES.md).
 * The library is now marked as trim and AOT compatible.
   ([#7441](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7441))
 
+* The `Resource` Schema URL is now printed alongside the resource attributes.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -146,6 +146,11 @@ public class ConsoleActivityExporter : ConsoleExporter<Activity>
                         this.WriteLine($"    {result.Key}: {result.Value}");
                     }
                 }
+
+                if (!string.IsNullOrEmpty(resource.SchemaUrl))
+                {
+                    this.WriteLine($"    Schema URL: {resource.SchemaUrl}");
+                }
             }
 
             this.WriteLine(string.Empty);

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -148,6 +148,11 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
                         this.WriteLine($"{result.Key}: {result.Value}");
                     }
                 }
+
+                if (!string.IsNullOrEmpty(resource.SchemaUrl))
+                {
+                    this.WriteLine($"Schema URL: {resource.SchemaUrl}");
+                }
             }
 
             this.WriteLine(string.Empty);

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -29,6 +29,11 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                     this.WriteLine($"\t{result.Key}: {result.Value}");
                 }
             }
+
+            if (!string.IsNullOrEmpty(resource.SchemaUrl))
+            {
+                this.WriteLine($"\tSchema URL: {resource.SchemaUrl}");
+            }
         }
 
         foreach (var metric in batch)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -32,7 +32,7 @@ Notes](../../RELEASENOTES.md).
 
 * The `Resource` Schema URL is now exported on the OTLP `ResourceSpans`,
   `ResourceMetrics`, and `ResourceLogs` messages.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7472](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7472))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -30,6 +30,10 @@ Notes](../../RELEASENOTES.md).
 * Fixed the OTLP/gRPC exporter logging incorrectly when an export timed out.
   ([#7455](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7455))
 
+* The `Resource` Schema URL is now exported on the OTLP `ResourceSpans`,
+  `ResourceMetrics`, and `ResourceLogs` messages.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -120,6 +120,12 @@ internal static class ProtobufOtlpLogSerializer
     {
         writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, writePosition, resource);
         writePosition = WriteScopeLogs(buffer, writePosition, sdkLimitOptions, experimentalOptions, scopeLogs);
+
+        if (resource?.SchemaUrl is { Length: > 0 } schemaUrl)
+        {
+            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.ResourceLogs_Schema_Url, schemaUrl);
+        }
+
         return writePosition;
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
@@ -95,6 +95,11 @@ internal static class ProtobufOtlpMetricSerializer
         writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, writePosition, resource);
         writePosition = WriteScopeMetrics(buffer, writePosition, scopeMetrics);
 
+        if (resource?.SchemaUrl is { Length: > 0 } schemaUrl)
+        {
+            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ResourceMetrics_Schema_Url, schemaUrl);
+        }
+
         return writePosition;
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -98,6 +98,11 @@ internal static class ProtobufOtlpTraceSerializer
         writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, writePosition, resource);
         writePosition = WriteScopeSpans(buffer, writePosition, sdkLimitOptions);
 
+        if (resource?.SchemaUrl is { Length: > 0 } schemaUrl)
+        {
+            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Schema_Url, schemaUrl);
+        }
+
         return writePosition;
     }
 

--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+OpenTelemetry.Resources.Resource.Resource(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object!>>! attributes, string? schemaUrl) -> void
+OpenTelemetry.Resources.Resource.SchemaUrl.get -> string?
+static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this OpenTelemetry.Resources.ResourceBuilder! resourceBuilder, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object!>>! attributes, string? schemaUrl) -> OpenTelemetry.Resources.ResourceBuilder!

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -24,6 +24,9 @@ Notes](../../RELEASENOTES.md).
   recorded.
   ([#7427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7427))
 
+* Added support for a Schema URL on `Resource` instances.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -25,7 +25,7 @@ Notes](../../RELEASENOTES.md).
   ([#7427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7427))
 
 * Added support for a Schema URL on `Resource` instances.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7472](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7472))
 
 ## 1.16.0
 

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -344,7 +344,7 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource, IConfigurationE
     public void ActivityDroppedDueToUnsampledLocalParent(string activityName, string activitySourceName)
         => this.WriteEvent(58, activityName, activitySourceName);
 
-    [Event(59, Message = "Resource merge encountered conflicting Schema URLs: old = '{0}', updating = '{1}'. The updating Schema URL will be used for the merged resource.", Level = EventLevel.Warning)]
+    [Event(59, Message = "Resource merge encountered conflicting Schema URLs: old = '{0}', updating = '{1}'. No Schema URL will be used for the merged resource.", Level = EventLevel.Warning)]
     public void ResourceSchemaUrlMergeConflict(string oldSchemaUrl, string updatingSchemaUrl)
         => this.WriteEvent(59, oldSchemaUrl, updatingSchemaUrl);
 

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -344,6 +344,10 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource, IConfigurationE
     public void ActivityDroppedDueToUnsampledLocalParent(string activityName, string activitySourceName)
         => this.WriteEvent(58, activityName, activitySourceName);
 
+    [Event(59, Message = "Resource merge encountered conflicting Schema URLs: old = '{0}', updating = '{1}'. The updating Schema URL will be used for the merged resource.", Level = EventLevel.Warning)]
+    public void ResourceSchemaUrlMergeConflict(string oldSchemaUrl, string updatingSchemaUrl)
+        => this.WriteEvent(59, oldSchemaUrl, updatingSchemaUrl);
+
     void IConfigurationExtensionsLogger.LogInvalidConfigurationValue(string key, string value)
         => this.InvalidConfigurationValue(key, value);
 

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -20,7 +20,21 @@ public class Resource
     /// </summary>
     /// <param name="attributes">An <see cref="IEnumerable{T}"/> of attributes that describe the resource.</param>
     public Resource(IEnumerable<KeyValuePair<string, object>> attributes)
+        : this(attributes, schemaUrl: null)
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Resource"/> class.
+    /// </summary>
+    /// <param name="attributes">An <see cref="IEnumerable{T}"/> of attributes that describe the resource.</param>
+    /// <param name="schemaUrl">The Schema URL (semantic conventions URL) that applies to the resource, or <see langword="null"/> if the resource has no Schema URL.</param>
+#pragma warning disable CA1054 // Change the type of parameter from 'string' to 'System.Uri'
+    public Resource(IEnumerable<KeyValuePair<string, object>> attributes, string? schemaUrl)
+#pragma warning restore CA1054 // Change the type of parameter from 'string' to 'System.Uri'
+    {
+        this.SchemaUrl = string.IsNullOrEmpty(schemaUrl) ? null : schemaUrl;
+
         if (attributes == null)
         {
             OpenTelemetrySdkEventSource.Log.InvalidArgument("Create resource", "attributes", "are null");
@@ -41,6 +55,13 @@ public class Resource
     /// Gets the collection of key-value pairs describing the resource.
     /// </summary>
     public IEnumerable<KeyValuePair<string, object>> Attributes { get; }
+
+#pragma warning disable CA1056 // Change the type of property from 'string' to 'System.Uri'
+    /// <summary>
+    /// Gets the Schema URL (semantic conventions URL) that applies to the resource, or <see langword="null"/> if the resource has no Schema URL.
+    /// </summary>
+    public string? SchemaUrl { get; }
+#pragma warning restore CA1056 // Change the type of property from 'string' to 'System.Uri'
 
     /// <summary>
     /// Returns a new, merged <see cref="Resource"/> by merging the old <see cref="Resource"/> with the
@@ -71,7 +92,38 @@ public class Resource
             }
         }
 
-        return new Resource(newAttributes);
+        return new Resource(newAttributes, MergeSchemaUrl(this.SchemaUrl, other?.SchemaUrl));
+    }
+
+    // Implements the Schema URL merge logic from
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#merge
+    // where "this" is the old resource and "other" is the updating resource.
+    private static string? MergeSchemaUrl(string? oldSchemaUrl, string? updatingSchemaUrl)
+    {
+        // If the old resource's Schema URL is empty then the result is the updating resource's Schema URL.
+        if (oldSchemaUrl is not { Length: > 0 })
+        {
+            return updatingSchemaUrl;
+        }
+
+        // Else if the updating resource's Schema URL is empty then the result is the old resource's Schema URL.
+        if (updatingSchemaUrl is not { Length: > 0 })
+        {
+            return oldSchemaUrl;
+        }
+
+        // Else if the Schema URLs are the same then that is the result.
+        if (string.Equals(oldSchemaUrl, updatingSchemaUrl, StringComparison.Ordinal))
+        {
+            return oldSchemaUrl;
+        }
+
+        // Else this is a merging error: the Schema URLs are both non-empty and different. The spec leaves the
+        // result undefined; we log a warning and use the updating resource's Schema URL, consistent with the
+        // attribute merge precedence where the updating ("other") resource takes precedence.
+        OpenTelemetrySdkEventSource.Log.ResourceSchemaUrlMergeConflict(oldSchemaUrl, updatingSchemaUrl);
+
+        return updatingSchemaUrl;
     }
 
     private static KeyValuePair<string, object> SanitizeAttribute(KeyValuePair<string, object> attribute)

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -119,11 +119,10 @@ public class Resource
         }
 
         // Else this is a merging error: the Schema URLs are both non-empty and different. The spec leaves the
-        // result undefined; we log a warning and use the updating resource's Schema URL, consistent with the
-        // attribute merge precedence where the updating ("other") resource takes precedence.
+        // result undefined; we log a warning and return null consistent with the Go, Java, JavaScript, and Rust SDKs.
         OpenTelemetrySdkEventSource.Log.ResourceSchemaUrlMergeConflict(oldSchemaUrl, updatingSchemaUrl);
 
-        return updatingSchemaUrl;
+        return null;
     }
 
     private static KeyValuePair<string, object> SanitizeAttribute(KeyValuePair<string, object> attribute)

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -32,8 +32,14 @@ public class Resource
 #pragma warning disable CA1054 // Change the type of parameter from 'string' to 'System.Uri'
     public Resource(IEnumerable<KeyValuePair<string, object>> attributes, string? schemaUrl)
 #pragma warning restore CA1054 // Change the type of parameter from 'string' to 'System.Uri'
+        : this(attributes, schemaUrl, schemaUrlConflict: false)
+    {
+    }
+
+    private Resource(IEnumerable<KeyValuePair<string, object>> attributes, string? schemaUrl, bool schemaUrlConflict)
     {
         this.SchemaUrl = string.IsNullOrEmpty(schemaUrl) ? null : schemaUrl;
+        this.HasSchemaUrlConflict = schemaUrlConflict;
 
         if (attributes == null)
         {
@@ -64,6 +70,16 @@ public class Resource
 #pragma warning restore CA1056 // Change the type of property from 'string' to 'System.Uri'
 
     /// <summary>
+    /// Gets a value indicating whether a Schema URL conflict has occurred during a chain of merges.
+    /// </summary>
+    /// <remarks>
+    /// Once a conflict occurs the merged resource keeps an empty Schema URL, and the conflict is
+    /// "sticky" so that subsequent merges cannot recover a Schema URL. This keeps Build() deterministic
+    /// regardless of the number and order of detectors that contribute conflicting Schema URLs.
+    /// </remarks>
+    internal bool HasSchemaUrlConflict { get; }
+
+    /// <summary>
     /// Returns a new, merged <see cref="Resource"/> by merging the old <see cref="Resource"/> with the
     /// <c>other</c> <see cref="Resource"/>. In case of a collision the other <see cref="Resource"/> takes precedence.
     /// </summary>
@@ -92,14 +108,27 @@ public class Resource
             }
         }
 
-        return new Resource(newAttributes, MergeSchemaUrl(this.SchemaUrl, other?.SchemaUrl));
+        // A Schema URL conflict is sticky: if either resource in the chain already had a conflict the
+        // merged resource keeps an empty Schema URL, regardless of the other resource's Schema URL.
+        var conflict = this.HasSchemaUrlConflict || (other?.HasSchemaUrlConflict ?? false);
+
+        var mergedSchemaUrl = MergeSchemaUrl(this.SchemaUrl, other?.SchemaUrl, ref conflict);
+
+        return new Resource(newAttributes, mergedSchemaUrl, conflict);
     }
 
     // Implements the Schema URL merge logic from
     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#merge
     // where "this" is the old resource and "other" is the updating resource.
-    private static string? MergeSchemaUrl(string? oldSchemaUrl, string? updatingSchemaUrl)
+    private static string? MergeSchemaUrl(string? oldSchemaUrl, string? updatingSchemaUrl, ref bool conflict)
     {
+        // If a previous merge in the chain already conflicted then the conflict is sticky: the merged
+        // resource keeps an empty Schema URL and no further Schema URL can be recovered.
+        if (conflict)
+        {
+            return null;
+        }
+
         // If the old resource's Schema URL is empty then the result is the updating resource's Schema URL.
         if (oldSchemaUrl is not { Length: > 0 })
         {
@@ -121,6 +150,8 @@ public class Resource
         // Else this is a merging error: the Schema URLs are both non-empty and different. The spec leaves the
         // result undefined; we log a warning and return null consistent with the Go, Java, JavaScript, and Rust SDKs.
         OpenTelemetrySdkEventSource.Log.ResourceSchemaUrlMergeConflict(oldSchemaUrl, updatingSchemaUrl);
+
+        conflict = true;
 
         return null;
     }

--- a/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
@@ -114,7 +114,24 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds resource attributes parsed from OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME environment variables
+    /// Adds attributes and a Schema URL to a <see cref="ResourceBuilder"/>.
+    /// </summary>
+    /// <param name="resourceBuilder"><see cref="ResourceBuilder"/>.</param>
+    /// <param name="attributes">An <see cref="IEnumerable{T}"/> of attributes that describe the resource.</param>
+    /// <param name="schemaUrl">The Schema URL (semantic conventions URL) that applies to the resource, or <see langword="null"/> if the resource has no Schema URL. See <see cref="Resource.Merge(Resource)"/> for how Schema URLs are combined.</param>
+    /// <returns>Returns <see cref="ResourceBuilder"/> for chaining.</returns>
+#pragma warning disable CA1054 // Change the type of parameter from 'string' to 'System.Uri'
+    public static ResourceBuilder AddAttributes(this ResourceBuilder resourceBuilder, IEnumerable<KeyValuePair<string, object>> attributes, string? schemaUrl)
+#pragma warning restore CA1054 // Change the type of parameter from 'string' to 'System.Uri'
+    {
+        Guard.ThrowIfNull(resourceBuilder);
+#pragma warning disable CA1062 // Validate arguments of public methods - needed for netstandard2.1
+        return resourceBuilder.AddResource(new Resource(attributes, schemaUrl));
+#pragma warning restore CA1062 // Validate arguments of public methods - needed for netstandard2.1
+    }
+
+    /// <summary>
+    /// Adds resource attributes parsed from the <c>OTEL_RESOURCE_ATTRIBUTES</c> and <c>OTEL_SERVICE_NAME</c> environment variables
     /// to a <see cref="ResourceBuilder"/> following the <a
     /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable">Resource
     /// SDK</a>.

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
@@ -34,6 +34,14 @@ internal static class Generators
         LogRecordSeverity.Warn,
     ]);
 
+    private static readonly Gen<string?> SchemaUrls = Gen.Elements(
+    [
+        null,
+        string.Empty,
+        "https://opentelemetry.io/schemas/1.0.0",
+        "https://opentelemetry.io/schemas/1.36.0",
+    ]);
+
     public static Arbitrary<SdkLimitOptions> SdkLimitOptionsArbitrary()
     {
         var gen = from spanAttributesLimit in Gen.Choose(0, 1000).Select(x => (int?)x)
@@ -132,7 +140,9 @@ internal static class Generators
                 attributes[$"resource.attr.{i}"] = $"value_{i}";
             }
 
-            return Gen.Constant(Resource.Empty.Merge(new Resource(attributes)));
+            var schemaUrl = SchemaUrls.Sample(size, 1).First();
+
+            return Gen.Constant(Resource.Empty.Merge(new Resource(attributes, schemaUrl)));
         });
 
         return gen.ToArbitrary();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpLogSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpLogSerializerTests.cs
@@ -234,6 +234,60 @@ public class ProtobufOtlpLogSerializerTests
             }
         });
 
+    [Property(MaxTest = 100)]
+    public Property ResourceSchemaUrlRoundTrips() => Prop.ForAll(
+        Generators.SdkLimitOptionsArbitrary(),
+        Generators.ResourceArbitrary(),
+        Generators.LogRecordSeverityArbitrary(),
+        (sdkLimits, resource, severity) =>
+        {
+            var logRecords = CreateLogRecords(severity);
+
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<LogRecord>(logRecords, logRecords.Length);
+                var experimentalOptions = new ExperimentalOptions();
+
+                var writePos = ProtobufOtlpLogSerializer.WriteLogsData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    experimentalOptions,
+                    resource,
+                    batch);
+
+                if (writePos <= 0)
+                {
+                    return true;
+                }
+
+                using var stream = new MemoryStream(buffer, 0, writePos);
+                var request = OtlpCollector.ExportLogsServiceRequest.Parser.ParseFrom(stream);
+
+                if (request == null || request.ResourceLogs.Count == 0)
+                {
+                    return true;
+                }
+
+                var expected = resource.SchemaUrl ?? string.Empty;
+
+                foreach (var resourceLogs in request.ResourceLogs)
+                {
+                    if (resourceLogs.SchemaUrl != expected)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+        });
+
     private static LogRecord[] CreateLogRecords(LogRecordSeverity severity)
         => Generators.LogRecordArbitrary(severity).Generator.ArrayOf().Sample(1, 10).First();
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpMetricSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpMetricSerializerTests.cs
@@ -142,6 +142,53 @@ public class ProtobufOtlpMetricSerializerTests
             }
         });
 
+    [Property(MaxTest = 100)]
+    public Property ResourceSchemaUrlRoundTrips() => Prop.ForAll(
+        Generators.BatchMetricArbitrary(),
+        Generators.ResourceArbitrary(),
+        (metrics, resource) =>
+        {
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+
+                var writePos = ProtobufOtlpMetricSerializer.WriteMetricsData(
+                    ref buffer,
+                    0,
+                    resource,
+                    metrics);
+
+                if (writePos <= 0)
+                {
+                    return true;
+                }
+
+                using var stream = new MemoryStream(buffer, 0, writePos);
+                var request = ExportMetricsServiceRequest.Parser.ParseFrom(stream);
+
+                if (request == null || request.ResourceMetrics.Count == 0)
+                {
+                    return true;
+                }
+
+                var expected = resource.SchemaUrl ?? string.Empty;
+
+                foreach (var resourceMetrics in request.ResourceMetrics)
+                {
+                    if (resourceMetrics.SchemaUrl != expected)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+        });
+
     private static bool IsAllowedException(Exception ex)
         => ex is IndexOutOfRangeException or ArgumentException;
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
@@ -286,6 +286,68 @@ public class ProtobufOtlpTraceSerializerTests
             }
         });
 
+    [Property(MaxTest = 100)]
+    public Property ResourceSchemaUrlRoundTrips() => Prop.ForAll(
+        Generators.ActivityBatchArbitrary(),
+        Generators.SdkLimitOptionsArbitrary(),
+        Generators.ResourceArbitrary(),
+        (activities, sdkLimits, resource) =>
+        {
+            if (activities == null || activities.Length == 0)
+            {
+                return true;
+            }
+
+            try
+            {
+                var buffer = new byte[10 * 1024 * 1024];
+                var batch = new Batch<Activity>(activities, activities.Length);
+
+                var writePos = ProtobufOtlpTraceSerializer.WriteTraceData(
+                    ref buffer,
+                    0,
+                    sdkLimits,
+                    resource,
+                    batch);
+
+                if (writePos <= 0)
+                {
+                    return true;
+                }
+
+                using var stream = new MemoryStream(buffer, 0, writePos);
+                var request = OtlpCollector.ExportTraceServiceRequest.Parser.ParseFrom(stream);
+
+                if (request == null || request.ResourceSpans.Count == 0)
+                {
+                    return true;
+                }
+
+                var expected = resource.SchemaUrl ?? string.Empty;
+
+                foreach (var resourceSpans in request.ResourceSpans)
+                {
+                    if (resourceSpans.SchemaUrl != expected)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (IsAllowedException(ex))
+            {
+                return true;
+            }
+            finally
+            {
+                foreach (var activity in activities)
+                {
+                    activity?.Dispose();
+                }
+            }
+        });
+
     private static bool IsAllowedException(Exception ex)
         => ex is IndexOutOfRangeException or ArgumentException;
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -352,6 +352,44 @@ public sealed class OtlpTraceExporterTests : IDisposable
         Assert.Equal(expectedScopeSpanScehamUrl, scopeSpans.SchemaUrl);
     }
 
+    [Theory]
+    [InlineData("https://opentelemetry.io/schemas/1.0.0", "https://opentelemetry.io/schemas/1.0.0")]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+#pragma warning disable CA1054 // Url parameters should not be strings
+    public void ResourceSpansSchemaUrlTest(string? schemaUrl, string expectedResourceSpansSchemaUrl)
+#pragma warning restore CA1054 // Url parameters should not be strings
+    {
+        using var activitySource = new ActivitySource(nameof(this.ResourceSpansSchemaUrlTest));
+
+        var exportedItems = new List<Activity>();
+
+        // Set the Schema URL via the public ResourceBuilder API and resolve it through the
+        // provider's GetResource() so the full Build() -> GetResource() -> serializer path is exercised.
+        var builder = Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder.CreateEmpty().AddAttributes([], schemaUrl))
+            .AddSource(activitySource.Name)
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            .AddProcessor(new SimpleActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems)));
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+        using var openTelemetrySdk = builder.Build();
+
+        using var activity = activitySource.StartActivity("test-activity");
+        activity?.Stop();
+
+        var item = Assert.Single(exportedItems);
+        var batch = new Batch<Activity>([item], 1);
+
+        var resource = openTelemetrySdk.GetResource();
+
+        var request = CreateTraceExportRequest(DefaultSdkLimitOptions, batch, resource);
+
+        var resourceSpans = Assert.Single(request.ResourceSpans);
+
+        Assert.Equal(expectedResourceSpansSchemaUrl, resourceSpans.SchemaUrl);
+    }
+
     [Fact]
     public void ScopeAttributesLimitsTest()
     {

--- a/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
@@ -1,7 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Tracing;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Tests;
 
 namespace OpenTelemetry.Resources.Tests;
 
@@ -377,6 +380,130 @@ public sealed class ResourceTests : IDisposable
         // Assert
         Assert.Single(newResource.Attributes);
         Assert.Contains(new KeyValuePair<string, object>("value", "updatedValue"), newResource.Attributes);
+    }
+
+    [Fact]
+    public void CreateResource_DefaultSchemaUrlIsNull()
+    {
+        var resource = new Resource(new Dictionary<string, object> { { KeyName, ValueName } });
+
+        Assert.Null(resource.SchemaUrl);
+    }
+
+    [Fact]
+    public void CreateResource_WithSchemaUrl()
+    {
+        const string SchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
+
+        var resource = new Resource(new Dictionary<string, object> { { KeyName, ValueName } }, SchemaUrl);
+
+        Assert.Equal(SchemaUrl, resource.SchemaUrl);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+#pragma warning disable CA1054 // Url parameters should not be strings
+    public void CreateResource_EmptySchemaUrlIsNormalizedToNull(string? schemaUrl)
+#pragma warning restore CA1054 // Url parameters should not be strings
+    {
+        var resource = new Resource(new Dictionary<string, object> { { KeyName, ValueName } }, schemaUrl);
+
+        Assert.Null(resource.SchemaUrl);
+    }
+
+    [Fact]
+    public void MergeResource_SchemaUrl_OldEmptyUsesUpdating()
+    {
+        const string SchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
+        var current = new Resource([], schemaUrl: null);
+        var updating = new Resource([], SchemaUrl);
+
+        var merged = current.Merge(updating);
+
+        Assert.Equal(SchemaUrl, merged.SchemaUrl);
+    }
+
+    [Fact]
+    public void MergeResource_SchemaUrl_UpdatingEmptyUsesOld()
+    {
+        const string SchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
+        var current = new Resource([], SchemaUrl);
+        var updating = new Resource([], schemaUrl: null);
+
+        var merged = current.Merge(updating);
+
+        Assert.Equal(SchemaUrl, merged.SchemaUrl);
+    }
+
+    [Fact]
+    public void MergeResource_SchemaUrl_BothEmptyResultIsNull()
+    {
+        var current = new Resource([], schemaUrl: null);
+        var updating = new Resource([], schemaUrl: null);
+
+        var merged = current.Merge(updating);
+
+        Assert.Null(merged.SchemaUrl);
+    }
+
+    [Fact]
+    public void MergeResource_SchemaUrl_BothEqualUsesValue()
+    {
+        const string SchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
+        var current = new Resource([], SchemaUrl);
+        var updating = new Resource([], SchemaUrl);
+
+        var merged = current.Merge(updating);
+
+        Assert.Equal(SchemaUrl, merged.SchemaUrl);
+    }
+
+    [Fact]
+    public void MergeResource_SchemaUrl_ConflictUsesUpdatingAndLogsWarning()
+    {
+        const string OldSchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
+        const string UpdatingSchemaUrl = "https://opentelemetry.io/schemas/1.1.0";
+
+        using var listener = new TestEventListener(OpenTelemetrySdkEventSource.Log, EventLevel.Warning);
+
+        var current = new Resource([], OldSchemaUrl);
+        var updating = new Resource([], UpdatingSchemaUrl);
+
+        var merged = current.Merge(updating);
+
+        // On conflict the updating (other) Schema URL wins, consistent with attribute merge precedence.
+        Assert.Equal(UpdatingSchemaUrl, merged.SchemaUrl);
+
+        var conflictEvent = Assert.Single(listener.Messages, e => e.EventId == 59);
+        Assert.Equal(OldSchemaUrl, conflictEvent.Payload![0]);
+        Assert.Equal(UpdatingSchemaUrl, conflictEvent.Payload![1]);
+    }
+
+    [Fact]
+    public void ResourceBuilder_AddAttributes_WithSchemaUrl_IsPropagatedByBuild()
+    {
+        const string SchemaUrl = "https://opentelemetry.io/schemas/1.36.0";
+
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddAttributes([new KeyValuePair<string, object>(KeyName, ValueName)], SchemaUrl)
+            .Build();
+
+        Assert.Equal(SchemaUrl, resource.SchemaUrl);
+        Assert.Contains(new KeyValuePair<string, object>(KeyName, ValueName), resource.Attributes);
+    }
+
+    [Fact]
+    public void ResourceBuilder_Build_PropagatesSchemaUrlFromSingleContributor()
+    {
+        const string SchemaUrl = "https://opentelemetry.io/schemas/1.36.0";
+
+        // A detector contributes a Schema URL; other contributors leave it empty.
+        var resource = ResourceBuilder.CreateDefault()
+            .AddAttributes([new KeyValuePair<string, object>(KeyName, ValueName)], SchemaUrl)
+            .Build();
+
+        Assert.Equal(SchemaUrl, resource.SchemaUrl);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
@@ -481,6 +481,22 @@ public sealed class ResourceTests : IDisposable
     }
 
     [Fact]
+    public void MergeResource_SchemaUrl_ChainedConflictThenMergeUsesLastSchemaUrl()
+    {
+        const string OldSchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
+        const string UpdatingSchemaUrl1 = "https://opentelemetry.io/schemas/1.1.0";
+        const string UpdatingSchemaUrl2 = "https://opentelemetry.io/schemas/1.2.0";
+
+        var current = new Resource([], OldSchemaUrl);
+        var updating1 = new Resource([], UpdatingSchemaUrl1);
+        var updating2 = new Resource([], UpdatingSchemaUrl2);
+
+        var merged = current.Merge(updating1).Merge(updating2);
+
+        Assert.Equal(UpdatingSchemaUrl2, merged.SchemaUrl);
+    }
+
+    [Fact]
     public void ResourceBuilder_AddAttributes_WithSchemaUrl_IsPropagatedByBuild()
     {
         const string SchemaUrl = "https://opentelemetry.io/schemas/1.36.0";

--- a/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
@@ -13,14 +13,15 @@ public sealed class ResourceTests : IDisposable
     private const string KeyName = "key";
     private const string ValueName = "value";
 
-    public ResourceTests()
-    {
-        ClearEnvVars();
-    }
+    private readonly IDisposable scope = EnvironmentVariableScope.Create(
+    [
+        new(OtelEnvResourceDetector.EnvVarKey, null),
+        new(OtelServiceNameEnvVarDetector.EnvVarKey, null),
+    ]);
 
     public void Dispose()
     {
-        ClearEnvVars();
+        this.scope?.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -472,8 +473,7 @@ public sealed class ResourceTests : IDisposable
 
         var merged = current.Merge(updating);
 
-        // On conflict the updating (other) Schema URL wins, consistent with attribute merge precedence.
-        Assert.Equal(UpdatingSchemaUrl, merged.SchemaUrl);
+        Assert.Null(merged.SchemaUrl);
 
         var conflictEvent = Assert.Single(listener.Messages, e => e.EventId == 59);
         Assert.Equal(OldSchemaUrl, conflictEvent.Payload![0]);
@@ -703,12 +703,6 @@ public sealed class ResourceTests : IDisposable
         var serviceName = attributes.Where(pair => pair.Key.Equals("service.name", StringComparison.Ordinal));
         Assert.Single(serviceName);
         Assert.Contains("unknown_service", serviceName.FirstOrDefault().Value as string, StringComparison.Ordinal);
-    }
-
-    private static void ClearEnvVars()
-    {
-        Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, null);
-        Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, null);
     }
 
     private static void AddAttributes(Dictionary<string, object> attributes, int attributeCount, int startIndex = 0)

--- a/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTests.cs
@@ -461,7 +461,7 @@ public sealed class ResourceTests : IDisposable
     }
 
     [Fact]
-    public void MergeResource_SchemaUrl_ConflictUsesUpdatingAndLogsWarning()
+    public void MergeResource_SchemaUrl_ConflictClearsSchemaUrlAndLogsWarning()
     {
         const string OldSchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
         const string UpdatingSchemaUrl = "https://opentelemetry.io/schemas/1.1.0";
@@ -481,19 +481,27 @@ public sealed class ResourceTests : IDisposable
     }
 
     [Fact]
-    public void MergeResource_SchemaUrl_ChainedConflictThenMergeUsesLastSchemaUrl()
+    public void MergeResource_SchemaUrl_ChainedConflictIsStickyAndReportedOnce()
     {
         const string OldSchemaUrl = "https://opentelemetry.io/schemas/1.0.0";
         const string UpdatingSchemaUrl1 = "https://opentelemetry.io/schemas/1.1.0";
         const string UpdatingSchemaUrl2 = "https://opentelemetry.io/schemas/1.2.0";
 
+        using var listener = new TestEventListener(OpenTelemetrySdkEventSource.Log, EventLevel.Warning);
+
         var current = new Resource([], OldSchemaUrl);
         var updating1 = new Resource([], UpdatingSchemaUrl1);
         var updating2 = new Resource([], UpdatingSchemaUrl2);
 
+        // The first merge conflicts (1.0.0 vs 1.1.0) and clears the Schema URL. The conflict is sticky,
+        // so merging a further Schema URL (1.2.0) cannot recover a value and no second warning is logged.
         var merged = current.Merge(updating1).Merge(updating2);
 
-        Assert.Equal(UpdatingSchemaUrl2, merged.SchemaUrl);
+        Assert.Null(merged.SchemaUrl);
+
+        var conflictEvent = Assert.Single(listener.Messages, e => e.EventId == 59);
+        Assert.Equal(OldSchemaUrl, conflictEvent.Payload![0]);
+        Assert.Equal(UpdatingSchemaUrl1, conflictEvent.Payload![1]);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #6696

## Changes

- Add support for including a schema URL for resources.
- Print the schema URL in the console exporter.
- Serialize the schema URL in the OTLP exporter.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
