### PR TITLE
[Infra] Fix error if no origin remote

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -113,6 +113,7 @@
       Command="git rev-parse HEAD"
       ConsoleToMsBuild="True"
       IgnoreExitCode="True"
+      IgnoreStandardErrorWarningFormat="True"
       StandardOutputImportance="low">
       <Output PropertyName="GitCommitConsoleOutput" TaskParameter="ConsoleOutput"/>
       <Output PropertyName="GitCommitExitCode" TaskParameter="ExitCode"/>
@@ -122,6 +123,7 @@
       Command="git remote get-url origin"
       ConsoleToMsBuild="True"
       IgnoreExitCode="True"
+      IgnoreStandardErrorWarningFormat="True"
       StandardOutputImportance="low">
       <Output PropertyName="GitOriginConsoleOutput" TaskParameter="ConsoleOutput"/>
       <Output PropertyName="GitOriginExitCode" TaskParameter="ExitCode"/>
@@ -129,7 +131,7 @@
 
     <PropertyGroup>
       <MarkdownCommentRegex>\[([^]]+?)\]\(\.(.+?)\)</MarkdownCommentRegex>
-      <GitHubRepoUrl>$(GitOriginConsoleOutput.Replace('.git',''))</GitHubRepoUrl>
+      <GitHubRepoUrl Condition="'$(GitOriginExitCode)' == '0'">$(GitOriginConsoleOutput.Replace('.git',''))</GitHubRepoUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' != ''">$(GitHubRepoUrl)/blob/$(PackTag)</GitHubPermalinkUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' == ''">$(GitHubRepoUrl)/blob/$(GitCommitConsoleOutput)</GitHubPermalinkUrl>
     </PropertyGroup>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -132,6 +132,7 @@
     <PropertyGroup>
       <MarkdownCommentRegex>\[([^]]+?)\]\(\.(.+?)\)</MarkdownCommentRegex>
       <GitHubRepoUrl Condition="'$(GitOriginExitCode)' == '0'">$(GitOriginConsoleOutput.Replace('.git',''))</GitHubRepoUrl>
+      <GitHubRepoUrl Condition="'$(GitOriginExitCode)' != '0' AND '$(GITHUB_SERVER_URL)' != '' AND '$(GITHUB_REPOSITORY)' != ''">$(GITHUB_SERVER_URL)/$(GITHUB_REPOSITORY)</GitHubRepoUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' != ''">$(GitHubRepoUrl)/blob/$(PackTag)</GitHubPermalinkUrl>
       <GitHubPermalinkUrl Condition="'$(PackTag)' == ''">$(GitHubRepoUrl)/blob/$(GitCommitConsoleOutput)</GitHubPermalinkUrl>
     </PropertyGroup>
@@ -147,12 +148,13 @@
     </ItemGroup>
 
     <WriteLinesToFile
+        Condition="'$(GitHubPermalinkUrl)' != ''"
         File="$(IntermediateOutputPath)%(PackageMarkdownFiles.Filename)%(PackageMarkdownFiles.Extension)"
         Lines="$([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText(%(PackageMarkdownFiles.FullPath))), '$(MarkdownCommentRegex)', '[$1]($(GitHubPermalinkUrl)%(PackageMarkdownFiles.Path).$2)').Replace('\', '/'))"
         Overwrite="true"
         Encoding="UTF-8"/>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(GitHubPermalinkUrl)' != ''">
       <_PackageReleaseNotesFilePath>$([System.IO.Path]::GetFullPath('$(PackageReleaseNotesFile)').Replace('$(RepoRoot)', '').Replace('\', '/'))</_PackageReleaseNotesFilePath>
       <_PackageChangelogFilePath>$([System.IO.Path]::GetFullPath('$(PackageChangelogFile)').Replace('$(RepoRoot)', '').Replace('\', '/'))</_PackageChangelogFilePath>
       <PackageReleaseNotes>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -113,7 +113,6 @@
       Command="git rev-parse HEAD"
       ConsoleToMsBuild="True"
       IgnoreExitCode="True"
-      IgnoreStandardErrorWarningFormat="True"
       StandardOutputImportance="low">
       <Output PropertyName="GitCommitConsoleOutput" TaskParameter="ConsoleOutput"/>
       <Output PropertyName="GitCommitExitCode" TaskParameter="ExitCode"/>


### PR DESCRIPTION
Fixes #7473

## Changes

Fix build failure if there isn't a git remote named `origin`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
