### PR TITLE
[Infra] .NET 11 preparation

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -22,11 +22,19 @@ jobs:
         persist-credentials: false
         show-progress: false
 
+    - name: Get Git commit timestamp
+      id: get-commit-timestamp
+      shell: pwsh
+      run: |
+        "epoch=$(git log -1 --pretty=%ct)" >> ${env:GITHUB_OUTPUT}
+
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
 
     - name: dotnet pack
       run: dotnet pack ./build/OpenTelemetry.proj --configuration Release /p:EnablePackageValidation=true /p:ExposeExperimentalFeatures=false /p:RunningDotNetPack=true
+      env:
+        SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.epoch }}
 
     - name: Publish stable NuGet packages to Artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -50,11 +58,19 @@ jobs:
         persist-credentials: false
         show-progress: false
 
+    - name: Get Git commit timestamp
+      id: get-commit-timestamp
+      shell: pwsh
+      run: |
+        "epoch=$(git log -1 --pretty=%ct)" >> ${env:GITHUB_OUTPUT}
+
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
 
     - name: dotnet pack
       run: dotnet pack ./build/OpenTelemetry.proj --configuration Release /p:EnablePackageValidation=true /p:ExposeExperimentalFeatures=true /p:RunningDotNetPack=true
+      env:
+        SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.epoch }}
 
     - name: Publish experimental NuGet packages to Artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -58,6 +58,12 @@ jobs:
         persist-credentials: false
         show-progress: false
 
+    - name: Get Git commit timestamp
+      id: get-commit-timestamp
+      shell: pwsh
+      run: |
+        "epoch=$(git log -1 --pretty=%ct)" >> ${env:GITHUB_OUTPUT}
+
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
 
@@ -97,6 +103,7 @@ jobs:
       shell: pwsh
       env:
         PACK_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.epoch }}
       run: dotnet pack ./build/OpenTelemetry.proj --configuration Release --no-restore --no-build -p:"PackTag=${env:PACK_TAG}"
 
     - name: Install NuGet package validation tools

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
@@ -219,11 +219,15 @@ internal static class TraceStateUtils
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool IsValidFirstCharacter(char c)
-            => char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c);
+        {
+            return char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool IsValidCharacter(char c)
-            => IsValidFirstCharacter(c) || c is '_' or '-' or '*' or '/' or '@';
+        {
+            return IsValidFirstCharacter(c) || c is '_' or '-' or '*' or '/' or '@';
+        }
     }
 
     private static bool ValidateValue(ReadOnlySpan<char> value)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
@@ -12,7 +12,12 @@ internal static class ProtobufOtlpMetricSerializer
     private const int ReserveSizeForLength = 4;
     private const int TraceIdSize = 16;
     private const int SpanIdSize = 8;
+
+#if NETFRAMEWORK || NETSTANDARD2_0
     private static readonly ConditionalWeakTable<Metric, byte[]> CachedMetricMetadata = new();
+#else
+    private static readonly ConditionalWeakTable<Metric, byte[]> CachedMetricMetadata = [];
+#endif
 
     [ThreadStatic]
     private static Stack<List<Metric>>? metricListPool;

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusMetric.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusMetric.cs
@@ -239,7 +239,7 @@ internal sealed class PrometheusMetric
         EscapingScheme.AllowUtf8 => this.allowUtf8Names ??= BuildAllowUtf8Names(this.rawName, this.Unit, this.Type, this.disableTotalNameSuffixForCounters),
         EscapingScheme.Dots => this.dotsNames ??= BuildEscapedNames(this.rawName, this.Unit, this.Type, this.disableTotalNameSuffixForCounters, EscapingScheme.Dots),
         EscapingScheme.Values => this.valuesNames ??= BuildEscapedNames(this.rawName, this.Unit, this.Type, this.disableTotalNameSuffixForCounters, EscapingScheme.Values),
-        _ => this.underscoreNames,
+        EscapingScheme.Underscores or _ => this.underscoreNames,
     };
 
     private static byte[] ConvertToBytes(string value)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
@@ -354,7 +354,7 @@ internal abstract class TextFormatSerializer
         // the scrape immediately rather than repeatedly re-entering this allocation.
         var newBufferSize = currentBufferSize * 2;
 
-        return newBufferSize <= 0 || newBufferSize > MaxSerializedTagsBufferSize
+        return newBufferSize is <= 0 or > MaxSerializedTagsBufferSize
             ? throw new InvalidOperationException("The serialized Prometheus tag set exceeded the maximum supported size.")
             : newBufferSize;
     }
@@ -2124,7 +2124,7 @@ internal abstract class TextFormatSerializer
             EscapingScheme.AllowUtf8 => WriteLabelName(buffer, cursor, key),
 
             // The dots and values schemes escape the name and quote it only if a colon survives.
-            _ => WriteEscapedLabelKey(buffer, cursor, key, this.Escaping),
+            EscapingScheme.Dots or EscapingScheme.Values or _ => WriteEscapedLabelKey(buffer, cursor, key, this.Escaping),
         };
     }
 

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -10,9 +10,11 @@ namespace OpenTelemetry.Shims.OpenTracing;
 
 internal sealed class ScopeManagerShim : IScopeManager
 {
-#pragma warning disable IDE0028 // Simplify collection initialization
+#if NETFRAMEWORK || NETSTANDARD2_0
     private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = new();
-#pragma warning restore IDE0028 // Simplify collection initialization
+#else
+    private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = [];
+#endif
 
 #if DEBUG
     private int spanScopeTableCount;

--- a/src/OpenTelemetry/Metrics/MetricPoint/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint/MetricPoint.cs
@@ -902,7 +902,9 @@ public struct MetricPoint
     /// <returns><see langword="true"/> if there is unexported data; otherwise, <see langword="false"/>.</returns>
     internal bool HasUnexportedData()
     {
+#pragma warning disable IDE0066 // Convert switch statement to expression
         switch (this.aggType)
+#pragma warning restore IDE0066 // Convert switch statement to expression
         {
             case AggregationType.LongSumIncomingDelta:
             case AggregationType.LongSumIncomingCumulative:
@@ -918,6 +920,13 @@ public struct MetricPoint
             case AggregationType.DoubleGauge:
                 return InterlockedHelper.Read(ref this.runningValue.AsDouble) != this.snapshotValue.AsDouble;
 
+            case AggregationType.Base2ExponentialHistogram:
+            case AggregationType.Base2ExponentialHistogramWithMinMax:
+            case AggregationType.Histogram:
+            case AggregationType.HistogramWithBuckets:
+            case AggregationType.HistogramWithMinMax:
+            case AggregationType.HistogramWithMinMaxBuckets:
+            case AggregationType.Invalid:
             default:
                 // Histogram aggregations reset the running count to zero on each delta snapshot, so
                 // a non-zero running count means measurements have been recorded since the last

--- a/test/Benchmarks/Exporter/ProtobufOtlpMetricSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ProtobufOtlpMetricSerializerBenchmarks.cs
@@ -53,7 +53,7 @@ public class ProtobufOtlpMetricSerializerBenchmarks
 
         this.meterProvider.ForceFlush();
 
-        this.capturedMetrics = collected.ToArray();
+        this.capturedMetrics = [.. collected];
         this.batch = new Batch<Metric>(this.capturedMetrics, this.capturedMetrics.Length);
     }
 

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Changes

- Fix new code analysis warnings from the .NET 11 SDK.
- Set `SOURCE_DATE_EPOCH` during package publishing (to support NuGet's new [DeterministicTimestamp](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/nuget.md#deterministic-pack-support-is-restored) feature).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
