### PR TITLE
[Exporter.Prometheus] Make maximum buffer size configurable

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ Microsoft.AspNetCore.Builder.PrometheusExporterEndpointRouteBuilderExtensions
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableTotalNameSuffixForCounters.get -> bool
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableTotalNameSuffixForCounters.set -> void
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.MaxScrapeResponseSizeBytes.get -> int
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.MaxScrapeResponseSizeBytes.set -> void
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.PrometheusAspNetCoreOptions() -> void
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.ScopeInfoEnabled.get -> bool
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.ScopeInfoEnabled.set -> void

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -35,6 +35,14 @@ Notes](../../RELEASENOTES.md).
   when negotiated via the `Accept` header.
   ([#7440](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7440))
 
+* Add `PrometheusAspNetCoreOptions.MaxScrapeResponseSizeBytes` to configure
+  the maximum size of a scrape response. The default is now ~166 MiB.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
+* A scrape whose serialized output exceeds the maximum scrape response size
+  limit now responds with HTTP 500.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -37,11 +37,11 @@ Notes](../../RELEASENOTES.md).
 
 * Add `PrometheusAspNetCoreOptions.MaxScrapeResponseSizeBytes` to configure
   the maximum size of a scrape response. The default is now ~166 MiB.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
 * A scrape whose serialized output exceeds the maximum scrape response size
   limit now responds with HTTP 500.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
@@ -58,5 +58,17 @@ public class PrometheusAspNetCoreOptions
         set => this.ExporterOptions.TargetInfoEnabled = value;
     }
 
+    /// <summary>
+    /// Gets or sets the maximum size in bytes that a single scrape response is allowed to grow to. Default value: ~166 MiB.
+    /// </summary>
+    /// <remarks>
+    /// Increase this value when exposing a very large number of time series.
+    /// </remarks>
+    public int MaxScrapeResponseSizeBytes
+    {
+        get => this.ExporterOptions.MaxScrapeResponseSizeBytes;
+        set => this.ExporterOptions.MaxScrapeResponseSizeBytes = value;
+    }
+
     internal PrometheusExporterOptions ExporterOptions { get; } = new();
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -85,21 +85,29 @@ internal sealed class PrometheusExporterMiddleware
             {
                 linkedCts.Token.ThrowIfCancellationRequested();
 
-                var dataView = collectionResponse.View;
-
-                response.StatusCode = StatusCodes.Status200OK;
-
-                if (dataView.Count > 0)
+                if (!collectionResponse.Succeeded)
                 {
-                    response.Headers.Append("Last-Modified", collectionResponse.GeneratedAtUtc.ToString("R"));
-                    response.ContentType = PrometheusProtocol.GetContentType(protocol);
-
-                    await WriteResponseAsync(response, dataView.Array.AsMemory(0, dataView.Count), AcceptsGZip(requestHeaders), linkedCts.Token);
+                    PrometheusExporterEventSource.Log.ScrapeFailed();
+                    response.StatusCode = StatusCodes.Status500InternalServerError;
                 }
                 else
                 {
-                    // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
-                    PrometheusExporterEventSource.Log.NoMetrics();
+                    var dataView = collectionResponse.View;
+
+                    response.StatusCode = StatusCodes.Status200OK;
+
+                    if (dataView.Count > 0)
+                    {
+                        response.Headers.Append("Last-Modified", collectionResponse.GeneratedAtUtc.ToString("R"));
+                        response.ContentType = PrometheusProtocol.GetContentType(protocol);
+
+                        await WriteResponseAsync(response, dataView.Array.AsMemory(0, dataView.Count), AcceptsGZip(requestHeaders), linkedCts.Token);
+                    }
+                    else
+                    {
+                        // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
+                        PrometheusExporterEventSource.Log.NoMetrics();
+                    }
                 }
             }
             catch (OperationCanceledException ex) when (ex.CancellationToken == linkedCts.Token)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
@@ -1,21 +1,23 @@
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ConfigureHttpListener.get -> System.Action<OpenTelemetry.Exporter.PrometheusHttpListenerOptions!, System.Net.HttpListener!>?
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ConfigureHttpListener.set -> void
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.get -> bool
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.set -> void
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes.get -> int
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Host.get -> string!
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Host.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Port.get -> int
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Port.set -> void
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.get -> bool
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.set -> void
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.PrometheusHttpListenerOptions() -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScopeInfoEnabled.get -> bool
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScopeInfoEnabled.set -> void
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TargetInfoEnabled.get -> bool
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TargetInfoEnabled.set -> void
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.PrometheusHttpListenerOptions() -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeEndpointPath.get -> string?
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeEndpointPath.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds.get -> int
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds.set -> void
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TargetInfoEnabled.get -> bool
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TargetInfoEnabled.set -> void
 OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions
 static OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions.AddPrometheusHttpListener(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions.AddPrometheusHttpListener(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, string? name, System.Action<OpenTelemetry.Exporter.PrometheusHttpListenerOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
@@ -3,10 +3,10 @@ OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ConfigureHttpListener.get -
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ConfigureHttpListener.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.get -> bool
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.set -> void
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes.get -> int
-OpenTelemetry.Exporter.PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Host.get -> string!
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Host.set -> void
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes.get -> int
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Port.get -> int
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.Port.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.PrometheusHttpListenerOptions() -> void

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -43,11 +43,11 @@ Notes](../../RELEASENOTES.md).
 
 * Add `PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes` to configure
   the maximum size of a scrape response. The default is now ~166 MiB.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
 * A scrape whose serialized output exceeds the maximum scrape response size
   limit now responds with HTTP 500.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -41,6 +41,14 @@ Notes](../../RELEASENOTES.md).
   when negotiated via the `Accept` header.
   ([#7440](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7440))
 
+* Add `PrometheusHttpListenerOptions.MaxScrapeResponseSizeBytes` to configure
+  the maximum size of a scrape response. The default is now ~166 MiB.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
+* A scrape whose serialized output exceeds the maximum scrape response size
+  limit now responds with HTTP 500.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -22,6 +22,8 @@ internal sealed class PrometheusCollectionManager
     private readonly long baseTimestamp = Stopwatch.GetTimestamp();
     private readonly PrometheusExporter.ExportFunc onCollectRef;
     private readonly Dictionary<Metric, PrometheusMetric> metricsCache;
+    private readonly int maxBufferSize;
+
     private int metricsCacheCount;
     private int globalLockState;
     private CollectionContext? collectionContext;
@@ -37,6 +39,7 @@ internal sealed class PrometheusCollectionManager
         this.onCollectRef = this.OnCollect;
         this.metricsCache = [];
         this.GetElapsedTime = () => Stopwatch.GetElapsedTime(this.baseTimestamp);
+        this.maxBufferSize = this.exporter.MaxScrapeResponseSizeBytes;
     }
 
     internal Func<DateTime> UtcNow { get; set; } = static () => DateTime.UtcNow;
@@ -474,8 +477,12 @@ internal sealed class PrometheusCollectionManager
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private PrometheusProtocolState GetProtocolState(in PrometheusProtocol protocol)
-        => this.protocolStates.GetOrAdd(protocol, static _ => new());
+    private PrometheusProtocolState GetProtocolState(in PrometheusProtocol protocol) =>
+#if NET
+        this.protocolStates.GetOrAdd(protocol, static (_, maxBufferSize) => new(maxBufferSize), this.maxBufferSize);
+#else
+        this.protocolStates.GetOrAdd(protocol, (_) => new(this.maxBufferSize));
+#endif
 
     private int WriteTargetInfo(TextFormatSerializer serializer, PrometheusProtocolState state)
     {
@@ -621,6 +628,7 @@ internal sealed class PrometheusCollectionManager
             this.View = view;
             this.GeneratedAtUtc = generatedAtUtc;
             this.FromCache = fromCache;
+            this.Succeeded = true;
         }
 
         public readonly ArraySegment<byte> View { get; }
@@ -628,6 +636,15 @@ internal sealed class PrometheusCollectionManager
         public readonly DateTime GeneratedAtUtc { get; }
 
         public readonly bool FromCache { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the collection that produced this response succeeded.
+        /// </summary>
+        /// <remarks>
+        /// Used to distinguish between a successful collection that produced an empty response
+        /// and a failed collection that produced no response.
+        /// </remarks>
+        public readonly bool Succeeded { get; }
     }
 
     private readonly struct CollectionResult
@@ -784,10 +801,15 @@ internal sealed class PrometheusCollectionManager
 
     private sealed class PrometheusProtocolState
     {
-        private const int InitialBufferSize = 85_000; // Encourage the object to live in Large Object Heap (LOH)
-        private const int MaxBufferSize = 100 * 1024 * 1024; // 100 MB
+        private const int InitialBufferSize = PrometheusExporterOptions.InitialScrapeResponseSizeBytes;
+        private readonly int maxBufferSize;
 
         private int readerCount;
+
+        public PrometheusProtocolState(int maxBufferSize)
+        {
+            this.maxBufferSize = Math.Max(maxBufferSize, InitialBufferSize);
+        }
 
         public static ArraySegment<byte> EmptyView { get; } =
 #if NET
@@ -815,12 +837,16 @@ internal sealed class PrometheusCollectionManager
 
         public bool TryExpandBuffer()
         {
-            var newBufferSize = this.Buffer.Length * 2;
-
-            if (newBufferSize > MaxBufferSize)
+            if (this.Buffer.Length >= this.maxBufferSize)
             {
                 return false;
             }
+
+            // Grow by doubling, but never past the configured maximum. Clamping
+            // to the maximum (rather than refusing the grow outright when the
+            // doubled size would overshoot) means the entire configured budget
+            // is usable, with no unreachable remainder.
+            var newBufferSize = (int)Math.Min((long)this.Buffer.Length * 2, this.maxBufferSize);
 
             var expanded = new byte[newBufferSize];
             this.Buffer.CopyTo(expanded, 0);

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -427,6 +427,14 @@ internal sealed class PrometheusCollectionManager
         var protocols = executionResult.Protocols ?? collectionContext.FreezeProtocols();
         var responses = new Dictionary<PrometheusProtocol, CollectionResponse>(protocols.Length);
 
+        if (!succeeded && executionResult.Protocols is not null)
+        {
+            foreach (var protocol in protocols)
+            {
+                responses[protocol] = default;
+            }
+        }
+
         if (succeeded)
         {
             var generatedAt = this.UtcNow();
@@ -438,6 +446,7 @@ internal sealed class PrometheusCollectionManager
                 if (successfulProtocols is not null &&
                     !successfulProtocols.Contains(protocol))
                 {
+                    responses[protocol] = default;
                     continue;
                 }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
@@ -27,6 +27,7 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
         this.ScrapeResponseCacheDurationMilliseconds = options.ScrapeResponseCacheDurationMilliseconds;
         this.TargetInfoEnabled = options.TargetInfoEnabled;
         this.DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters;
+        this.MaxScrapeResponseSizeBytes = options.MaxScrapeResponseSizeBytes;
 
         this.CollectionManager = new PrometheusCollectionManager(this);
     }
@@ -51,6 +52,8 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
     internal int ScrapeResponseCacheDurationMilliseconds { get; }
 
     internal bool DisableTotalNameSuffixForCounters { get; }
+
+    internal int MaxScrapeResponseSizeBytes { get; }
 
     internal Resource Resource
     {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
@@ -103,4 +103,8 @@ internal sealed class PrometheusExporterEventSource : EventSource, IConfiguratio
     [Event(10, Message = "Metric '{0}' ignored as metrics of type '{1}' are not supported by Prometheus.", Level = EventLevel.Verbose)]
     public void MetricIgnored(string metricName, string metricType)
         => this.WriteEvent(10, metricName, metricType);
+
+    [Event(11, Message = "Failed to collect metrics for a scrape request; the response may have exceeded the configured maximum size.", Level = EventLevel.Error)]
+    public void ScrapeFailed()
+        => this.WriteEvent(11);
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterOptions.cs
@@ -10,11 +10,31 @@ namespace OpenTelemetry.Exporter.Prometheus;
 /// </summary>
 internal sealed class PrometheusExporterOptions
 {
+    /// <summary>
+    /// The initial scrape response buffer size in bytes.
+    /// The buffer is always allocated at this size, so it is also the
+    /// smallest meaningful value for <see cref="MaxScrapeResponseSizeBytes"/>.
+    /// </summary>
+    public const int InitialScrapeResponseSizeBytes = 85_000; // Encourage the object to live in the Large Object Heap (LOH).
+
+    /// <summary>
+    /// The default maximum scrape response size in bytes (~166 MiB).
+    /// </summary>
+    /// <remarks>
+    /// The response buffer starts at <see cref="InitialScrapeResponseSizeBytes"/>
+    /// and grows on demand by doubling. This default is equal to that size
+    /// multiplied by <c>2^11</c>, i.e. the largest size reachable by that doubling
+    /// sequence, so the whole budget is usable and none is left as an unreachable
+    /// remainder.
+    /// </remarks>
+    public const int DefaultMaxScrapeResponseSizeBytes = InitialScrapeResponseSizeBytes * 2048;
+
     public PrometheusExporterOptions()
     {
         this.ScopeInfoEnabled = true;
         this.ScrapeResponseCacheDurationMilliseconds = 300;
         this.TargetInfoEnabled = true;
+        this.MaxScrapeResponseSizeBytes = DefaultMaxScrapeResponseSizeBytes;
     }
 
     /// <summary>
@@ -49,4 +69,21 @@ internal sealed class PrometheusExporterOptions
     /// Gets or sets a value indicating whether addition of _total suffix for counter metric names is disabled. Default value: <see langword="false"/>.
     /// </summary>
     public bool DisableTotalNameSuffixForCounters { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum size in bytes that a single scrape response is
+    /// allowed to grow to. Default value: <see cref="DefaultMaxScrapeResponseSizeBytes"/> (~166 MiB).
+    /// </summary>
+    /// <remarks>
+    /// Increase this value when exposing a very large number of time series.
+    /// </remarks>
+    public int MaxScrapeResponseSizeBytes
+    {
+        get;
+        set
+        {
+            Guard.ThrowIfOutOfRange(value, min: InitialScrapeResponseSizeBytes);
+            field = value;
+        }
+    }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -262,25 +262,34 @@ internal sealed class PrometheusHttpListener : IDisposable
 
                 context.Response.Headers.Add("Server", string.Empty);
 
-                var dataView = collectionResponse.View;
-
-                if (dataView.Count > 0)
+                if (!collectionResponse.Succeeded)
                 {
-                    context.Response.StatusCode = 200;
-                    context.Response.Headers.Add("Last-Modified", collectionResponse.GeneratedAtUtc.ToString("R"));
-                    context.Response.ContentType = PrometheusProtocol.GetContentType(protocol);
-
-#if NET
-                    await context.Response.OutputStream.WriteAsync(dataView.Array.AsMemory(0, dataView.Count), linkedCts.Token).ConfigureAwait(false);
-#else
-                    await context.Response.OutputStream.WriteAsync(dataView.Array, 0, dataView.Count, linkedCts.Token).ConfigureAwait(false);
-#endif
+                    PrometheusExporterEventSource.Log.ScrapeFailed();
+                    context.Response.StatusCode = 500;
+                    context.Response.ContentLength64 = 0;
                 }
                 else
                 {
-                    // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
-                    context.Response.StatusCode = 200;
-                    PrometheusExporterEventSource.Log.NoMetrics();
+                    var dataView = collectionResponse.View;
+
+                    if (dataView.Count > 0)
+                    {
+                        context.Response.StatusCode = 200;
+                        context.Response.Headers.Add("Last-Modified", collectionResponse.GeneratedAtUtc.ToString("R"));
+                        context.Response.ContentType = PrometheusProtocol.GetContentType(protocol);
+
+#if NET
+                        await context.Response.OutputStream.WriteAsync(dataView.Array.AsMemory(0, dataView.Count), linkedCts.Token).ConfigureAwait(false);
+#else
+                        await context.Response.OutputStream.WriteAsync(dataView.Array, 0, dataView.Count, linkedCts.Token).ConfigureAwait(false);
+#endif
+                    }
+                    else
+                    {
+                        // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
+                        context.Response.StatusCode = 200;
+                        PrometheusExporterEventSource.Log.NoMetrics();
+                    }
                 }
             }
             catch (OperationCanceledException ex) when (ex.CancellationToken == requestCancelled.Token)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
@@ -71,6 +71,7 @@ public static class PrometheusHttpListenerMeterProviderBuilderExtensions
             ScrapeResponseCacheDurationMilliseconds = options.ScrapeResponseCacheDurationMilliseconds,
             TargetInfoEnabled = options.TargetInfoEnabled,
             DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters,
+            MaxScrapeResponseSizeBytes = options.MaxScrapeResponseSizeBytes,
         });
 
         var reader = new BaseExportingMetricReader(exporter)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -49,6 +49,7 @@ public class PrometheusHttpListenerOptions
         this.Host = host;
         this.Port = port;
         this.ScrapeResponseCacheDurationMilliseconds = 300;
+        this.MaxScrapeResponseSizeBytes = PrometheusExporterOptions.DefaultMaxScrapeResponseSizeBytes;
     }
 
     /// <summary>
@@ -98,6 +99,22 @@ public class PrometheusHttpListenerOptions
     /// Default value: <see langword="true"/>.
     /// </summary>
     public bool TargetInfoEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum size in bytes that a single scrape response is allowed to grow to. Default value: ~166 MiB.
+    /// </summary>
+    /// <remarks>
+    /// Increase this value when exposing a very large number of time series.
+    /// </remarks>
+    public int MaxScrapeResponseSizeBytes
+    {
+        get;
+        set
+        {
+            Guard.ThrowIfOutOfRange(value, min: PrometheusExporterOptions.InitialScrapeResponseSizeBytes);
+            field = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets an optional callback to apply custom configuration for the

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -429,6 +429,34 @@ public sealed class PrometheusExporterMiddlewareTests
     }
 
     [Fact]
+    public async Task ScrapeExceedingMaxResponseSizeReturns500()
+    {
+        using var host = await StartTestHostAsync(
+            app => app.UseOpenTelemetryPrometheusScrapingEndpoint(),
+            configureOptions: o => o.MaxScrapeResponseSizeBytes = PrometheusExporterOptions.InitialScrapeResponseSizeBytes);
+
+        using var meter = new Meter(MeterName, MeterVersion);
+
+        // Emit enough series that the serialized response far exceeds the configured maximum, so
+        // the response buffer cannot grow to hold it and the scrape fails rather than returning a
+        // misleading empty 200 response.
+        for (var x = 0; x < 2_000; x++)
+        {
+            meter.CreateCounter<double>("counter_double_" + x, unit: "By").Add(1);
+        }
+
+        host.Services.GetRequiredService<MeterProvider>().ForceFlush();
+
+        using var client = host.GetTestClient();
+
+        using var response = await client.GetAsync(new Uri("/metrics", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        await host.StopAsync();
+    }
+
+    [Fact]
     public async Task InvokeAsync_WhenNoData_Returns200()
     {
         using var exporter = new PrometheusExporter(new PrometheusExporterOptions());

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -495,6 +495,99 @@ public sealed class PrometheusCollectionManagerTests
     }
 
     [Fact]
+    public async Task EnterCollectSharesFailedSerializationResult()
+    {
+        using var meter = CreateMeter();
+#if PROMETHEUS_HTTP_LISTENER
+        using var provider = CreateMeterProviderWithRandomPort(
+            meter,
+            options => options.MaxScrapeResponseSizeBytes = PrometheusExporterOptions.InitialScrapeResponseSizeBytes);
+#elif PROMETHEUS_ASPNETCORE
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddPrometheusExporter(options =>
+            {
+                options.MaxScrapeResponseSizeBytes = PrometheusExporterOptions.InitialScrapeResponseSizeBytes;
+                options.ScrapeResponseCacheDurationMilliseconds = 0;
+            })
+            .Build();
+#endif
+
+#pragma warning disable CA2000 // MeterProvider owns exporter lifecycle
+        Assert.True(provider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
+
+        var collectCount = 0;
+        var firstCollectStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowFirstCollectToComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var originalCollect = exporter!.Collect;
+        exporter.Collect = (timeout) =>
+        {
+            var currentCollectCount = Interlocked.Increment(ref collectCount);
+
+            if (currentCollectCount == 1)
+            {
+                firstCollectStarted.SetResult(true);
+                Assert.True(allowFirstCollectToComplete.Task.Wait(TimeSpan.FromSeconds(5)), "First collection did not resume.");
+            }
+
+            return originalCollect!(timeout);
+        };
+
+        var counter = meter.CreateCounter<long>("test_counter", description: "Help text.");
+        const int SeriesCount = 4_000;
+        for (var i = 0; i < SeriesCount; i++)
+        {
+            counter.Add(
+                1234567890123456789L,
+                new KeyValuePair<string, object?>("index", $"series-value-{i:D8}-padding-padding-padding"));
+        }
+
+        var protocol = GetProtocol(openMetricsRequested: false);
+
+        async Task<PrometheusCollectionManager.CollectionResponse> CollectAsync()
+        {
+            var response = await EnterCollectAsync(exporter, protocol);
+            try
+            {
+                return response;
+            }
+            finally
+            {
+                exporter.CollectionManager.ExitCollect(protocol);
+            }
+        }
+
+        var firstCollectTask = Task.Run(CollectAsync);
+
+        await firstCollectStarted.Task;
+
+        var secondCollectTask = CollectAsync();
+
+        Assert.False(secondCollectTask.IsCompleted, "Second collection did not join the active collection.");
+
+        allowFirstCollectToComplete.SetResult(true);
+
+        var timeout = TimeSpan.FromSeconds(5);
+        var all = Task.WhenAll(firstCollectTask, secondCollectTask);
+
+        using (var cts = new CancellationTokenSource(timeout))
+        {
+            var completion = await Task.WhenAny(all, Task.Delay(timeout, cts.Token));
+            Assert.Same(all, completion);
+        }
+
+        var responses = await all;
+
+        Assert.Equal(1, collectCount);
+        Assert.All(responses, response =>
+        {
+            Assert.False(response.Succeeded, "Expected the collection to fail.");
+            Assert.Equal(0, response.View.Count);
+        });
+    }
+
+    [Fact]
     public async Task OpenMetricsDoesNotEmitScopeInfoMetricFamily()
     {
         using var meter = new Meter("test_meter", "1.0.0", [new("library.mascot", "dotnetbot")], scope: null);
@@ -971,7 +1064,9 @@ public sealed class PrometheusCollectionManagerTests
     private static Meter CreateMeter([CallerMemberName] string name = "") => new(name);
 
 #if PROMETHEUS_HTTP_LISTENER
-    private static MeterProvider CreateMeterProviderWithRandomPort(Meter meter)
+    private static MeterProvider CreateMeterProviderWithRandomPort(
+        Meter meter,
+        Action<PrometheusHttpListenerOptions>? configure = null)
     {
         var retryAttempts = 5;
 
@@ -987,6 +1082,7 @@ public sealed class PrometheusCollectionManagerTests
                     {
                         options.Port = port;
                         options.ScrapeResponseCacheDurationMilliseconds = 0;
+                        configure?.Invoke(options);
                     })
                     .Build();
             }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -877,6 +877,70 @@ public sealed class PrometheusCollectionManagerTests
         }
     }
 
+    [Theory]
+    [InlineData(85_000, false)] // The buffer cannot grow beyond its initial size, so the large scrape is dropped.
+    [InlineData(64 * 1024 * 1024, true)] // Ample budget, so the large scrape is served in full.
+    public async Task MaxScrapeResponseSizeBytesBoundsTheResponseBuffer(int maxScrapeResponseSizeBytes, bool expectNonEmpty)
+    {
+        using var meter = CreateMeter();
+
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+#if PROMETHEUS_HTTP_LISTENER
+            .AddPrometheusHttpListener(options =>
+            {
+                options.MaxScrapeResponseSizeBytes = maxScrapeResponseSizeBytes;
+                options.ScrapeResponseCacheDurationMilliseconds = 0;
+            })
+#elif PROMETHEUS_ASPNETCORE
+            .AddPrometheusExporter(options =>
+            {
+                options.MaxScrapeResponseSizeBytes = maxScrapeResponseSizeBytes;
+                options.ScrapeResponseCacheDurationMilliseconds = 0;
+            })
+#endif
+            .Build();
+
+#pragma warning disable CA2000 // MeterProvider owns exporter lifecycle
+        Assert.True(provider.TryFindExporter(out PrometheusExporter? exporter));
+#pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
+
+        // Emit enough unique time series that the serialized output is far larger than the
+        // 85,000-byte initial scrape buffer, so serving the scrape requires the buffer to grow.
+        var counter = meter.CreateCounter<long>("test_counter", description: "Help text.");
+        const int SeriesCount = 4_000;
+        for (var i = 0; i < SeriesCount; i++)
+        {
+            counter.Add(
+                1234567890123456789L,
+                new KeyValuePair<string, object?>("index", $"series-value-{i:D8}-padding-padding-padding"));
+        }
+
+        var protocol = GetProtocol(openMetricsRequested: false);
+        var response = await exporter!.CollectionManager.EnterCollect(protocol);
+
+        try
+        {
+            if (expectNonEmpty)
+            {
+                // The configured budget is large enough for the buffer to grow and serve the scrape.
+                Assert.True(response.Succeeded, "Expected the collection to succeed.");
+                Assert.True(response.View.Count > 85_000, $"Expected a complete response, but only {response.View.Count} bytes were written.");
+            }
+            else
+            {
+                // The buffer cannot grow past the configured maximum, so the scrape is dropped and a
+                // failed (empty) response is returned rather than allocating without bound.
+                Assert.False(response.Succeeded, "Expected the collection to fail.");
+                Assert.Equal(0, response.View.Count);
+            }
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect(protocol);
+        }
+    }
+
     private static int CountOccurrences(string value, string substring)
     {
         var count = 0;

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -490,6 +490,35 @@ public class PrometheusHttpListenerTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
+    [Fact]
+    public async Task WhenResponseExceedsMaxScrapeResponseSize_Returns500()
+    {
+        using var meter = new Meter(MeterName, MeterVersion);
+
+        using var context = CreateMeterProvider(
+            meter,
+            configureListener: options =>
+            {
+                options.Port = GetRandomPort();
+                options.MaxScrapeResponseSizeBytes = PrometheusExporterOptions.InitialScrapeResponseSizeBytes;
+                return options.Port;
+            });
+
+        // Emit enough series that the serialized response far exceeds the configured maximum, so
+        // the response buffer cannot grow to hold it and the scrape fails rather than returning a
+        // misleading empty 200 response.
+        for (var x = 0; x < 2_000; x++)
+        {
+            meter.CreateCounter<double>("counter_double_" + x, unit: "By").Add(1);
+        }
+
+        using var client = new HttpClient { BaseAddress = context.BaseAddress };
+
+        using var response = await client.GetAsync(new Uri("metrics", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
     internal static MeterProviderTestContext CreateMeterProvider(
         Meter meter,
         Func<PrometheusHttpListenerOptions, int>? configureListener = null,


### PR DESCRIPTION
## Changes

- Allow the maximum Prometheus buffer size to be configured to allow for scrape responses beyond 100,000 metrics.
- Return an HTTP 500 if the buffer is not large enough to contain the scrape response.

---

I was doing some testing and found that there was a practical and unavoidable limit of ~100,000 metric series being handled by the exporter before it hit the limits of the internal buffer length and would then just return empty scrape responses, regardless of the configured cardinality limits.

https://github.com/open-telemetry/opentelemetry-dotnet/blob/8592991371f0227e0522d145546cc67757bea9e1/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs#L788

With these changes from some testing, the exporter can now handle up to somewhere in the region of ~2.4 million series for PrometheusText format and somewhere in the region of ~1.8 million for OpenMetrics format.

The buffer length limit appears to have been an arbitrary cap added in #2610:

https://github.com/open-telemetry/opentelemetry-dotnet/blob/f94bc5f36130a1dcb0a21c69c5837cf9bcba03a3/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusCollectionManager.cs#L188-L197

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
