### PR TITLE
[Exporter.OTLP] Mask reserved log trace flag bits

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogFieldNumberConstants.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogFieldNumberConstants.cs
@@ -67,6 +67,6 @@ internal static class ProtobufOtlpLogFieldNumberConstants
 
     // LogRecordFlags
     internal const int LogRecord_Flags_Do_Not_Use = 0;
-    internal const int LogRecord_Flags_Trace_Flags_Mask = 0x000000FF;
+    internal const uint LogRecord_Flags_Trace_Flags_Mask = 0x000000FF;
 }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -270,7 +270,9 @@ internal static class ProtobufOtlpLogSerializer
             otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTagAndLength(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, SpanIdSize, ProtobufOtlpLogFieldNumberConstants.LogRecord_Span_Id, ProtobufWireType.LEN);
             otlpTagWriterState.WritePosition = ProtobufOtlpTraceSerializer.WriteSpanId(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, logRecord.SpanId);
 
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteFixed32WithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Flags, (uint)logRecord.TraceFlags);
+            var traceFlags = (uint)logRecord.TraceFlags
+                & ProtobufOtlpLogFieldNumberConstants.LogRecord_Flags_Trace_Flags_Mask;
+            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteFixed32WithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Flags, traceFlags);
         }
 
         if (logRecord.EventId.Name != null)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -612,6 +612,32 @@ public class OtlpLogExporterTests
         Assert.Equal((uint)logRecord.TraceFlags, otlpLogRecord.Flags);
     }
 
+    [Fact]
+    public void CheckToOtlpLogRecordMasksReservedTraceFlagBits()
+    {
+        var logRecords = new List<LogRecord>();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.UseOpenTelemetry(logging => logging.AddInMemoryExporter(logRecords));
+        });
+
+        var logger = loggerFactory.CreateLogger("OtlpLogExporterTests");
+
+        using (var activity = new Activity(Utils.GetCurrentMethodName()))
+        {
+            activity.Start();
+            logger.LogWithinAnActivity();
+        }
+
+        var logRecord = Assert.Single(logRecords);
+        logRecord.TraceFlags = (ActivityTraceFlags)0x00000103;
+
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+
+        Assert.NotNull(otlpLogRecord);
+        Assert.Equal(0x00000003u, otlpLogRecord.Flags);
+    }
+
     [Theory]
     [InlineData(LogLevel.Trace)]
     [InlineData(LogLevel.Debug)]


### PR DESCRIPTION
Fixes #6041

## Changes

Leftovers from the historical implementation of OTLP exporter.
I would not consider this as a breaking change. It is tiny fix, such values should never occur in the real life. Purely defensive programming.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
