### PR TITLE
[Exporter.Prometheus] Fix spec compliance

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -55,6 +55,15 @@ Notes](../../RELEASENOTES.md).
   `PrometheusHttpListener` endpoint.
   ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
 
+* Fixed `# HELP` metadata not escaping double-quote characters for the
+  OpenMetrics text format.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
+* Fixed content negotiation defaulting to OpenMetrics 0.0.1 instead of 1.0.0
+  when an `application/openmetrics-text` `Accept` header entry does not
+  specify a `version` parameter.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -48,6 +48,13 @@ Notes](../../RELEASENOTES.md).
   limit now responds with HTTP 500.
   ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
+* Fixed the Prometheus text exposition format emitting redundant comments.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
+* Made `Accept` header content negotiation consistent with the
+  `PrometheusHttpListener` endpoint.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -49,20 +49,20 @@ Notes](../../RELEASENOTES.md).
   ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
 * Fixed the Prometheus text exposition format emitting redundant comments.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
 * Made `Accept` header content negotiation consistent with the
   `PrometheusHttpListener` endpoint.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
 * Fixed `# HELP` metadata not escaping double-quote characters for the
   OpenMetrics text format.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
 * Fixed content negotiation defaulting to OpenMetrics 0.0.1 instead of 1.0.0
   when an `application/openmetrics-text` `Accept` header entry does not
   specify a `version` parameter.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -165,28 +165,23 @@ internal sealed class PrometheusExporterMiddleware
             return PrometheusProtocol.Fallback;
         }
 
-        if (acceptHeader is { Count: 1 })
-        {
-            return TryParse(acceptHeader[0], out var protocol, out _)
-                ? protocol.GetValueOrDefault(PrometheusProtocol.Fallback)
-                : PrometheusProtocol.Fallback;
-        }
-
-        const int SupportedProtocols = 4;
-        var preferences = new PriorityQueue<PrometheusProtocol, double>(SupportedProtocols);
+        // Select the acceptable protocol with the highest quality factor, preferring
+        // the one listed first on a tie. Only a strictly greater quality replaces
+        // the current best, so the selection is stable in document order.
+        PrometheusProtocol? preferred = null;
+        var preferredQuality = 0.0;
 
         foreach (var mediaType in acceptHeader)
         {
-            if (TryParse(mediaType, out var protocol, out var quality))
+            if (TryParse(mediaType, out var protocol, out var quality) &&
+                (preferred is null || quality > preferredQuality))
             {
-                preferences.Enqueue(protocol.Value, -quality);
+                preferred = protocol;
+                preferredQuality = quality;
             }
         }
 
-        // Use the first supported protocol that was parsed that has the highest quality factor
-        return preferences.TryDequeue(out var preferred, out _)
-            ? preferred
-            : PrometheusProtocol.Fallback;
+        return preferred ?? PrometheusProtocol.Fallback;
     }
 
     private static bool TryParse(
@@ -221,23 +216,31 @@ internal sealed class PrometheusExporterMiddleware
             return false;
         }
 
-        // Quality ignores values greater than one and returns null so we cannot
-        // distinguish between an invalid quality and the quality not be provided.
-        // Default to a value of 0.99 so that an invalid quality value will be treated
-        // as a lower preference than a valid quality value of 1.0.
-        quality = value.Quality ?? 0.99;
-
-        if (quality <= 0)
-        {
-            return false;
-        }
+        // Default to a quality of 1.0 when no "q" parameter is present (per HTTP semantics) and
+        // reject any quality outside the (0, 1] range. The "q" parameter is parsed directly from
+        // the parameter collection rather than via MediaTypeHeaderValue.Quality for consistent
+        // behaviour with the HttpListener implementation.
+        quality = 1.0;
 
         string? escaping = null;
         Version? version = null;
 
         foreach (var parameter in value.Parameters)
         {
-            if (string.Equals(parameter.Name.Value, "version", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(parameter.Name.Value, "q", StringComparison.OrdinalIgnoreCase))
+            {
+                if (double.TryParse(parameter.Value.Value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var parsedQuality) &&
+                    parsedQuality is > 0 and <= 1)
+                {
+                    quality = parsedQuality;
+                }
+                else
+                {
+                    // Invalid quality
+                    return false;
+                }
+            }
+            else if (string.Equals(parameter.Name.Value, "version", StringComparison.OrdinalIgnoreCase))
             {
                 if (Version.TryParse(parameter.Value.Value?.Trim('"'), out var parsedVersion) &&
                     supportedVersions.Contains(parsedVersion))

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -269,11 +269,15 @@ internal sealed class PrometheusExporterMiddleware
 
         if (version is null)
         {
-            // Use the oldest version if no version preference was specified
-            version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV0 : PrometheusProtocol.PrometheusV0;
-            escaping = null;
+            // Use the oldest version if no version preference was specified. Per the OpenMetrics
+            // specification's negotiation rules (https://prometheus.io/docs/specs/om/open_metrics_spec/#protocol-negotiation),
+            // "the standard" begins at 1.0.0 (0.0.1 predates the standard being ratified), so servers
+            // MUST default to OpenMetrics 1.0.0 for an unversioned "application/openmetrics-text" entry.
+            // The Prometheus text media type is unaffected by that rule and still falls back to 0.0.4.
+            version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV0;
         }
-        else if (version.Major is not > 0)
+
+        if (version.Major is not > 0)
         {
             // From https://prometheus.io/docs/instrumenting/content_negotiation/#content-type-response:
             // "The Content-Type header MUST include [...] For text formats version 1.0.0 and above, the escaping scheme parameter."

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -54,6 +54,9 @@ Notes](../../RELEASENOTES.md).
   limit now responds with HTTP 500.
   ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
+* Fixed the Prometheus text exposition format emitting redundant comments.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -55,16 +55,16 @@ Notes](../../RELEASENOTES.md).
   ([#7487](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7487))
 
 * Fixed the Prometheus text exposition format emitting redundant comments.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
 * Fixed `# HELP` metadata not escaping double-quote characters for the
   OpenMetrics text format.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
 * Fixed content negotiation defaulting to OpenMetrics 0.0.1 instead of 1.0.0
   when an `application/openmetrics-text` `Accept` header entry does not
   specify a `version` parameter.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -57,6 +57,15 @@ Notes](../../RELEASENOTES.md).
 * Fixed the Prometheus text exposition format emitting redundant comments.
   ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
 
+* Fixed `# HELP` metadata not escaping double-quote characters for the
+  OpenMetrics text format.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
+* Fixed content negotiation defaulting to OpenMetrics 0.0.1 instead of 1.0.0
+  when an `application/openmetrics-text` `Accept` header entry does not
+  specify a `version` parameter.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusHeadersParser.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusHeadersParser.cs
@@ -110,13 +110,13 @@ internal static class PrometheusHeadersParser
                 continue;
             }
 
-            if (version is null)
-            {
-                // Use the oldest version if no version preference was specified
-                version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV0 : PrometheusProtocol.PrometheusV0;
-                escaping = null;
-            }
-            else if (version.Major is not > 0)
+            // Use the oldest version if no version preference was specified. Per the OpenMetrics
+            // specification's negotiation rules (https://prometheus.io/docs/specs/om/open_metrics_spec/#protocol-negotiation),
+            // "the standard" begins at 1.0.0 (0.0.1 predates the standard being ratified), so servers
+            // MUST default to OpenMetrics 1.0.0 for an unversioned "application/openmetrics-text" entry.
+            version ??= isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV0;
+
+            if (version.Major is not > 0)
             {
                 // From https://prometheus.io/docs/instrumenting/content_negotiation/#content-type-response:
                 // "The Content-Type header MUST include [...] For text formats version 1.0.0 and above, the escaping scheme parameter."

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -402,7 +402,7 @@ internal sealed class PrometheusCollectionManager
             {
                 try
                 {
-                    cursor = TextFormatSerializer.WriteEof(state.Buffer, cursor);
+                    cursor = serializer.WriteEof(state.Buffer, cursor);
                     break;
                 }
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/OpenMetricsSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/OpenMetricsSerializer.cs
@@ -16,6 +16,16 @@ internal abstract class OpenMetricsSerializer : TextFormatSerializer
 
     protected override string TargetInfoTypeValue => "info";
 
+    public override int WriteEof(byte[] buffer, int cursor)
+    {
+        // OpenMetrics expositions MUST be terminated with "# EOF".
+        // See https://prometheus.io/docs/specs/om/open_metrics_spec/#overall-structure.
+        cursor = WriteAsciiStringNoEscape(buffer, cursor, "# EOF");
+        buffer[cursor++] = AsciiLineFeed;
+
+        return cursor;
+    }
+
     public override string GetMetadataName(PrometheusMetric metric)
         => metric.GetNameSet(this.Escaping).OpenMetricsMetadataName;
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/OpenMetricsSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/OpenMetricsSerializer.cs
@@ -16,6 +16,8 @@ internal abstract class OpenMetricsSerializer : TextFormatSerializer
 
     protected override string TargetInfoTypeValue => "info";
 
+    protected override bool EscapeHelpQuotationMarks => true;
+
     public override int WriteEof(byte[] buffer, int cursor)
     {
         // OpenMetrics expositions MUST be terminated with "# EOF".

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/PrometheusTextSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/PrometheusTextSerializer.cs
@@ -20,6 +20,8 @@ internal abstract class PrometheusTextSerializer : TextFormatSerializer
 
     protected override string TargetInfoTypeValue => "gauge";
 
+    protected override bool EscapeHelpQuotationMarks => false;
+
     public override string GetMetadataName(PrometheusMetric metric)
         => metric.GetNameSet(this.Escaping).Name;
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/PrometheusTextSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/PrometheusTextSerializer.cs
@@ -23,6 +23,9 @@ internal abstract class PrometheusTextSerializer : TextFormatSerializer
     public override string GetMetadataName(PrometheusMetric metric)
         => metric.GetNameSet(this.Escaping).Name;
 
+    internal override int WriteUnitMetadata(byte[] buffer, int cursor, PrometheusMetric metric, string? unit)
+        => cursor;
+
     protected override ReadOnlySpan<byte> GetMetricNameBytes(PrometheusMetric metric)
         => metric.GetNameSet(this.Escaping).NameBytes;
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
@@ -150,14 +150,7 @@ internal abstract class TextFormatSerializer
         };
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int WriteEof(byte[] buffer, int cursor)
-    {
-        cursor = WriteAsciiStringNoEscape(buffer, cursor, "# EOF");
-        buffer[cursor++] = AsciiLineFeed;
-
-        return cursor;
-    }
+    public virtual int WriteEof(byte[] buffer, int cursor) => cursor;
 
     public int WriteMetric(
         byte[] buffer,
@@ -1129,8 +1122,7 @@ internal abstract class TextFormatSerializer
         return cursor;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int WriteUnitMetadata(byte[] buffer, int cursor, PrometheusMetric metric, string? unit)
+    internal virtual int WriteUnitMetadata(byte[] buffer, int cursor, PrometheusMetric metric, string? unit)
     {
         if (string.IsNullOrEmpty(unit))
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
@@ -129,6 +129,11 @@ internal abstract class TextFormatSerializer
     /// </summary>
     protected abstract string TargetInfoTypeValue { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether double-quote characters in <c>HELP</c> text must be escaped.
+    /// </summary>
+    protected abstract bool EscapeHelpQuotationMarks { get; }
+
     public static TextFormatSerializer GetSerializer(in PrometheusProtocol protocol)
     {
         var escaping = protocol.EscapingScheme;
@@ -1097,7 +1102,7 @@ internal abstract class TextFormatSerializer
         if (!string.IsNullOrEmpty(metricDescription))
         {
             buffer[cursor++] = unchecked((byte)' ');
-            cursor = WriteUnicodeString(buffer, cursor, metricDescription);
+            cursor = WriteEscapedString(buffer, cursor, metricDescription, this.EscapeHelpQuotationMarks);
         }
 
         buffer[cursor++] = AsciiLineFeed;

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -768,9 +768,7 @@ public sealed class PrometheusExporterMiddlewareTests
                     # HELP target_info Target metadata
                     target_info{service_name="my_service",service_instance_id="id1"} 1
                     # TYPE counter_double_bytes_total counter
-                    # UNIT counter_double_bytes_total bytes
                     counter_double_bytes_total{otel_scope_name="{{MeterName}}",otel_scope_version="{{MeterVersion}}",{{additionalTags}}key1="value1",key2="value2"} 101.17
-                    # EOF
 
                     """.ReplaceLineEndings();
 

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -732,7 +732,7 @@ public sealed class PrometheusExporterMiddlewareTests
 
         contentType ??=
             requestOpenMetrics ?
-            "application/openmetrics-text; version=0.0.1; charset=utf-8" :
+            "application/openmetrics-text; version=1.0.0; charset=utf-8; escaping=underscores" :
             "text/plain; version=0.0.4; charset=utf-8";
 
         Assert.Equal(contentType, response.Content.Headers.ContentType!.ToString());

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusIntegrationTests.cs
@@ -118,7 +118,8 @@ public class PrometheusIntegrationTests(PromToolFixture promtool, ITestOutputHel
         var content = await reader.ReadToEndAsync();
 
         Assert.NotEmpty(content);
-        Assert.EndsWith("# EOF\n", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("# EOF", content, StringComparison.Ordinal);
+        Assert.EndsWith("\n", content, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusAcceptHeaders.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusAcceptHeaders.cs
@@ -33,19 +33,23 @@ public static class PrometheusAcceptHeaders
 
         string[] openMetricsV0 =
         [
-            "application/openmetrics-text",
             "application/openmetrics-text;version=0.0.1;q=0.6,*/*;q=0.5",
             "application/openmetrics-text; version=0.0.1",
             "application/openmetrics-text; version=0.0.1; charset=utf-8",
             "application/openmetrics-text; version=\"0.0.1\"",
-            "application/openmetrics-text; escaping=dots",
-            "application/openmetrics-text; escaping=values",
         ];
 
         foreach (var accept in openMetricsV0)
         {
             testCases.Add(accept, "application/openmetrics-text", true, "0.0.1", null);
         }
+
+        // Per https://prometheus.io/docs/specs/om/open_metrics_spec/#protocol-negotiation, negotiation
+        // "MUST default to the oldest version of the standard (i.e. 1.0.0)" when no version is requested,
+        // so an "application/openmetrics-text" entry without a version parameter negotiates 1.0.0, not 0.0.1.
+        testCases.Add("application/openmetrics-text", "application/openmetrics-text", true, "1.0.0", "underscores");
+        testCases.Add("application/openmetrics-text; escaping=dots", "application/openmetrics-text", true, "1.0.0", "dots");
+        testCases.Add("application/openmetrics-text; escaping=values", "application/openmetrics-text", true, "1.0.0", "values");
 
         string[] openMetricsV1 =
         [

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -672,9 +672,7 @@ public class PrometheusHttpListenerTests
                   + "# HELP target_info Target metadata\n"
                   + "target_info{service_name='my_service',service_instance_id='id1'} 1\n"
                   + "# TYPE counter_double_bytes_total counter\n"
-                  + "# UNIT counter_double_bytes_total bytes\n"
-                  + $"counter_double_bytes_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',{additionalTags}key1='value1',key2='value2'}} 101.17\n"
-                  + "# EOF\n";
+                  + $"counter_double_bytes_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',{additionalTags}key1='value1',key2='value2'}} 101.17\n";
 
             Assert.Matches(("^" + expected + "$").Replace('\'', '"'), content);
         }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -645,7 +645,7 @@ public class PrometheusHttpListenerTests
 
             contentType ??=
                 requestOpenMetrics ?
-                "application/openmetrics-text; version=0.0.1; charset=utf-8" :
+                "application/openmetrics-text; version=1.0.0; charset=utf-8; escaping=underscores" :
                 "text/plain; version=0.0.4; charset=utf-8";
 
             Assert.NotNull(response.Content);

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -1664,6 +1664,35 @@ public sealed partial class PrometheusSerializerTests
         Assert.Equal(expected, actual);
     }
 
+    [Fact]
+    public void WriteHelpMetadataDoesNotEscapeQuotationMarksForPrometheusText()
+    {
+        var buffer = new byte[128];
+        var metric = new PrometheusMetric("test_metric", string.Empty, PrometheusType.Gauge, disableTotalNameSuffixForCounters: false);
+
+        var cursor = TextFormatSerializer.PrometheusV1.WriteHelpMetadata(buffer, 0, metric, "A \"quoted\" description");
+        var actual = Encoding.UTF8.GetString(buffer, 0, cursor);
+
+        // The Prometheus text exposition format only requires escaping the backslash and line feed
+        // characters in HELP text, so double quotes are written unescaped.
+        Assert.Equal("# HELP test_metric A \"quoted\" description\n", actual);
+    }
+
+    [Fact]
+    public void WriteHelpMetadataEscapesQuotationMarksForOpenMetrics()
+    {
+        var buffer = new byte[128];
+        var metric = new PrometheusMetric("test_metric", string.Empty, PrometheusType.Gauge, disableTotalNameSuffixForCounters: false);
+
+        var cursor = TextFormatSerializer.OpenMetricsV1.WriteHelpMetadata(buffer, 0, metric, "A \"quoted\" description");
+        var actual = Encoding.UTF8.GetString(buffer, 0, cursor);
+
+        // Per the OpenMetrics 1.0.0 ABNF, double quotes are excluded from "normal-char" and MUST be
+        // escaped as \" within an "escaped-string" (which HELP text is), unlike the classic Prometheus
+        // text format. See https://prometheus.io/docs/specs/om/open_metrics_spec/#escaping.
+        Assert.Equal("# HELP test_metric A \\\"quoted\\\" description\n", actual);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -1721,9 +1721,20 @@ public sealed partial class PrometheusSerializerTests
         var buffer = new byte[64];
         var metric = new PrometheusMetric("test", string.Empty, PrometheusType.Gauge, disableTotalNameSuffixForCounters: false);
 
-        var cursor = TextFormatSerializer.PrometheusV1.WriteUnitMetadata(buffer, 0, metric, "seconds");
+        var cursor = TextFormatSerializer.OpenMetricsV1.WriteUnitMetadata(buffer, 0, metric, "seconds");
 
         Assert.Equal("# UNIT test seconds\n", Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    [Fact]
+    public void WriteUnitMetadataIsNotWrittenForPrometheusTextFormat()
+    {
+        var buffer = new byte[64];
+        var metric = new PrometheusMetric("test", string.Empty, PrometheusType.Gauge, disableTotalNameSuffixForCounters: false);
+
+        var cursor = TextFormatSerializer.PrometheusV1.WriteUnitMetadata(buffer, 0, metric, "seconds");
+
+        Assert.Equal(0, cursor);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.BufferSizeIncreasesWithLotOfMetrics.verified.text
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.BufferSizeIncreasesWithLotOfMetrics.verified.text
@@ -2,3003 +2,2002 @@
 # HELP target_info Target metadata
 target_info{service_name="my_service",service_instance_id="id1"} 1
 # TYPE counter_double_0_bytes_total counter
-# UNIT counter_double_0_bytes_total bytes
 counter_double_0_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_100_bytes_total counter
-# UNIT counter_double_100_bytes_total bytes
 counter_double_100_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_101_bytes_total counter
-# UNIT counter_double_101_bytes_total bytes
 counter_double_101_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_102_bytes_total counter
-# UNIT counter_double_102_bytes_total bytes
 counter_double_102_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_103_bytes_total counter
-# UNIT counter_double_103_bytes_total bytes
 counter_double_103_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_104_bytes_total counter
-# UNIT counter_double_104_bytes_total bytes
 counter_double_104_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_105_bytes_total counter
-# UNIT counter_double_105_bytes_total bytes
 counter_double_105_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_106_bytes_total counter
-# UNIT counter_double_106_bytes_total bytes
 counter_double_106_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_107_bytes_total counter
-# UNIT counter_double_107_bytes_total bytes
 counter_double_107_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_108_bytes_total counter
-# UNIT counter_double_108_bytes_total bytes
 counter_double_108_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_109_bytes_total counter
-# UNIT counter_double_109_bytes_total bytes
 counter_double_109_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_10_bytes_total counter
-# UNIT counter_double_10_bytes_total bytes
 counter_double_10_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_110_bytes_total counter
-# UNIT counter_double_110_bytes_total bytes
 counter_double_110_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_111_bytes_total counter
-# UNIT counter_double_111_bytes_total bytes
 counter_double_111_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_112_bytes_total counter
-# UNIT counter_double_112_bytes_total bytes
 counter_double_112_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_113_bytes_total counter
-# UNIT counter_double_113_bytes_total bytes
 counter_double_113_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_114_bytes_total counter
-# UNIT counter_double_114_bytes_total bytes
 counter_double_114_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_115_bytes_total counter
-# UNIT counter_double_115_bytes_total bytes
 counter_double_115_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_116_bytes_total counter
-# UNIT counter_double_116_bytes_total bytes
 counter_double_116_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_117_bytes_total counter
-# UNIT counter_double_117_bytes_total bytes
 counter_double_117_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_118_bytes_total counter
-# UNIT counter_double_118_bytes_total bytes
 counter_double_118_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_119_bytes_total counter
-# UNIT counter_double_119_bytes_total bytes
 counter_double_119_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_11_bytes_total counter
-# UNIT counter_double_11_bytes_total bytes
 counter_double_11_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_120_bytes_total counter
-# UNIT counter_double_120_bytes_total bytes
 counter_double_120_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_121_bytes_total counter
-# UNIT counter_double_121_bytes_total bytes
 counter_double_121_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_122_bytes_total counter
-# UNIT counter_double_122_bytes_total bytes
 counter_double_122_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_123_bytes_total counter
-# UNIT counter_double_123_bytes_total bytes
 counter_double_123_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_124_bytes_total counter
-# UNIT counter_double_124_bytes_total bytes
 counter_double_124_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_125_bytes_total counter
-# UNIT counter_double_125_bytes_total bytes
 counter_double_125_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_126_bytes_total counter
-# UNIT counter_double_126_bytes_total bytes
 counter_double_126_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_127_bytes_total counter
-# UNIT counter_double_127_bytes_total bytes
 counter_double_127_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_128_bytes_total counter
-# UNIT counter_double_128_bytes_total bytes
 counter_double_128_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_129_bytes_total counter
-# UNIT counter_double_129_bytes_total bytes
 counter_double_129_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_12_bytes_total counter
-# UNIT counter_double_12_bytes_total bytes
 counter_double_12_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_130_bytes_total counter
-# UNIT counter_double_130_bytes_total bytes
 counter_double_130_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_131_bytes_total counter
-# UNIT counter_double_131_bytes_total bytes
 counter_double_131_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_132_bytes_total counter
-# UNIT counter_double_132_bytes_total bytes
 counter_double_132_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_133_bytes_total counter
-# UNIT counter_double_133_bytes_total bytes
 counter_double_133_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_134_bytes_total counter
-# UNIT counter_double_134_bytes_total bytes
 counter_double_134_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_135_bytes_total counter
-# UNIT counter_double_135_bytes_total bytes
 counter_double_135_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_136_bytes_total counter
-# UNIT counter_double_136_bytes_total bytes
 counter_double_136_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_137_bytes_total counter
-# UNIT counter_double_137_bytes_total bytes
 counter_double_137_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_138_bytes_total counter
-# UNIT counter_double_138_bytes_total bytes
 counter_double_138_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_139_bytes_total counter
-# UNIT counter_double_139_bytes_total bytes
 counter_double_139_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_13_bytes_total counter
-# UNIT counter_double_13_bytes_total bytes
 counter_double_13_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_140_bytes_total counter
-# UNIT counter_double_140_bytes_total bytes
 counter_double_140_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_141_bytes_total counter
-# UNIT counter_double_141_bytes_total bytes
 counter_double_141_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_142_bytes_total counter
-# UNIT counter_double_142_bytes_total bytes
 counter_double_142_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_143_bytes_total counter
-# UNIT counter_double_143_bytes_total bytes
 counter_double_143_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_144_bytes_total counter
-# UNIT counter_double_144_bytes_total bytes
 counter_double_144_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_145_bytes_total counter
-# UNIT counter_double_145_bytes_total bytes
 counter_double_145_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_146_bytes_total counter
-# UNIT counter_double_146_bytes_total bytes
 counter_double_146_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_147_bytes_total counter
-# UNIT counter_double_147_bytes_total bytes
 counter_double_147_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_148_bytes_total counter
-# UNIT counter_double_148_bytes_total bytes
 counter_double_148_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_149_bytes_total counter
-# UNIT counter_double_149_bytes_total bytes
 counter_double_149_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_14_bytes_total counter
-# UNIT counter_double_14_bytes_total bytes
 counter_double_14_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_150_bytes_total counter
-# UNIT counter_double_150_bytes_total bytes
 counter_double_150_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_151_bytes_total counter
-# UNIT counter_double_151_bytes_total bytes
 counter_double_151_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_152_bytes_total counter
-# UNIT counter_double_152_bytes_total bytes
 counter_double_152_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_153_bytes_total counter
-# UNIT counter_double_153_bytes_total bytes
 counter_double_153_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_154_bytes_total counter
-# UNIT counter_double_154_bytes_total bytes
 counter_double_154_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_155_bytes_total counter
-# UNIT counter_double_155_bytes_total bytes
 counter_double_155_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_156_bytes_total counter
-# UNIT counter_double_156_bytes_total bytes
 counter_double_156_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_157_bytes_total counter
-# UNIT counter_double_157_bytes_total bytes
 counter_double_157_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_158_bytes_total counter
-# UNIT counter_double_158_bytes_total bytes
 counter_double_158_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_159_bytes_total counter
-# UNIT counter_double_159_bytes_total bytes
 counter_double_159_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_15_bytes_total counter
-# UNIT counter_double_15_bytes_total bytes
 counter_double_15_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_160_bytes_total counter
-# UNIT counter_double_160_bytes_total bytes
 counter_double_160_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_161_bytes_total counter
-# UNIT counter_double_161_bytes_total bytes
 counter_double_161_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_162_bytes_total counter
-# UNIT counter_double_162_bytes_total bytes
 counter_double_162_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_163_bytes_total counter
-# UNIT counter_double_163_bytes_total bytes
 counter_double_163_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_164_bytes_total counter
-# UNIT counter_double_164_bytes_total bytes
 counter_double_164_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_165_bytes_total counter
-# UNIT counter_double_165_bytes_total bytes
 counter_double_165_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_166_bytes_total counter
-# UNIT counter_double_166_bytes_total bytes
 counter_double_166_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_167_bytes_total counter
-# UNIT counter_double_167_bytes_total bytes
 counter_double_167_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_168_bytes_total counter
-# UNIT counter_double_168_bytes_total bytes
 counter_double_168_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_169_bytes_total counter
-# UNIT counter_double_169_bytes_total bytes
 counter_double_169_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_16_bytes_total counter
-# UNIT counter_double_16_bytes_total bytes
 counter_double_16_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_170_bytes_total counter
-# UNIT counter_double_170_bytes_total bytes
 counter_double_170_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_171_bytes_total counter
-# UNIT counter_double_171_bytes_total bytes
 counter_double_171_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_172_bytes_total counter
-# UNIT counter_double_172_bytes_total bytes
 counter_double_172_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_173_bytes_total counter
-# UNIT counter_double_173_bytes_total bytes
 counter_double_173_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_174_bytes_total counter
-# UNIT counter_double_174_bytes_total bytes
 counter_double_174_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_175_bytes_total counter
-# UNIT counter_double_175_bytes_total bytes
 counter_double_175_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_176_bytes_total counter
-# UNIT counter_double_176_bytes_total bytes
 counter_double_176_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_177_bytes_total counter
-# UNIT counter_double_177_bytes_total bytes
 counter_double_177_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_178_bytes_total counter
-# UNIT counter_double_178_bytes_total bytes
 counter_double_178_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_179_bytes_total counter
-# UNIT counter_double_179_bytes_total bytes
 counter_double_179_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_17_bytes_total counter
-# UNIT counter_double_17_bytes_total bytes
 counter_double_17_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_180_bytes_total counter
-# UNIT counter_double_180_bytes_total bytes
 counter_double_180_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_181_bytes_total counter
-# UNIT counter_double_181_bytes_total bytes
 counter_double_181_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_182_bytes_total counter
-# UNIT counter_double_182_bytes_total bytes
 counter_double_182_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_183_bytes_total counter
-# UNIT counter_double_183_bytes_total bytes
 counter_double_183_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_184_bytes_total counter
-# UNIT counter_double_184_bytes_total bytes
 counter_double_184_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_185_bytes_total counter
-# UNIT counter_double_185_bytes_total bytes
 counter_double_185_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_186_bytes_total counter
-# UNIT counter_double_186_bytes_total bytes
 counter_double_186_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_187_bytes_total counter
-# UNIT counter_double_187_bytes_total bytes
 counter_double_187_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_188_bytes_total counter
-# UNIT counter_double_188_bytes_total bytes
 counter_double_188_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_189_bytes_total counter
-# UNIT counter_double_189_bytes_total bytes
 counter_double_189_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_18_bytes_total counter
-# UNIT counter_double_18_bytes_total bytes
 counter_double_18_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_190_bytes_total counter
-# UNIT counter_double_190_bytes_total bytes
 counter_double_190_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_191_bytes_total counter
-# UNIT counter_double_191_bytes_total bytes
 counter_double_191_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_192_bytes_total counter
-# UNIT counter_double_192_bytes_total bytes
 counter_double_192_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_193_bytes_total counter
-# UNIT counter_double_193_bytes_total bytes
 counter_double_193_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_194_bytes_total counter
-# UNIT counter_double_194_bytes_total bytes
 counter_double_194_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_195_bytes_total counter
-# UNIT counter_double_195_bytes_total bytes
 counter_double_195_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_196_bytes_total counter
-# UNIT counter_double_196_bytes_total bytes
 counter_double_196_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_197_bytes_total counter
-# UNIT counter_double_197_bytes_total bytes
 counter_double_197_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_198_bytes_total counter
-# UNIT counter_double_198_bytes_total bytes
 counter_double_198_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_199_bytes_total counter
-# UNIT counter_double_199_bytes_total bytes
 counter_double_199_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_19_bytes_total counter
-# UNIT counter_double_19_bytes_total bytes
 counter_double_19_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_1_bytes_total counter
-# UNIT counter_double_1_bytes_total bytes
 counter_double_1_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_200_bytes_total counter
-# UNIT counter_double_200_bytes_total bytes
 counter_double_200_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_201_bytes_total counter
-# UNIT counter_double_201_bytes_total bytes
 counter_double_201_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_202_bytes_total counter
-# UNIT counter_double_202_bytes_total bytes
 counter_double_202_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_203_bytes_total counter
-# UNIT counter_double_203_bytes_total bytes
 counter_double_203_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_204_bytes_total counter
-# UNIT counter_double_204_bytes_total bytes
 counter_double_204_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_205_bytes_total counter
-# UNIT counter_double_205_bytes_total bytes
 counter_double_205_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_206_bytes_total counter
-# UNIT counter_double_206_bytes_total bytes
 counter_double_206_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_207_bytes_total counter
-# UNIT counter_double_207_bytes_total bytes
 counter_double_207_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_208_bytes_total counter
-# UNIT counter_double_208_bytes_total bytes
 counter_double_208_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_209_bytes_total counter
-# UNIT counter_double_209_bytes_total bytes
 counter_double_209_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_20_bytes_total counter
-# UNIT counter_double_20_bytes_total bytes
 counter_double_20_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_210_bytes_total counter
-# UNIT counter_double_210_bytes_total bytes
 counter_double_210_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_211_bytes_total counter
-# UNIT counter_double_211_bytes_total bytes
 counter_double_211_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_212_bytes_total counter
-# UNIT counter_double_212_bytes_total bytes
 counter_double_212_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_213_bytes_total counter
-# UNIT counter_double_213_bytes_total bytes
 counter_double_213_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_214_bytes_total counter
-# UNIT counter_double_214_bytes_total bytes
 counter_double_214_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_215_bytes_total counter
-# UNIT counter_double_215_bytes_total bytes
 counter_double_215_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_216_bytes_total counter
-# UNIT counter_double_216_bytes_total bytes
 counter_double_216_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_217_bytes_total counter
-# UNIT counter_double_217_bytes_total bytes
 counter_double_217_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_218_bytes_total counter
-# UNIT counter_double_218_bytes_total bytes
 counter_double_218_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_219_bytes_total counter
-# UNIT counter_double_219_bytes_total bytes
 counter_double_219_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_21_bytes_total counter
-# UNIT counter_double_21_bytes_total bytes
 counter_double_21_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_220_bytes_total counter
-# UNIT counter_double_220_bytes_total bytes
 counter_double_220_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_221_bytes_total counter
-# UNIT counter_double_221_bytes_total bytes
 counter_double_221_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_222_bytes_total counter
-# UNIT counter_double_222_bytes_total bytes
 counter_double_222_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_223_bytes_total counter
-# UNIT counter_double_223_bytes_total bytes
 counter_double_223_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_224_bytes_total counter
-# UNIT counter_double_224_bytes_total bytes
 counter_double_224_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_225_bytes_total counter
-# UNIT counter_double_225_bytes_total bytes
 counter_double_225_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_226_bytes_total counter
-# UNIT counter_double_226_bytes_total bytes
 counter_double_226_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_227_bytes_total counter
-# UNIT counter_double_227_bytes_total bytes
 counter_double_227_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_228_bytes_total counter
-# UNIT counter_double_228_bytes_total bytes
 counter_double_228_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_229_bytes_total counter
-# UNIT counter_double_229_bytes_total bytes
 counter_double_229_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_22_bytes_total counter
-# UNIT counter_double_22_bytes_total bytes
 counter_double_22_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_230_bytes_total counter
-# UNIT counter_double_230_bytes_total bytes
 counter_double_230_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_231_bytes_total counter
-# UNIT counter_double_231_bytes_total bytes
 counter_double_231_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_232_bytes_total counter
-# UNIT counter_double_232_bytes_total bytes
 counter_double_232_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_233_bytes_total counter
-# UNIT counter_double_233_bytes_total bytes
 counter_double_233_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_234_bytes_total counter
-# UNIT counter_double_234_bytes_total bytes
 counter_double_234_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_235_bytes_total counter
-# UNIT counter_double_235_bytes_total bytes
 counter_double_235_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_236_bytes_total counter
-# UNIT counter_double_236_bytes_total bytes
 counter_double_236_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_237_bytes_total counter
-# UNIT counter_double_237_bytes_total bytes
 counter_double_237_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_238_bytes_total counter
-# UNIT counter_double_238_bytes_total bytes
 counter_double_238_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_239_bytes_total counter
-# UNIT counter_double_239_bytes_total bytes
 counter_double_239_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_23_bytes_total counter
-# UNIT counter_double_23_bytes_total bytes
 counter_double_23_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_240_bytes_total counter
-# UNIT counter_double_240_bytes_total bytes
 counter_double_240_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_241_bytes_total counter
-# UNIT counter_double_241_bytes_total bytes
 counter_double_241_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_242_bytes_total counter
-# UNIT counter_double_242_bytes_total bytes
 counter_double_242_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_243_bytes_total counter
-# UNIT counter_double_243_bytes_total bytes
 counter_double_243_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_244_bytes_total counter
-# UNIT counter_double_244_bytes_total bytes
 counter_double_244_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_245_bytes_total counter
-# UNIT counter_double_245_bytes_total bytes
 counter_double_245_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_246_bytes_total counter
-# UNIT counter_double_246_bytes_total bytes
 counter_double_246_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_247_bytes_total counter
-# UNIT counter_double_247_bytes_total bytes
 counter_double_247_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_248_bytes_total counter
-# UNIT counter_double_248_bytes_total bytes
 counter_double_248_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_249_bytes_total counter
-# UNIT counter_double_249_bytes_total bytes
 counter_double_249_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_24_bytes_total counter
-# UNIT counter_double_24_bytes_total bytes
 counter_double_24_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_250_bytes_total counter
-# UNIT counter_double_250_bytes_total bytes
 counter_double_250_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_251_bytes_total counter
-# UNIT counter_double_251_bytes_total bytes
 counter_double_251_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_252_bytes_total counter
-# UNIT counter_double_252_bytes_total bytes
 counter_double_252_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_253_bytes_total counter
-# UNIT counter_double_253_bytes_total bytes
 counter_double_253_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_254_bytes_total counter
-# UNIT counter_double_254_bytes_total bytes
 counter_double_254_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_255_bytes_total counter
-# UNIT counter_double_255_bytes_total bytes
 counter_double_255_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_256_bytes_total counter
-# UNIT counter_double_256_bytes_total bytes
 counter_double_256_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_257_bytes_total counter
-# UNIT counter_double_257_bytes_total bytes
 counter_double_257_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_258_bytes_total counter
-# UNIT counter_double_258_bytes_total bytes
 counter_double_258_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_259_bytes_total counter
-# UNIT counter_double_259_bytes_total bytes
 counter_double_259_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_25_bytes_total counter
-# UNIT counter_double_25_bytes_total bytes
 counter_double_25_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_260_bytes_total counter
-# UNIT counter_double_260_bytes_total bytes
 counter_double_260_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_261_bytes_total counter
-# UNIT counter_double_261_bytes_total bytes
 counter_double_261_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_262_bytes_total counter
-# UNIT counter_double_262_bytes_total bytes
 counter_double_262_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_263_bytes_total counter
-# UNIT counter_double_263_bytes_total bytes
 counter_double_263_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_264_bytes_total counter
-# UNIT counter_double_264_bytes_total bytes
 counter_double_264_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_265_bytes_total counter
-# UNIT counter_double_265_bytes_total bytes
 counter_double_265_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_266_bytes_total counter
-# UNIT counter_double_266_bytes_total bytes
 counter_double_266_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_267_bytes_total counter
-# UNIT counter_double_267_bytes_total bytes
 counter_double_267_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_268_bytes_total counter
-# UNIT counter_double_268_bytes_total bytes
 counter_double_268_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_269_bytes_total counter
-# UNIT counter_double_269_bytes_total bytes
 counter_double_269_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_26_bytes_total counter
-# UNIT counter_double_26_bytes_total bytes
 counter_double_26_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_270_bytes_total counter
-# UNIT counter_double_270_bytes_total bytes
 counter_double_270_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_271_bytes_total counter
-# UNIT counter_double_271_bytes_total bytes
 counter_double_271_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_272_bytes_total counter
-# UNIT counter_double_272_bytes_total bytes
 counter_double_272_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_273_bytes_total counter
-# UNIT counter_double_273_bytes_total bytes
 counter_double_273_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_274_bytes_total counter
-# UNIT counter_double_274_bytes_total bytes
 counter_double_274_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_275_bytes_total counter
-# UNIT counter_double_275_bytes_total bytes
 counter_double_275_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_276_bytes_total counter
-# UNIT counter_double_276_bytes_total bytes
 counter_double_276_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_277_bytes_total counter
-# UNIT counter_double_277_bytes_total bytes
 counter_double_277_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_278_bytes_total counter
-# UNIT counter_double_278_bytes_total bytes
 counter_double_278_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_279_bytes_total counter
-# UNIT counter_double_279_bytes_total bytes
 counter_double_279_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_27_bytes_total counter
-# UNIT counter_double_27_bytes_total bytes
 counter_double_27_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_280_bytes_total counter
-# UNIT counter_double_280_bytes_total bytes
 counter_double_280_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_281_bytes_total counter
-# UNIT counter_double_281_bytes_total bytes
 counter_double_281_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_282_bytes_total counter
-# UNIT counter_double_282_bytes_total bytes
 counter_double_282_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_283_bytes_total counter
-# UNIT counter_double_283_bytes_total bytes
 counter_double_283_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_284_bytes_total counter
-# UNIT counter_double_284_bytes_total bytes
 counter_double_284_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_285_bytes_total counter
-# UNIT counter_double_285_bytes_total bytes
 counter_double_285_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_286_bytes_total counter
-# UNIT counter_double_286_bytes_total bytes
 counter_double_286_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_287_bytes_total counter
-# UNIT counter_double_287_bytes_total bytes
 counter_double_287_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_288_bytes_total counter
-# UNIT counter_double_288_bytes_total bytes
 counter_double_288_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_289_bytes_total counter
-# UNIT counter_double_289_bytes_total bytes
 counter_double_289_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_28_bytes_total counter
-# UNIT counter_double_28_bytes_total bytes
 counter_double_28_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_290_bytes_total counter
-# UNIT counter_double_290_bytes_total bytes
 counter_double_290_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_291_bytes_total counter
-# UNIT counter_double_291_bytes_total bytes
 counter_double_291_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_292_bytes_total counter
-# UNIT counter_double_292_bytes_total bytes
 counter_double_292_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_293_bytes_total counter
-# UNIT counter_double_293_bytes_total bytes
 counter_double_293_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_294_bytes_total counter
-# UNIT counter_double_294_bytes_total bytes
 counter_double_294_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_295_bytes_total counter
-# UNIT counter_double_295_bytes_total bytes
 counter_double_295_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_296_bytes_total counter
-# UNIT counter_double_296_bytes_total bytes
 counter_double_296_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_297_bytes_total counter
-# UNIT counter_double_297_bytes_total bytes
 counter_double_297_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_298_bytes_total counter
-# UNIT counter_double_298_bytes_total bytes
 counter_double_298_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_299_bytes_total counter
-# UNIT counter_double_299_bytes_total bytes
 counter_double_299_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_29_bytes_total counter
-# UNIT counter_double_29_bytes_total bytes
 counter_double_29_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_2_bytes_total counter
-# UNIT counter_double_2_bytes_total bytes
 counter_double_2_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_300_bytes_total counter
-# UNIT counter_double_300_bytes_total bytes
 counter_double_300_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_301_bytes_total counter
-# UNIT counter_double_301_bytes_total bytes
 counter_double_301_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_302_bytes_total counter
-# UNIT counter_double_302_bytes_total bytes
 counter_double_302_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_303_bytes_total counter
-# UNIT counter_double_303_bytes_total bytes
 counter_double_303_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_304_bytes_total counter
-# UNIT counter_double_304_bytes_total bytes
 counter_double_304_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_305_bytes_total counter
-# UNIT counter_double_305_bytes_total bytes
 counter_double_305_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_306_bytes_total counter
-# UNIT counter_double_306_bytes_total bytes
 counter_double_306_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_307_bytes_total counter
-# UNIT counter_double_307_bytes_total bytes
 counter_double_307_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_308_bytes_total counter
-# UNIT counter_double_308_bytes_total bytes
 counter_double_308_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_309_bytes_total counter
-# UNIT counter_double_309_bytes_total bytes
 counter_double_309_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_30_bytes_total counter
-# UNIT counter_double_30_bytes_total bytes
 counter_double_30_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_310_bytes_total counter
-# UNIT counter_double_310_bytes_total bytes
 counter_double_310_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_311_bytes_total counter
-# UNIT counter_double_311_bytes_total bytes
 counter_double_311_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_312_bytes_total counter
-# UNIT counter_double_312_bytes_total bytes
 counter_double_312_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_313_bytes_total counter
-# UNIT counter_double_313_bytes_total bytes
 counter_double_313_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_314_bytes_total counter
-# UNIT counter_double_314_bytes_total bytes
 counter_double_314_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_315_bytes_total counter
-# UNIT counter_double_315_bytes_total bytes
 counter_double_315_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_316_bytes_total counter
-# UNIT counter_double_316_bytes_total bytes
 counter_double_316_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_317_bytes_total counter
-# UNIT counter_double_317_bytes_total bytes
 counter_double_317_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_318_bytes_total counter
-# UNIT counter_double_318_bytes_total bytes
 counter_double_318_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_319_bytes_total counter
-# UNIT counter_double_319_bytes_total bytes
 counter_double_319_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_31_bytes_total counter
-# UNIT counter_double_31_bytes_total bytes
 counter_double_31_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_320_bytes_total counter
-# UNIT counter_double_320_bytes_total bytes
 counter_double_320_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_321_bytes_total counter
-# UNIT counter_double_321_bytes_total bytes
 counter_double_321_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_322_bytes_total counter
-# UNIT counter_double_322_bytes_total bytes
 counter_double_322_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_323_bytes_total counter
-# UNIT counter_double_323_bytes_total bytes
 counter_double_323_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_324_bytes_total counter
-# UNIT counter_double_324_bytes_total bytes
 counter_double_324_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_325_bytes_total counter
-# UNIT counter_double_325_bytes_total bytes
 counter_double_325_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_326_bytes_total counter
-# UNIT counter_double_326_bytes_total bytes
 counter_double_326_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_327_bytes_total counter
-# UNIT counter_double_327_bytes_total bytes
 counter_double_327_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_328_bytes_total counter
-# UNIT counter_double_328_bytes_total bytes
 counter_double_328_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_329_bytes_total counter
-# UNIT counter_double_329_bytes_total bytes
 counter_double_329_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_32_bytes_total counter
-# UNIT counter_double_32_bytes_total bytes
 counter_double_32_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_330_bytes_total counter
-# UNIT counter_double_330_bytes_total bytes
 counter_double_330_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_331_bytes_total counter
-# UNIT counter_double_331_bytes_total bytes
 counter_double_331_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_332_bytes_total counter
-# UNIT counter_double_332_bytes_total bytes
 counter_double_332_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_333_bytes_total counter
-# UNIT counter_double_333_bytes_total bytes
 counter_double_333_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_334_bytes_total counter
-# UNIT counter_double_334_bytes_total bytes
 counter_double_334_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_335_bytes_total counter
-# UNIT counter_double_335_bytes_total bytes
 counter_double_335_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_336_bytes_total counter
-# UNIT counter_double_336_bytes_total bytes
 counter_double_336_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_337_bytes_total counter
-# UNIT counter_double_337_bytes_total bytes
 counter_double_337_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_338_bytes_total counter
-# UNIT counter_double_338_bytes_total bytes
 counter_double_338_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_339_bytes_total counter
-# UNIT counter_double_339_bytes_total bytes
 counter_double_339_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_33_bytes_total counter
-# UNIT counter_double_33_bytes_total bytes
 counter_double_33_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_340_bytes_total counter
-# UNIT counter_double_340_bytes_total bytes
 counter_double_340_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_341_bytes_total counter
-# UNIT counter_double_341_bytes_total bytes
 counter_double_341_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_342_bytes_total counter
-# UNIT counter_double_342_bytes_total bytes
 counter_double_342_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_343_bytes_total counter
-# UNIT counter_double_343_bytes_total bytes
 counter_double_343_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_344_bytes_total counter
-# UNIT counter_double_344_bytes_total bytes
 counter_double_344_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_345_bytes_total counter
-# UNIT counter_double_345_bytes_total bytes
 counter_double_345_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_346_bytes_total counter
-# UNIT counter_double_346_bytes_total bytes
 counter_double_346_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_347_bytes_total counter
-# UNIT counter_double_347_bytes_total bytes
 counter_double_347_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_348_bytes_total counter
-# UNIT counter_double_348_bytes_total bytes
 counter_double_348_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_349_bytes_total counter
-# UNIT counter_double_349_bytes_total bytes
 counter_double_349_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_34_bytes_total counter
-# UNIT counter_double_34_bytes_total bytes
 counter_double_34_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_350_bytes_total counter
-# UNIT counter_double_350_bytes_total bytes
 counter_double_350_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_351_bytes_total counter
-# UNIT counter_double_351_bytes_total bytes
 counter_double_351_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_352_bytes_total counter
-# UNIT counter_double_352_bytes_total bytes
 counter_double_352_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_353_bytes_total counter
-# UNIT counter_double_353_bytes_total bytes
 counter_double_353_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_354_bytes_total counter
-# UNIT counter_double_354_bytes_total bytes
 counter_double_354_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_355_bytes_total counter
-# UNIT counter_double_355_bytes_total bytes
 counter_double_355_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_356_bytes_total counter
-# UNIT counter_double_356_bytes_total bytes
 counter_double_356_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_357_bytes_total counter
-# UNIT counter_double_357_bytes_total bytes
 counter_double_357_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_358_bytes_total counter
-# UNIT counter_double_358_bytes_total bytes
 counter_double_358_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_359_bytes_total counter
-# UNIT counter_double_359_bytes_total bytes
 counter_double_359_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_35_bytes_total counter
-# UNIT counter_double_35_bytes_total bytes
 counter_double_35_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_360_bytes_total counter
-# UNIT counter_double_360_bytes_total bytes
 counter_double_360_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_361_bytes_total counter
-# UNIT counter_double_361_bytes_total bytes
 counter_double_361_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_362_bytes_total counter
-# UNIT counter_double_362_bytes_total bytes
 counter_double_362_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_363_bytes_total counter
-# UNIT counter_double_363_bytes_total bytes
 counter_double_363_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_364_bytes_total counter
-# UNIT counter_double_364_bytes_total bytes
 counter_double_364_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_365_bytes_total counter
-# UNIT counter_double_365_bytes_total bytes
 counter_double_365_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_366_bytes_total counter
-# UNIT counter_double_366_bytes_total bytes
 counter_double_366_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_367_bytes_total counter
-# UNIT counter_double_367_bytes_total bytes
 counter_double_367_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_368_bytes_total counter
-# UNIT counter_double_368_bytes_total bytes
 counter_double_368_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_369_bytes_total counter
-# UNIT counter_double_369_bytes_total bytes
 counter_double_369_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_36_bytes_total counter
-# UNIT counter_double_36_bytes_total bytes
 counter_double_36_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_370_bytes_total counter
-# UNIT counter_double_370_bytes_total bytes
 counter_double_370_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_371_bytes_total counter
-# UNIT counter_double_371_bytes_total bytes
 counter_double_371_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_372_bytes_total counter
-# UNIT counter_double_372_bytes_total bytes
 counter_double_372_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_373_bytes_total counter
-# UNIT counter_double_373_bytes_total bytes
 counter_double_373_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_374_bytes_total counter
-# UNIT counter_double_374_bytes_total bytes
 counter_double_374_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_375_bytes_total counter
-# UNIT counter_double_375_bytes_total bytes
 counter_double_375_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_376_bytes_total counter
-# UNIT counter_double_376_bytes_total bytes
 counter_double_376_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_377_bytes_total counter
-# UNIT counter_double_377_bytes_total bytes
 counter_double_377_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_378_bytes_total counter
-# UNIT counter_double_378_bytes_total bytes
 counter_double_378_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_379_bytes_total counter
-# UNIT counter_double_379_bytes_total bytes
 counter_double_379_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_37_bytes_total counter
-# UNIT counter_double_37_bytes_total bytes
 counter_double_37_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_380_bytes_total counter
-# UNIT counter_double_380_bytes_total bytes
 counter_double_380_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_381_bytes_total counter
-# UNIT counter_double_381_bytes_total bytes
 counter_double_381_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_382_bytes_total counter
-# UNIT counter_double_382_bytes_total bytes
 counter_double_382_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_383_bytes_total counter
-# UNIT counter_double_383_bytes_total bytes
 counter_double_383_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_384_bytes_total counter
-# UNIT counter_double_384_bytes_total bytes
 counter_double_384_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_385_bytes_total counter
-# UNIT counter_double_385_bytes_total bytes
 counter_double_385_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_386_bytes_total counter
-# UNIT counter_double_386_bytes_total bytes
 counter_double_386_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_387_bytes_total counter
-# UNIT counter_double_387_bytes_total bytes
 counter_double_387_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_388_bytes_total counter
-# UNIT counter_double_388_bytes_total bytes
 counter_double_388_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_389_bytes_total counter
-# UNIT counter_double_389_bytes_total bytes
 counter_double_389_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_38_bytes_total counter
-# UNIT counter_double_38_bytes_total bytes
 counter_double_38_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_390_bytes_total counter
-# UNIT counter_double_390_bytes_total bytes
 counter_double_390_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_391_bytes_total counter
-# UNIT counter_double_391_bytes_total bytes
 counter_double_391_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_392_bytes_total counter
-# UNIT counter_double_392_bytes_total bytes
 counter_double_392_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_393_bytes_total counter
-# UNIT counter_double_393_bytes_total bytes
 counter_double_393_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_394_bytes_total counter
-# UNIT counter_double_394_bytes_total bytes
 counter_double_394_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_395_bytes_total counter
-# UNIT counter_double_395_bytes_total bytes
 counter_double_395_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_396_bytes_total counter
-# UNIT counter_double_396_bytes_total bytes
 counter_double_396_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_397_bytes_total counter
-# UNIT counter_double_397_bytes_total bytes
 counter_double_397_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_398_bytes_total counter
-# UNIT counter_double_398_bytes_total bytes
 counter_double_398_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_399_bytes_total counter
-# UNIT counter_double_399_bytes_total bytes
 counter_double_399_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_39_bytes_total counter
-# UNIT counter_double_39_bytes_total bytes
 counter_double_39_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_3_bytes_total counter
-# UNIT counter_double_3_bytes_total bytes
 counter_double_3_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_400_bytes_total counter
-# UNIT counter_double_400_bytes_total bytes
 counter_double_400_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_401_bytes_total counter
-# UNIT counter_double_401_bytes_total bytes
 counter_double_401_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_402_bytes_total counter
-# UNIT counter_double_402_bytes_total bytes
 counter_double_402_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_403_bytes_total counter
-# UNIT counter_double_403_bytes_total bytes
 counter_double_403_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_404_bytes_total counter
-# UNIT counter_double_404_bytes_total bytes
 counter_double_404_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_405_bytes_total counter
-# UNIT counter_double_405_bytes_total bytes
 counter_double_405_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_406_bytes_total counter
-# UNIT counter_double_406_bytes_total bytes
 counter_double_406_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_407_bytes_total counter
-# UNIT counter_double_407_bytes_total bytes
 counter_double_407_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_408_bytes_total counter
-# UNIT counter_double_408_bytes_total bytes
 counter_double_408_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_409_bytes_total counter
-# UNIT counter_double_409_bytes_total bytes
 counter_double_409_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_40_bytes_total counter
-# UNIT counter_double_40_bytes_total bytes
 counter_double_40_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_410_bytes_total counter
-# UNIT counter_double_410_bytes_total bytes
 counter_double_410_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_411_bytes_total counter
-# UNIT counter_double_411_bytes_total bytes
 counter_double_411_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_412_bytes_total counter
-# UNIT counter_double_412_bytes_total bytes
 counter_double_412_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_413_bytes_total counter
-# UNIT counter_double_413_bytes_total bytes
 counter_double_413_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_414_bytes_total counter
-# UNIT counter_double_414_bytes_total bytes
 counter_double_414_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_415_bytes_total counter
-# UNIT counter_double_415_bytes_total bytes
 counter_double_415_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_416_bytes_total counter
-# UNIT counter_double_416_bytes_total bytes
 counter_double_416_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_417_bytes_total counter
-# UNIT counter_double_417_bytes_total bytes
 counter_double_417_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_418_bytes_total counter
-# UNIT counter_double_418_bytes_total bytes
 counter_double_418_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_419_bytes_total counter
-# UNIT counter_double_419_bytes_total bytes
 counter_double_419_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_41_bytes_total counter
-# UNIT counter_double_41_bytes_total bytes
 counter_double_41_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_420_bytes_total counter
-# UNIT counter_double_420_bytes_total bytes
 counter_double_420_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_421_bytes_total counter
-# UNIT counter_double_421_bytes_total bytes
 counter_double_421_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_422_bytes_total counter
-# UNIT counter_double_422_bytes_total bytes
 counter_double_422_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_423_bytes_total counter
-# UNIT counter_double_423_bytes_total bytes
 counter_double_423_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_424_bytes_total counter
-# UNIT counter_double_424_bytes_total bytes
 counter_double_424_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_425_bytes_total counter
-# UNIT counter_double_425_bytes_total bytes
 counter_double_425_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_426_bytes_total counter
-# UNIT counter_double_426_bytes_total bytes
 counter_double_426_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_427_bytes_total counter
-# UNIT counter_double_427_bytes_total bytes
 counter_double_427_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_428_bytes_total counter
-# UNIT counter_double_428_bytes_total bytes
 counter_double_428_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_429_bytes_total counter
-# UNIT counter_double_429_bytes_total bytes
 counter_double_429_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_42_bytes_total counter
-# UNIT counter_double_42_bytes_total bytes
 counter_double_42_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_430_bytes_total counter
-# UNIT counter_double_430_bytes_total bytes
 counter_double_430_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_431_bytes_total counter
-# UNIT counter_double_431_bytes_total bytes
 counter_double_431_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_432_bytes_total counter
-# UNIT counter_double_432_bytes_total bytes
 counter_double_432_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_433_bytes_total counter
-# UNIT counter_double_433_bytes_total bytes
 counter_double_433_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_434_bytes_total counter
-# UNIT counter_double_434_bytes_total bytes
 counter_double_434_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_435_bytes_total counter
-# UNIT counter_double_435_bytes_total bytes
 counter_double_435_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_436_bytes_total counter
-# UNIT counter_double_436_bytes_total bytes
 counter_double_436_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_437_bytes_total counter
-# UNIT counter_double_437_bytes_total bytes
 counter_double_437_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_438_bytes_total counter
-# UNIT counter_double_438_bytes_total bytes
 counter_double_438_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_439_bytes_total counter
-# UNIT counter_double_439_bytes_total bytes
 counter_double_439_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_43_bytes_total counter
-# UNIT counter_double_43_bytes_total bytes
 counter_double_43_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_440_bytes_total counter
-# UNIT counter_double_440_bytes_total bytes
 counter_double_440_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_441_bytes_total counter
-# UNIT counter_double_441_bytes_total bytes
 counter_double_441_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_442_bytes_total counter
-# UNIT counter_double_442_bytes_total bytes
 counter_double_442_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_443_bytes_total counter
-# UNIT counter_double_443_bytes_total bytes
 counter_double_443_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_444_bytes_total counter
-# UNIT counter_double_444_bytes_total bytes
 counter_double_444_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_445_bytes_total counter
-# UNIT counter_double_445_bytes_total bytes
 counter_double_445_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_446_bytes_total counter
-# UNIT counter_double_446_bytes_total bytes
 counter_double_446_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_447_bytes_total counter
-# UNIT counter_double_447_bytes_total bytes
 counter_double_447_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_448_bytes_total counter
-# UNIT counter_double_448_bytes_total bytes
 counter_double_448_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_449_bytes_total counter
-# UNIT counter_double_449_bytes_total bytes
 counter_double_449_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_44_bytes_total counter
-# UNIT counter_double_44_bytes_total bytes
 counter_double_44_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_450_bytes_total counter
-# UNIT counter_double_450_bytes_total bytes
 counter_double_450_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_451_bytes_total counter
-# UNIT counter_double_451_bytes_total bytes
 counter_double_451_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_452_bytes_total counter
-# UNIT counter_double_452_bytes_total bytes
 counter_double_452_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_453_bytes_total counter
-# UNIT counter_double_453_bytes_total bytes
 counter_double_453_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_454_bytes_total counter
-# UNIT counter_double_454_bytes_total bytes
 counter_double_454_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_455_bytes_total counter
-# UNIT counter_double_455_bytes_total bytes
 counter_double_455_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_456_bytes_total counter
-# UNIT counter_double_456_bytes_total bytes
 counter_double_456_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_457_bytes_total counter
-# UNIT counter_double_457_bytes_total bytes
 counter_double_457_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_458_bytes_total counter
-# UNIT counter_double_458_bytes_total bytes
 counter_double_458_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_459_bytes_total counter
-# UNIT counter_double_459_bytes_total bytes
 counter_double_459_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_45_bytes_total counter
-# UNIT counter_double_45_bytes_total bytes
 counter_double_45_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_460_bytes_total counter
-# UNIT counter_double_460_bytes_total bytes
 counter_double_460_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_461_bytes_total counter
-# UNIT counter_double_461_bytes_total bytes
 counter_double_461_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_462_bytes_total counter
-# UNIT counter_double_462_bytes_total bytes
 counter_double_462_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_463_bytes_total counter
-# UNIT counter_double_463_bytes_total bytes
 counter_double_463_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_464_bytes_total counter
-# UNIT counter_double_464_bytes_total bytes
 counter_double_464_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_465_bytes_total counter
-# UNIT counter_double_465_bytes_total bytes
 counter_double_465_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_466_bytes_total counter
-# UNIT counter_double_466_bytes_total bytes
 counter_double_466_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_467_bytes_total counter
-# UNIT counter_double_467_bytes_total bytes
 counter_double_467_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_468_bytes_total counter
-# UNIT counter_double_468_bytes_total bytes
 counter_double_468_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_469_bytes_total counter
-# UNIT counter_double_469_bytes_total bytes
 counter_double_469_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_46_bytes_total counter
-# UNIT counter_double_46_bytes_total bytes
 counter_double_46_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_470_bytes_total counter
-# UNIT counter_double_470_bytes_total bytes
 counter_double_470_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_471_bytes_total counter
-# UNIT counter_double_471_bytes_total bytes
 counter_double_471_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_472_bytes_total counter
-# UNIT counter_double_472_bytes_total bytes
 counter_double_472_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_473_bytes_total counter
-# UNIT counter_double_473_bytes_total bytes
 counter_double_473_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_474_bytes_total counter
-# UNIT counter_double_474_bytes_total bytes
 counter_double_474_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_475_bytes_total counter
-# UNIT counter_double_475_bytes_total bytes
 counter_double_475_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_476_bytes_total counter
-# UNIT counter_double_476_bytes_total bytes
 counter_double_476_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_477_bytes_total counter
-# UNIT counter_double_477_bytes_total bytes
 counter_double_477_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_478_bytes_total counter
-# UNIT counter_double_478_bytes_total bytes
 counter_double_478_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_479_bytes_total counter
-# UNIT counter_double_479_bytes_total bytes
 counter_double_479_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_47_bytes_total counter
-# UNIT counter_double_47_bytes_total bytes
 counter_double_47_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_480_bytes_total counter
-# UNIT counter_double_480_bytes_total bytes
 counter_double_480_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_481_bytes_total counter
-# UNIT counter_double_481_bytes_total bytes
 counter_double_481_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_482_bytes_total counter
-# UNIT counter_double_482_bytes_total bytes
 counter_double_482_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_483_bytes_total counter
-# UNIT counter_double_483_bytes_total bytes
 counter_double_483_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_484_bytes_total counter
-# UNIT counter_double_484_bytes_total bytes
 counter_double_484_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_485_bytes_total counter
-# UNIT counter_double_485_bytes_total bytes
 counter_double_485_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_486_bytes_total counter
-# UNIT counter_double_486_bytes_total bytes
 counter_double_486_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_487_bytes_total counter
-# UNIT counter_double_487_bytes_total bytes
 counter_double_487_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_488_bytes_total counter
-# UNIT counter_double_488_bytes_total bytes
 counter_double_488_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_489_bytes_total counter
-# UNIT counter_double_489_bytes_total bytes
 counter_double_489_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_48_bytes_total counter
-# UNIT counter_double_48_bytes_total bytes
 counter_double_48_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_490_bytes_total counter
-# UNIT counter_double_490_bytes_total bytes
 counter_double_490_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_491_bytes_total counter
-# UNIT counter_double_491_bytes_total bytes
 counter_double_491_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_492_bytes_total counter
-# UNIT counter_double_492_bytes_total bytes
 counter_double_492_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_493_bytes_total counter
-# UNIT counter_double_493_bytes_total bytes
 counter_double_493_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_494_bytes_total counter
-# UNIT counter_double_494_bytes_total bytes
 counter_double_494_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_495_bytes_total counter
-# UNIT counter_double_495_bytes_total bytes
 counter_double_495_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_496_bytes_total counter
-# UNIT counter_double_496_bytes_total bytes
 counter_double_496_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_497_bytes_total counter
-# UNIT counter_double_497_bytes_total bytes
 counter_double_497_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_498_bytes_total counter
-# UNIT counter_double_498_bytes_total bytes
 counter_double_498_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_499_bytes_total counter
-# UNIT counter_double_499_bytes_total bytes
 counter_double_499_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_49_bytes_total counter
-# UNIT counter_double_49_bytes_total bytes
 counter_double_49_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_4_bytes_total counter
-# UNIT counter_double_4_bytes_total bytes
 counter_double_4_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_500_bytes_total counter
-# UNIT counter_double_500_bytes_total bytes
 counter_double_500_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_501_bytes_total counter
-# UNIT counter_double_501_bytes_total bytes
 counter_double_501_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_502_bytes_total counter
-# UNIT counter_double_502_bytes_total bytes
 counter_double_502_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_503_bytes_total counter
-# UNIT counter_double_503_bytes_total bytes
 counter_double_503_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_504_bytes_total counter
-# UNIT counter_double_504_bytes_total bytes
 counter_double_504_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_505_bytes_total counter
-# UNIT counter_double_505_bytes_total bytes
 counter_double_505_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_506_bytes_total counter
-# UNIT counter_double_506_bytes_total bytes
 counter_double_506_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_507_bytes_total counter
-# UNIT counter_double_507_bytes_total bytes
 counter_double_507_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_508_bytes_total counter
-# UNIT counter_double_508_bytes_total bytes
 counter_double_508_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_509_bytes_total counter
-# UNIT counter_double_509_bytes_total bytes
 counter_double_509_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_50_bytes_total counter
-# UNIT counter_double_50_bytes_total bytes
 counter_double_50_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_510_bytes_total counter
-# UNIT counter_double_510_bytes_total bytes
 counter_double_510_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_511_bytes_total counter
-# UNIT counter_double_511_bytes_total bytes
 counter_double_511_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_512_bytes_total counter
-# UNIT counter_double_512_bytes_total bytes
 counter_double_512_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_513_bytes_total counter
-# UNIT counter_double_513_bytes_total bytes
 counter_double_513_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_514_bytes_total counter
-# UNIT counter_double_514_bytes_total bytes
 counter_double_514_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_515_bytes_total counter
-# UNIT counter_double_515_bytes_total bytes
 counter_double_515_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_516_bytes_total counter
-# UNIT counter_double_516_bytes_total bytes
 counter_double_516_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_517_bytes_total counter
-# UNIT counter_double_517_bytes_total bytes
 counter_double_517_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_518_bytes_total counter
-# UNIT counter_double_518_bytes_total bytes
 counter_double_518_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_519_bytes_total counter
-# UNIT counter_double_519_bytes_total bytes
 counter_double_519_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_51_bytes_total counter
-# UNIT counter_double_51_bytes_total bytes
 counter_double_51_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_520_bytes_total counter
-# UNIT counter_double_520_bytes_total bytes
 counter_double_520_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_521_bytes_total counter
-# UNIT counter_double_521_bytes_total bytes
 counter_double_521_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_522_bytes_total counter
-# UNIT counter_double_522_bytes_total bytes
 counter_double_522_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_523_bytes_total counter
-# UNIT counter_double_523_bytes_total bytes
 counter_double_523_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_524_bytes_total counter
-# UNIT counter_double_524_bytes_total bytes
 counter_double_524_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_525_bytes_total counter
-# UNIT counter_double_525_bytes_total bytes
 counter_double_525_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_526_bytes_total counter
-# UNIT counter_double_526_bytes_total bytes
 counter_double_526_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_527_bytes_total counter
-# UNIT counter_double_527_bytes_total bytes
 counter_double_527_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_528_bytes_total counter
-# UNIT counter_double_528_bytes_total bytes
 counter_double_528_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_529_bytes_total counter
-# UNIT counter_double_529_bytes_total bytes
 counter_double_529_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_52_bytes_total counter
-# UNIT counter_double_52_bytes_total bytes
 counter_double_52_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_530_bytes_total counter
-# UNIT counter_double_530_bytes_total bytes
 counter_double_530_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_531_bytes_total counter
-# UNIT counter_double_531_bytes_total bytes
 counter_double_531_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_532_bytes_total counter
-# UNIT counter_double_532_bytes_total bytes
 counter_double_532_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_533_bytes_total counter
-# UNIT counter_double_533_bytes_total bytes
 counter_double_533_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_534_bytes_total counter
-# UNIT counter_double_534_bytes_total bytes
 counter_double_534_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_535_bytes_total counter
-# UNIT counter_double_535_bytes_total bytes
 counter_double_535_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_536_bytes_total counter
-# UNIT counter_double_536_bytes_total bytes
 counter_double_536_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_537_bytes_total counter
-# UNIT counter_double_537_bytes_total bytes
 counter_double_537_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_538_bytes_total counter
-# UNIT counter_double_538_bytes_total bytes
 counter_double_538_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_539_bytes_total counter
-# UNIT counter_double_539_bytes_total bytes
 counter_double_539_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_53_bytes_total counter
-# UNIT counter_double_53_bytes_total bytes
 counter_double_53_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_540_bytes_total counter
-# UNIT counter_double_540_bytes_total bytes
 counter_double_540_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_541_bytes_total counter
-# UNIT counter_double_541_bytes_total bytes
 counter_double_541_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_542_bytes_total counter
-# UNIT counter_double_542_bytes_total bytes
 counter_double_542_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_543_bytes_total counter
-# UNIT counter_double_543_bytes_total bytes
 counter_double_543_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_544_bytes_total counter
-# UNIT counter_double_544_bytes_total bytes
 counter_double_544_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_545_bytes_total counter
-# UNIT counter_double_545_bytes_total bytes
 counter_double_545_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_546_bytes_total counter
-# UNIT counter_double_546_bytes_total bytes
 counter_double_546_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_547_bytes_total counter
-# UNIT counter_double_547_bytes_total bytes
 counter_double_547_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_548_bytes_total counter
-# UNIT counter_double_548_bytes_total bytes
 counter_double_548_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_549_bytes_total counter
-# UNIT counter_double_549_bytes_total bytes
 counter_double_549_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_54_bytes_total counter
-# UNIT counter_double_54_bytes_total bytes
 counter_double_54_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_550_bytes_total counter
-# UNIT counter_double_550_bytes_total bytes
 counter_double_550_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_551_bytes_total counter
-# UNIT counter_double_551_bytes_total bytes
 counter_double_551_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_552_bytes_total counter
-# UNIT counter_double_552_bytes_total bytes
 counter_double_552_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_553_bytes_total counter
-# UNIT counter_double_553_bytes_total bytes
 counter_double_553_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_554_bytes_total counter
-# UNIT counter_double_554_bytes_total bytes
 counter_double_554_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_555_bytes_total counter
-# UNIT counter_double_555_bytes_total bytes
 counter_double_555_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_556_bytes_total counter
-# UNIT counter_double_556_bytes_total bytes
 counter_double_556_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_557_bytes_total counter
-# UNIT counter_double_557_bytes_total bytes
 counter_double_557_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_558_bytes_total counter
-# UNIT counter_double_558_bytes_total bytes
 counter_double_558_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_559_bytes_total counter
-# UNIT counter_double_559_bytes_total bytes
 counter_double_559_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_55_bytes_total counter
-# UNIT counter_double_55_bytes_total bytes
 counter_double_55_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_560_bytes_total counter
-# UNIT counter_double_560_bytes_total bytes
 counter_double_560_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_561_bytes_total counter
-# UNIT counter_double_561_bytes_total bytes
 counter_double_561_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_562_bytes_total counter
-# UNIT counter_double_562_bytes_total bytes
 counter_double_562_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_563_bytes_total counter
-# UNIT counter_double_563_bytes_total bytes
 counter_double_563_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_564_bytes_total counter
-# UNIT counter_double_564_bytes_total bytes
 counter_double_564_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_565_bytes_total counter
-# UNIT counter_double_565_bytes_total bytes
 counter_double_565_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_566_bytes_total counter
-# UNIT counter_double_566_bytes_total bytes
 counter_double_566_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_567_bytes_total counter
-# UNIT counter_double_567_bytes_total bytes
 counter_double_567_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_568_bytes_total counter
-# UNIT counter_double_568_bytes_total bytes
 counter_double_568_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_569_bytes_total counter
-# UNIT counter_double_569_bytes_total bytes
 counter_double_569_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_56_bytes_total counter
-# UNIT counter_double_56_bytes_total bytes
 counter_double_56_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_570_bytes_total counter
-# UNIT counter_double_570_bytes_total bytes
 counter_double_570_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_571_bytes_total counter
-# UNIT counter_double_571_bytes_total bytes
 counter_double_571_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_572_bytes_total counter
-# UNIT counter_double_572_bytes_total bytes
 counter_double_572_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_573_bytes_total counter
-# UNIT counter_double_573_bytes_total bytes
 counter_double_573_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_574_bytes_total counter
-# UNIT counter_double_574_bytes_total bytes
 counter_double_574_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_575_bytes_total counter
-# UNIT counter_double_575_bytes_total bytes
 counter_double_575_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_576_bytes_total counter
-# UNIT counter_double_576_bytes_total bytes
 counter_double_576_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_577_bytes_total counter
-# UNIT counter_double_577_bytes_total bytes
 counter_double_577_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_578_bytes_total counter
-# UNIT counter_double_578_bytes_total bytes
 counter_double_578_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_579_bytes_total counter
-# UNIT counter_double_579_bytes_total bytes
 counter_double_579_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_57_bytes_total counter
-# UNIT counter_double_57_bytes_total bytes
 counter_double_57_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_580_bytes_total counter
-# UNIT counter_double_580_bytes_total bytes
 counter_double_580_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_581_bytes_total counter
-# UNIT counter_double_581_bytes_total bytes
 counter_double_581_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_582_bytes_total counter
-# UNIT counter_double_582_bytes_total bytes
 counter_double_582_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_583_bytes_total counter
-# UNIT counter_double_583_bytes_total bytes
 counter_double_583_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_584_bytes_total counter
-# UNIT counter_double_584_bytes_total bytes
 counter_double_584_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_585_bytes_total counter
-# UNIT counter_double_585_bytes_total bytes
 counter_double_585_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_586_bytes_total counter
-# UNIT counter_double_586_bytes_total bytes
 counter_double_586_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_587_bytes_total counter
-# UNIT counter_double_587_bytes_total bytes
 counter_double_587_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_588_bytes_total counter
-# UNIT counter_double_588_bytes_total bytes
 counter_double_588_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_589_bytes_total counter
-# UNIT counter_double_589_bytes_total bytes
 counter_double_589_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_58_bytes_total counter
-# UNIT counter_double_58_bytes_total bytes
 counter_double_58_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_590_bytes_total counter
-# UNIT counter_double_590_bytes_total bytes
 counter_double_590_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_591_bytes_total counter
-# UNIT counter_double_591_bytes_total bytes
 counter_double_591_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_592_bytes_total counter
-# UNIT counter_double_592_bytes_total bytes
 counter_double_592_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_593_bytes_total counter
-# UNIT counter_double_593_bytes_total bytes
 counter_double_593_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_594_bytes_total counter
-# UNIT counter_double_594_bytes_total bytes
 counter_double_594_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_595_bytes_total counter
-# UNIT counter_double_595_bytes_total bytes
 counter_double_595_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_596_bytes_total counter
-# UNIT counter_double_596_bytes_total bytes
 counter_double_596_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_597_bytes_total counter
-# UNIT counter_double_597_bytes_total bytes
 counter_double_597_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_598_bytes_total counter
-# UNIT counter_double_598_bytes_total bytes
 counter_double_598_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_599_bytes_total counter
-# UNIT counter_double_599_bytes_total bytes
 counter_double_599_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_59_bytes_total counter
-# UNIT counter_double_59_bytes_total bytes
 counter_double_59_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_5_bytes_total counter
-# UNIT counter_double_5_bytes_total bytes
 counter_double_5_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_600_bytes_total counter
-# UNIT counter_double_600_bytes_total bytes
 counter_double_600_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_601_bytes_total counter
-# UNIT counter_double_601_bytes_total bytes
 counter_double_601_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_602_bytes_total counter
-# UNIT counter_double_602_bytes_total bytes
 counter_double_602_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_603_bytes_total counter
-# UNIT counter_double_603_bytes_total bytes
 counter_double_603_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_604_bytes_total counter
-# UNIT counter_double_604_bytes_total bytes
 counter_double_604_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_605_bytes_total counter
-# UNIT counter_double_605_bytes_total bytes
 counter_double_605_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_606_bytes_total counter
-# UNIT counter_double_606_bytes_total bytes
 counter_double_606_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_607_bytes_total counter
-# UNIT counter_double_607_bytes_total bytes
 counter_double_607_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_608_bytes_total counter
-# UNIT counter_double_608_bytes_total bytes
 counter_double_608_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_609_bytes_total counter
-# UNIT counter_double_609_bytes_total bytes
 counter_double_609_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_60_bytes_total counter
-# UNIT counter_double_60_bytes_total bytes
 counter_double_60_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_610_bytes_total counter
-# UNIT counter_double_610_bytes_total bytes
 counter_double_610_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_611_bytes_total counter
-# UNIT counter_double_611_bytes_total bytes
 counter_double_611_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_612_bytes_total counter
-# UNIT counter_double_612_bytes_total bytes
 counter_double_612_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_613_bytes_total counter
-# UNIT counter_double_613_bytes_total bytes
 counter_double_613_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_614_bytes_total counter
-# UNIT counter_double_614_bytes_total bytes
 counter_double_614_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_615_bytes_total counter
-# UNIT counter_double_615_bytes_total bytes
 counter_double_615_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_616_bytes_total counter
-# UNIT counter_double_616_bytes_total bytes
 counter_double_616_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_617_bytes_total counter
-# UNIT counter_double_617_bytes_total bytes
 counter_double_617_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_618_bytes_total counter
-# UNIT counter_double_618_bytes_total bytes
 counter_double_618_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_619_bytes_total counter
-# UNIT counter_double_619_bytes_total bytes
 counter_double_619_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_61_bytes_total counter
-# UNIT counter_double_61_bytes_total bytes
 counter_double_61_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_620_bytes_total counter
-# UNIT counter_double_620_bytes_total bytes
 counter_double_620_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_621_bytes_total counter
-# UNIT counter_double_621_bytes_total bytes
 counter_double_621_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_622_bytes_total counter
-# UNIT counter_double_622_bytes_total bytes
 counter_double_622_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_623_bytes_total counter
-# UNIT counter_double_623_bytes_total bytes
 counter_double_623_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_624_bytes_total counter
-# UNIT counter_double_624_bytes_total bytes
 counter_double_624_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_625_bytes_total counter
-# UNIT counter_double_625_bytes_total bytes
 counter_double_625_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_626_bytes_total counter
-# UNIT counter_double_626_bytes_total bytes
 counter_double_626_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_627_bytes_total counter
-# UNIT counter_double_627_bytes_total bytes
 counter_double_627_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_628_bytes_total counter
-# UNIT counter_double_628_bytes_total bytes
 counter_double_628_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_629_bytes_total counter
-# UNIT counter_double_629_bytes_total bytes
 counter_double_629_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_62_bytes_total counter
-# UNIT counter_double_62_bytes_total bytes
 counter_double_62_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_630_bytes_total counter
-# UNIT counter_double_630_bytes_total bytes
 counter_double_630_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_631_bytes_total counter
-# UNIT counter_double_631_bytes_total bytes
 counter_double_631_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_632_bytes_total counter
-# UNIT counter_double_632_bytes_total bytes
 counter_double_632_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_633_bytes_total counter
-# UNIT counter_double_633_bytes_total bytes
 counter_double_633_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_634_bytes_total counter
-# UNIT counter_double_634_bytes_total bytes
 counter_double_634_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_635_bytes_total counter
-# UNIT counter_double_635_bytes_total bytes
 counter_double_635_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_636_bytes_total counter
-# UNIT counter_double_636_bytes_total bytes
 counter_double_636_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_637_bytes_total counter
-# UNIT counter_double_637_bytes_total bytes
 counter_double_637_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_638_bytes_total counter
-# UNIT counter_double_638_bytes_total bytes
 counter_double_638_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_639_bytes_total counter
-# UNIT counter_double_639_bytes_total bytes
 counter_double_639_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_63_bytes_total counter
-# UNIT counter_double_63_bytes_total bytes
 counter_double_63_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_640_bytes_total counter
-# UNIT counter_double_640_bytes_total bytes
 counter_double_640_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_641_bytes_total counter
-# UNIT counter_double_641_bytes_total bytes
 counter_double_641_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_642_bytes_total counter
-# UNIT counter_double_642_bytes_total bytes
 counter_double_642_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_643_bytes_total counter
-# UNIT counter_double_643_bytes_total bytes
 counter_double_643_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_644_bytes_total counter
-# UNIT counter_double_644_bytes_total bytes
 counter_double_644_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_645_bytes_total counter
-# UNIT counter_double_645_bytes_total bytes
 counter_double_645_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_646_bytes_total counter
-# UNIT counter_double_646_bytes_total bytes
 counter_double_646_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_647_bytes_total counter
-# UNIT counter_double_647_bytes_total bytes
 counter_double_647_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_648_bytes_total counter
-# UNIT counter_double_648_bytes_total bytes
 counter_double_648_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_649_bytes_total counter
-# UNIT counter_double_649_bytes_total bytes
 counter_double_649_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_64_bytes_total counter
-# UNIT counter_double_64_bytes_total bytes
 counter_double_64_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_650_bytes_total counter
-# UNIT counter_double_650_bytes_total bytes
 counter_double_650_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_651_bytes_total counter
-# UNIT counter_double_651_bytes_total bytes
 counter_double_651_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_652_bytes_total counter
-# UNIT counter_double_652_bytes_total bytes
 counter_double_652_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_653_bytes_total counter
-# UNIT counter_double_653_bytes_total bytes
 counter_double_653_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_654_bytes_total counter
-# UNIT counter_double_654_bytes_total bytes
 counter_double_654_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_655_bytes_total counter
-# UNIT counter_double_655_bytes_total bytes
 counter_double_655_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_656_bytes_total counter
-# UNIT counter_double_656_bytes_total bytes
 counter_double_656_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_657_bytes_total counter
-# UNIT counter_double_657_bytes_total bytes
 counter_double_657_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_658_bytes_total counter
-# UNIT counter_double_658_bytes_total bytes
 counter_double_658_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_659_bytes_total counter
-# UNIT counter_double_659_bytes_total bytes
 counter_double_659_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_65_bytes_total counter
-# UNIT counter_double_65_bytes_total bytes
 counter_double_65_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_660_bytes_total counter
-# UNIT counter_double_660_bytes_total bytes
 counter_double_660_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_661_bytes_total counter
-# UNIT counter_double_661_bytes_total bytes
 counter_double_661_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_662_bytes_total counter
-# UNIT counter_double_662_bytes_total bytes
 counter_double_662_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_663_bytes_total counter
-# UNIT counter_double_663_bytes_total bytes
 counter_double_663_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_664_bytes_total counter
-# UNIT counter_double_664_bytes_total bytes
 counter_double_664_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_665_bytes_total counter
-# UNIT counter_double_665_bytes_total bytes
 counter_double_665_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_666_bytes_total counter
-# UNIT counter_double_666_bytes_total bytes
 counter_double_666_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_667_bytes_total counter
-# UNIT counter_double_667_bytes_total bytes
 counter_double_667_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_668_bytes_total counter
-# UNIT counter_double_668_bytes_total bytes
 counter_double_668_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_669_bytes_total counter
-# UNIT counter_double_669_bytes_total bytes
 counter_double_669_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_66_bytes_total counter
-# UNIT counter_double_66_bytes_total bytes
 counter_double_66_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_670_bytes_total counter
-# UNIT counter_double_670_bytes_total bytes
 counter_double_670_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_671_bytes_total counter
-# UNIT counter_double_671_bytes_total bytes
 counter_double_671_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_672_bytes_total counter
-# UNIT counter_double_672_bytes_total bytes
 counter_double_672_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_673_bytes_total counter
-# UNIT counter_double_673_bytes_total bytes
 counter_double_673_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_674_bytes_total counter
-# UNIT counter_double_674_bytes_total bytes
 counter_double_674_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_675_bytes_total counter
-# UNIT counter_double_675_bytes_total bytes
 counter_double_675_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_676_bytes_total counter
-# UNIT counter_double_676_bytes_total bytes
 counter_double_676_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_677_bytes_total counter
-# UNIT counter_double_677_bytes_total bytes
 counter_double_677_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_678_bytes_total counter
-# UNIT counter_double_678_bytes_total bytes
 counter_double_678_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_679_bytes_total counter
-# UNIT counter_double_679_bytes_total bytes
 counter_double_679_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_67_bytes_total counter
-# UNIT counter_double_67_bytes_total bytes
 counter_double_67_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_680_bytes_total counter
-# UNIT counter_double_680_bytes_total bytes
 counter_double_680_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_681_bytes_total counter
-# UNIT counter_double_681_bytes_total bytes
 counter_double_681_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_682_bytes_total counter
-# UNIT counter_double_682_bytes_total bytes
 counter_double_682_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_683_bytes_total counter
-# UNIT counter_double_683_bytes_total bytes
 counter_double_683_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_684_bytes_total counter
-# UNIT counter_double_684_bytes_total bytes
 counter_double_684_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_685_bytes_total counter
-# UNIT counter_double_685_bytes_total bytes
 counter_double_685_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_686_bytes_total counter
-# UNIT counter_double_686_bytes_total bytes
 counter_double_686_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_687_bytes_total counter
-# UNIT counter_double_687_bytes_total bytes
 counter_double_687_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_688_bytes_total counter
-# UNIT counter_double_688_bytes_total bytes
 counter_double_688_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_689_bytes_total counter
-# UNIT counter_double_689_bytes_total bytes
 counter_double_689_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_68_bytes_total counter
-# UNIT counter_double_68_bytes_total bytes
 counter_double_68_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_690_bytes_total counter
-# UNIT counter_double_690_bytes_total bytes
 counter_double_690_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_691_bytes_total counter
-# UNIT counter_double_691_bytes_total bytes
 counter_double_691_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_692_bytes_total counter
-# UNIT counter_double_692_bytes_total bytes
 counter_double_692_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_693_bytes_total counter
-# UNIT counter_double_693_bytes_total bytes
 counter_double_693_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_694_bytes_total counter
-# UNIT counter_double_694_bytes_total bytes
 counter_double_694_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_695_bytes_total counter
-# UNIT counter_double_695_bytes_total bytes
 counter_double_695_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_696_bytes_total counter
-# UNIT counter_double_696_bytes_total bytes
 counter_double_696_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_697_bytes_total counter
-# UNIT counter_double_697_bytes_total bytes
 counter_double_697_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_698_bytes_total counter
-# UNIT counter_double_698_bytes_total bytes
 counter_double_698_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_699_bytes_total counter
-# UNIT counter_double_699_bytes_total bytes
 counter_double_699_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_69_bytes_total counter
-# UNIT counter_double_69_bytes_total bytes
 counter_double_69_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_6_bytes_total counter
-# UNIT counter_double_6_bytes_total bytes
 counter_double_6_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_700_bytes_total counter
-# UNIT counter_double_700_bytes_total bytes
 counter_double_700_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_701_bytes_total counter
-# UNIT counter_double_701_bytes_total bytes
 counter_double_701_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_702_bytes_total counter
-# UNIT counter_double_702_bytes_total bytes
 counter_double_702_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_703_bytes_total counter
-# UNIT counter_double_703_bytes_total bytes
 counter_double_703_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_704_bytes_total counter
-# UNIT counter_double_704_bytes_total bytes
 counter_double_704_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_705_bytes_total counter
-# UNIT counter_double_705_bytes_total bytes
 counter_double_705_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_706_bytes_total counter
-# UNIT counter_double_706_bytes_total bytes
 counter_double_706_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_707_bytes_total counter
-# UNIT counter_double_707_bytes_total bytes
 counter_double_707_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_708_bytes_total counter
-# UNIT counter_double_708_bytes_total bytes
 counter_double_708_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_709_bytes_total counter
-# UNIT counter_double_709_bytes_total bytes
 counter_double_709_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_70_bytes_total counter
-# UNIT counter_double_70_bytes_total bytes
 counter_double_70_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_710_bytes_total counter
-# UNIT counter_double_710_bytes_total bytes
 counter_double_710_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_711_bytes_total counter
-# UNIT counter_double_711_bytes_total bytes
 counter_double_711_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_712_bytes_total counter
-# UNIT counter_double_712_bytes_total bytes
 counter_double_712_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_713_bytes_total counter
-# UNIT counter_double_713_bytes_total bytes
 counter_double_713_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_714_bytes_total counter
-# UNIT counter_double_714_bytes_total bytes
 counter_double_714_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_715_bytes_total counter
-# UNIT counter_double_715_bytes_total bytes
 counter_double_715_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_716_bytes_total counter
-# UNIT counter_double_716_bytes_total bytes
 counter_double_716_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_717_bytes_total counter
-# UNIT counter_double_717_bytes_total bytes
 counter_double_717_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_718_bytes_total counter
-# UNIT counter_double_718_bytes_total bytes
 counter_double_718_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_719_bytes_total counter
-# UNIT counter_double_719_bytes_total bytes
 counter_double_719_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_71_bytes_total counter
-# UNIT counter_double_71_bytes_total bytes
 counter_double_71_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_720_bytes_total counter
-# UNIT counter_double_720_bytes_total bytes
 counter_double_720_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_721_bytes_total counter
-# UNIT counter_double_721_bytes_total bytes
 counter_double_721_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_722_bytes_total counter
-# UNIT counter_double_722_bytes_total bytes
 counter_double_722_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_723_bytes_total counter
-# UNIT counter_double_723_bytes_total bytes
 counter_double_723_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_724_bytes_total counter
-# UNIT counter_double_724_bytes_total bytes
 counter_double_724_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_725_bytes_total counter
-# UNIT counter_double_725_bytes_total bytes
 counter_double_725_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_726_bytes_total counter
-# UNIT counter_double_726_bytes_total bytes
 counter_double_726_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_727_bytes_total counter
-# UNIT counter_double_727_bytes_total bytes
 counter_double_727_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_728_bytes_total counter
-# UNIT counter_double_728_bytes_total bytes
 counter_double_728_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_729_bytes_total counter
-# UNIT counter_double_729_bytes_total bytes
 counter_double_729_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_72_bytes_total counter
-# UNIT counter_double_72_bytes_total bytes
 counter_double_72_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_730_bytes_total counter
-# UNIT counter_double_730_bytes_total bytes
 counter_double_730_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_731_bytes_total counter
-# UNIT counter_double_731_bytes_total bytes
 counter_double_731_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_732_bytes_total counter
-# UNIT counter_double_732_bytes_total bytes
 counter_double_732_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_733_bytes_total counter
-# UNIT counter_double_733_bytes_total bytes
 counter_double_733_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_734_bytes_total counter
-# UNIT counter_double_734_bytes_total bytes
 counter_double_734_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_735_bytes_total counter
-# UNIT counter_double_735_bytes_total bytes
 counter_double_735_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_736_bytes_total counter
-# UNIT counter_double_736_bytes_total bytes
 counter_double_736_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_737_bytes_total counter
-# UNIT counter_double_737_bytes_total bytes
 counter_double_737_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_738_bytes_total counter
-# UNIT counter_double_738_bytes_total bytes
 counter_double_738_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_739_bytes_total counter
-# UNIT counter_double_739_bytes_total bytes
 counter_double_739_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_73_bytes_total counter
-# UNIT counter_double_73_bytes_total bytes
 counter_double_73_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_740_bytes_total counter
-# UNIT counter_double_740_bytes_total bytes
 counter_double_740_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_741_bytes_total counter
-# UNIT counter_double_741_bytes_total bytes
 counter_double_741_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_742_bytes_total counter
-# UNIT counter_double_742_bytes_total bytes
 counter_double_742_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_743_bytes_total counter
-# UNIT counter_double_743_bytes_total bytes
 counter_double_743_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_744_bytes_total counter
-# UNIT counter_double_744_bytes_total bytes
 counter_double_744_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_745_bytes_total counter
-# UNIT counter_double_745_bytes_total bytes
 counter_double_745_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_746_bytes_total counter
-# UNIT counter_double_746_bytes_total bytes
 counter_double_746_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_747_bytes_total counter
-# UNIT counter_double_747_bytes_total bytes
 counter_double_747_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_748_bytes_total counter
-# UNIT counter_double_748_bytes_total bytes
 counter_double_748_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_749_bytes_total counter
-# UNIT counter_double_749_bytes_total bytes
 counter_double_749_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_74_bytes_total counter
-# UNIT counter_double_74_bytes_total bytes
 counter_double_74_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_750_bytes_total counter
-# UNIT counter_double_750_bytes_total bytes
 counter_double_750_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_751_bytes_total counter
-# UNIT counter_double_751_bytes_total bytes
 counter_double_751_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_752_bytes_total counter
-# UNIT counter_double_752_bytes_total bytes
 counter_double_752_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_753_bytes_total counter
-# UNIT counter_double_753_bytes_total bytes
 counter_double_753_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_754_bytes_total counter
-# UNIT counter_double_754_bytes_total bytes
 counter_double_754_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_755_bytes_total counter
-# UNIT counter_double_755_bytes_total bytes
 counter_double_755_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_756_bytes_total counter
-# UNIT counter_double_756_bytes_total bytes
 counter_double_756_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_757_bytes_total counter
-# UNIT counter_double_757_bytes_total bytes
 counter_double_757_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_758_bytes_total counter
-# UNIT counter_double_758_bytes_total bytes
 counter_double_758_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_759_bytes_total counter
-# UNIT counter_double_759_bytes_total bytes
 counter_double_759_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_75_bytes_total counter
-# UNIT counter_double_75_bytes_total bytes
 counter_double_75_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_760_bytes_total counter
-# UNIT counter_double_760_bytes_total bytes
 counter_double_760_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_761_bytes_total counter
-# UNIT counter_double_761_bytes_total bytes
 counter_double_761_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_762_bytes_total counter
-# UNIT counter_double_762_bytes_total bytes
 counter_double_762_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_763_bytes_total counter
-# UNIT counter_double_763_bytes_total bytes
 counter_double_763_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_764_bytes_total counter
-# UNIT counter_double_764_bytes_total bytes
 counter_double_764_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_765_bytes_total counter
-# UNIT counter_double_765_bytes_total bytes
 counter_double_765_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_766_bytes_total counter
-# UNIT counter_double_766_bytes_total bytes
 counter_double_766_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_767_bytes_total counter
-# UNIT counter_double_767_bytes_total bytes
 counter_double_767_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_768_bytes_total counter
-# UNIT counter_double_768_bytes_total bytes
 counter_double_768_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_769_bytes_total counter
-# UNIT counter_double_769_bytes_total bytes
 counter_double_769_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_76_bytes_total counter
-# UNIT counter_double_76_bytes_total bytes
 counter_double_76_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_770_bytes_total counter
-# UNIT counter_double_770_bytes_total bytes
 counter_double_770_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_771_bytes_total counter
-# UNIT counter_double_771_bytes_total bytes
 counter_double_771_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_772_bytes_total counter
-# UNIT counter_double_772_bytes_total bytes
 counter_double_772_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_773_bytes_total counter
-# UNIT counter_double_773_bytes_total bytes
 counter_double_773_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_774_bytes_total counter
-# UNIT counter_double_774_bytes_total bytes
 counter_double_774_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_775_bytes_total counter
-# UNIT counter_double_775_bytes_total bytes
 counter_double_775_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_776_bytes_total counter
-# UNIT counter_double_776_bytes_total bytes
 counter_double_776_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_777_bytes_total counter
-# UNIT counter_double_777_bytes_total bytes
 counter_double_777_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_778_bytes_total counter
-# UNIT counter_double_778_bytes_total bytes
 counter_double_778_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_779_bytes_total counter
-# UNIT counter_double_779_bytes_total bytes
 counter_double_779_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_77_bytes_total counter
-# UNIT counter_double_77_bytes_total bytes
 counter_double_77_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_780_bytes_total counter
-# UNIT counter_double_780_bytes_total bytes
 counter_double_780_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_781_bytes_total counter
-# UNIT counter_double_781_bytes_total bytes
 counter_double_781_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_782_bytes_total counter
-# UNIT counter_double_782_bytes_total bytes
 counter_double_782_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_783_bytes_total counter
-# UNIT counter_double_783_bytes_total bytes
 counter_double_783_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_784_bytes_total counter
-# UNIT counter_double_784_bytes_total bytes
 counter_double_784_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_785_bytes_total counter
-# UNIT counter_double_785_bytes_total bytes
 counter_double_785_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_786_bytes_total counter
-# UNIT counter_double_786_bytes_total bytes
 counter_double_786_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_787_bytes_total counter
-# UNIT counter_double_787_bytes_total bytes
 counter_double_787_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_788_bytes_total counter
-# UNIT counter_double_788_bytes_total bytes
 counter_double_788_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_789_bytes_total counter
-# UNIT counter_double_789_bytes_total bytes
 counter_double_789_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_78_bytes_total counter
-# UNIT counter_double_78_bytes_total bytes
 counter_double_78_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_790_bytes_total counter
-# UNIT counter_double_790_bytes_total bytes
 counter_double_790_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_791_bytes_total counter
-# UNIT counter_double_791_bytes_total bytes
 counter_double_791_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_792_bytes_total counter
-# UNIT counter_double_792_bytes_total bytes
 counter_double_792_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_793_bytes_total counter
-# UNIT counter_double_793_bytes_total bytes
 counter_double_793_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_794_bytes_total counter
-# UNIT counter_double_794_bytes_total bytes
 counter_double_794_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_795_bytes_total counter
-# UNIT counter_double_795_bytes_total bytes
 counter_double_795_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_796_bytes_total counter
-# UNIT counter_double_796_bytes_total bytes
 counter_double_796_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_797_bytes_total counter
-# UNIT counter_double_797_bytes_total bytes
 counter_double_797_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_798_bytes_total counter
-# UNIT counter_double_798_bytes_total bytes
 counter_double_798_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_799_bytes_total counter
-# UNIT counter_double_799_bytes_total bytes
 counter_double_799_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_79_bytes_total counter
-# UNIT counter_double_79_bytes_total bytes
 counter_double_79_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_7_bytes_total counter
-# UNIT counter_double_7_bytes_total bytes
 counter_double_7_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_800_bytes_total counter
-# UNIT counter_double_800_bytes_total bytes
 counter_double_800_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_801_bytes_total counter
-# UNIT counter_double_801_bytes_total bytes
 counter_double_801_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_802_bytes_total counter
-# UNIT counter_double_802_bytes_total bytes
 counter_double_802_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_803_bytes_total counter
-# UNIT counter_double_803_bytes_total bytes
 counter_double_803_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_804_bytes_total counter
-# UNIT counter_double_804_bytes_total bytes
 counter_double_804_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_805_bytes_total counter
-# UNIT counter_double_805_bytes_total bytes
 counter_double_805_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_806_bytes_total counter
-# UNIT counter_double_806_bytes_total bytes
 counter_double_806_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_807_bytes_total counter
-# UNIT counter_double_807_bytes_total bytes
 counter_double_807_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_808_bytes_total counter
-# UNIT counter_double_808_bytes_total bytes
 counter_double_808_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_809_bytes_total counter
-# UNIT counter_double_809_bytes_total bytes
 counter_double_809_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_80_bytes_total counter
-# UNIT counter_double_80_bytes_total bytes
 counter_double_80_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_810_bytes_total counter
-# UNIT counter_double_810_bytes_total bytes
 counter_double_810_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_811_bytes_total counter
-# UNIT counter_double_811_bytes_total bytes
 counter_double_811_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_812_bytes_total counter
-# UNIT counter_double_812_bytes_total bytes
 counter_double_812_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_813_bytes_total counter
-# UNIT counter_double_813_bytes_total bytes
 counter_double_813_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_814_bytes_total counter
-# UNIT counter_double_814_bytes_total bytes
 counter_double_814_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_815_bytes_total counter
-# UNIT counter_double_815_bytes_total bytes
 counter_double_815_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_816_bytes_total counter
-# UNIT counter_double_816_bytes_total bytes
 counter_double_816_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_817_bytes_total counter
-# UNIT counter_double_817_bytes_total bytes
 counter_double_817_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_818_bytes_total counter
-# UNIT counter_double_818_bytes_total bytes
 counter_double_818_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_819_bytes_total counter
-# UNIT counter_double_819_bytes_total bytes
 counter_double_819_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_81_bytes_total counter
-# UNIT counter_double_81_bytes_total bytes
 counter_double_81_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_820_bytes_total counter
-# UNIT counter_double_820_bytes_total bytes
 counter_double_820_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_821_bytes_total counter
-# UNIT counter_double_821_bytes_total bytes
 counter_double_821_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_822_bytes_total counter
-# UNIT counter_double_822_bytes_total bytes
 counter_double_822_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_823_bytes_total counter
-# UNIT counter_double_823_bytes_total bytes
 counter_double_823_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_824_bytes_total counter
-# UNIT counter_double_824_bytes_total bytes
 counter_double_824_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_825_bytes_total counter
-# UNIT counter_double_825_bytes_total bytes
 counter_double_825_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_826_bytes_total counter
-# UNIT counter_double_826_bytes_total bytes
 counter_double_826_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_827_bytes_total counter
-# UNIT counter_double_827_bytes_total bytes
 counter_double_827_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_828_bytes_total counter
-# UNIT counter_double_828_bytes_total bytes
 counter_double_828_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_829_bytes_total counter
-# UNIT counter_double_829_bytes_total bytes
 counter_double_829_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_82_bytes_total counter
-# UNIT counter_double_82_bytes_total bytes
 counter_double_82_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_830_bytes_total counter
-# UNIT counter_double_830_bytes_total bytes
 counter_double_830_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_831_bytes_total counter
-# UNIT counter_double_831_bytes_total bytes
 counter_double_831_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_832_bytes_total counter
-# UNIT counter_double_832_bytes_total bytes
 counter_double_832_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_833_bytes_total counter
-# UNIT counter_double_833_bytes_total bytes
 counter_double_833_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_834_bytes_total counter
-# UNIT counter_double_834_bytes_total bytes
 counter_double_834_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_835_bytes_total counter
-# UNIT counter_double_835_bytes_total bytes
 counter_double_835_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_836_bytes_total counter
-# UNIT counter_double_836_bytes_total bytes
 counter_double_836_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_837_bytes_total counter
-# UNIT counter_double_837_bytes_total bytes
 counter_double_837_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_838_bytes_total counter
-# UNIT counter_double_838_bytes_total bytes
 counter_double_838_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_839_bytes_total counter
-# UNIT counter_double_839_bytes_total bytes
 counter_double_839_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_83_bytes_total counter
-# UNIT counter_double_83_bytes_total bytes
 counter_double_83_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_840_bytes_total counter
-# UNIT counter_double_840_bytes_total bytes
 counter_double_840_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_841_bytes_total counter
-# UNIT counter_double_841_bytes_total bytes
 counter_double_841_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_842_bytes_total counter
-# UNIT counter_double_842_bytes_total bytes
 counter_double_842_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_843_bytes_total counter
-# UNIT counter_double_843_bytes_total bytes
 counter_double_843_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_844_bytes_total counter
-# UNIT counter_double_844_bytes_total bytes
 counter_double_844_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_845_bytes_total counter
-# UNIT counter_double_845_bytes_total bytes
 counter_double_845_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_846_bytes_total counter
-# UNIT counter_double_846_bytes_total bytes
 counter_double_846_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_847_bytes_total counter
-# UNIT counter_double_847_bytes_total bytes
 counter_double_847_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_848_bytes_total counter
-# UNIT counter_double_848_bytes_total bytes
 counter_double_848_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_849_bytes_total counter
-# UNIT counter_double_849_bytes_total bytes
 counter_double_849_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_84_bytes_total counter
-# UNIT counter_double_84_bytes_total bytes
 counter_double_84_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_850_bytes_total counter
-# UNIT counter_double_850_bytes_total bytes
 counter_double_850_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_851_bytes_total counter
-# UNIT counter_double_851_bytes_total bytes
 counter_double_851_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_852_bytes_total counter
-# UNIT counter_double_852_bytes_total bytes
 counter_double_852_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_853_bytes_total counter
-# UNIT counter_double_853_bytes_total bytes
 counter_double_853_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_854_bytes_total counter
-# UNIT counter_double_854_bytes_total bytes
 counter_double_854_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_855_bytes_total counter
-# UNIT counter_double_855_bytes_total bytes
 counter_double_855_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_856_bytes_total counter
-# UNIT counter_double_856_bytes_total bytes
 counter_double_856_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_857_bytes_total counter
-# UNIT counter_double_857_bytes_total bytes
 counter_double_857_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_858_bytes_total counter
-# UNIT counter_double_858_bytes_total bytes
 counter_double_858_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_859_bytes_total counter
-# UNIT counter_double_859_bytes_total bytes
 counter_double_859_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_85_bytes_total counter
-# UNIT counter_double_85_bytes_total bytes
 counter_double_85_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_860_bytes_total counter
-# UNIT counter_double_860_bytes_total bytes
 counter_double_860_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_861_bytes_total counter
-# UNIT counter_double_861_bytes_total bytes
 counter_double_861_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_862_bytes_total counter
-# UNIT counter_double_862_bytes_total bytes
 counter_double_862_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_863_bytes_total counter
-# UNIT counter_double_863_bytes_total bytes
 counter_double_863_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_864_bytes_total counter
-# UNIT counter_double_864_bytes_total bytes
 counter_double_864_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_865_bytes_total counter
-# UNIT counter_double_865_bytes_total bytes
 counter_double_865_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_866_bytes_total counter
-# UNIT counter_double_866_bytes_total bytes
 counter_double_866_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_867_bytes_total counter
-# UNIT counter_double_867_bytes_total bytes
 counter_double_867_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_868_bytes_total counter
-# UNIT counter_double_868_bytes_total bytes
 counter_double_868_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_869_bytes_total counter
-# UNIT counter_double_869_bytes_total bytes
 counter_double_869_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_86_bytes_total counter
-# UNIT counter_double_86_bytes_total bytes
 counter_double_86_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_870_bytes_total counter
-# UNIT counter_double_870_bytes_total bytes
 counter_double_870_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_871_bytes_total counter
-# UNIT counter_double_871_bytes_total bytes
 counter_double_871_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_872_bytes_total counter
-# UNIT counter_double_872_bytes_total bytes
 counter_double_872_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_873_bytes_total counter
-# UNIT counter_double_873_bytes_total bytes
 counter_double_873_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_874_bytes_total counter
-# UNIT counter_double_874_bytes_total bytes
 counter_double_874_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_875_bytes_total counter
-# UNIT counter_double_875_bytes_total bytes
 counter_double_875_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_876_bytes_total counter
-# UNIT counter_double_876_bytes_total bytes
 counter_double_876_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_877_bytes_total counter
-# UNIT counter_double_877_bytes_total bytes
 counter_double_877_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_878_bytes_total counter
-# UNIT counter_double_878_bytes_total bytes
 counter_double_878_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_879_bytes_total counter
-# UNIT counter_double_879_bytes_total bytes
 counter_double_879_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_87_bytes_total counter
-# UNIT counter_double_87_bytes_total bytes
 counter_double_87_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_880_bytes_total counter
-# UNIT counter_double_880_bytes_total bytes
 counter_double_880_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_881_bytes_total counter
-# UNIT counter_double_881_bytes_total bytes
 counter_double_881_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_882_bytes_total counter
-# UNIT counter_double_882_bytes_total bytes
 counter_double_882_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_883_bytes_total counter
-# UNIT counter_double_883_bytes_total bytes
 counter_double_883_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_884_bytes_total counter
-# UNIT counter_double_884_bytes_total bytes
 counter_double_884_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_885_bytes_total counter
-# UNIT counter_double_885_bytes_total bytes
 counter_double_885_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_886_bytes_total counter
-# UNIT counter_double_886_bytes_total bytes
 counter_double_886_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_887_bytes_total counter
-# UNIT counter_double_887_bytes_total bytes
 counter_double_887_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_888_bytes_total counter
-# UNIT counter_double_888_bytes_total bytes
 counter_double_888_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_889_bytes_total counter
-# UNIT counter_double_889_bytes_total bytes
 counter_double_889_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_88_bytes_total counter
-# UNIT counter_double_88_bytes_total bytes
 counter_double_88_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_890_bytes_total counter
-# UNIT counter_double_890_bytes_total bytes
 counter_double_890_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_891_bytes_total counter
-# UNIT counter_double_891_bytes_total bytes
 counter_double_891_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_892_bytes_total counter
-# UNIT counter_double_892_bytes_total bytes
 counter_double_892_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_893_bytes_total counter
-# UNIT counter_double_893_bytes_total bytes
 counter_double_893_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_894_bytes_total counter
-# UNIT counter_double_894_bytes_total bytes
 counter_double_894_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_895_bytes_total counter
-# UNIT counter_double_895_bytes_total bytes
 counter_double_895_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_896_bytes_total counter
-# UNIT counter_double_896_bytes_total bytes
 counter_double_896_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_897_bytes_total counter
-# UNIT counter_double_897_bytes_total bytes
 counter_double_897_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_898_bytes_total counter
-# UNIT counter_double_898_bytes_total bytes
 counter_double_898_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_899_bytes_total counter
-# UNIT counter_double_899_bytes_total bytes
 counter_double_899_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_89_bytes_total counter
-# UNIT counter_double_89_bytes_total bytes
 counter_double_89_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_8_bytes_total counter
-# UNIT counter_double_8_bytes_total bytes
 counter_double_8_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_900_bytes_total counter
-# UNIT counter_double_900_bytes_total bytes
 counter_double_900_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_901_bytes_total counter
-# UNIT counter_double_901_bytes_total bytes
 counter_double_901_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_902_bytes_total counter
-# UNIT counter_double_902_bytes_total bytes
 counter_double_902_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_903_bytes_total counter
-# UNIT counter_double_903_bytes_total bytes
 counter_double_903_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_904_bytes_total counter
-# UNIT counter_double_904_bytes_total bytes
 counter_double_904_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_905_bytes_total counter
-# UNIT counter_double_905_bytes_total bytes
 counter_double_905_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_906_bytes_total counter
-# UNIT counter_double_906_bytes_total bytes
 counter_double_906_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_907_bytes_total counter
-# UNIT counter_double_907_bytes_total bytes
 counter_double_907_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_908_bytes_total counter
-# UNIT counter_double_908_bytes_total bytes
 counter_double_908_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_909_bytes_total counter
-# UNIT counter_double_909_bytes_total bytes
 counter_double_909_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_90_bytes_total counter
-# UNIT counter_double_90_bytes_total bytes
 counter_double_90_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_910_bytes_total counter
-# UNIT counter_double_910_bytes_total bytes
 counter_double_910_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_911_bytes_total counter
-# UNIT counter_double_911_bytes_total bytes
 counter_double_911_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_912_bytes_total counter
-# UNIT counter_double_912_bytes_total bytes
 counter_double_912_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_913_bytes_total counter
-# UNIT counter_double_913_bytes_total bytes
 counter_double_913_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_914_bytes_total counter
-# UNIT counter_double_914_bytes_total bytes
 counter_double_914_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_915_bytes_total counter
-# UNIT counter_double_915_bytes_total bytes
 counter_double_915_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_916_bytes_total counter
-# UNIT counter_double_916_bytes_total bytes
 counter_double_916_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_917_bytes_total counter
-# UNIT counter_double_917_bytes_total bytes
 counter_double_917_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_918_bytes_total counter
-# UNIT counter_double_918_bytes_total bytes
 counter_double_918_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_919_bytes_total counter
-# UNIT counter_double_919_bytes_total bytes
 counter_double_919_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_91_bytes_total counter
-# UNIT counter_double_91_bytes_total bytes
 counter_double_91_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_920_bytes_total counter
-# UNIT counter_double_920_bytes_total bytes
 counter_double_920_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_921_bytes_total counter
-# UNIT counter_double_921_bytes_total bytes
 counter_double_921_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_922_bytes_total counter
-# UNIT counter_double_922_bytes_total bytes
 counter_double_922_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_923_bytes_total counter
-# UNIT counter_double_923_bytes_total bytes
 counter_double_923_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_924_bytes_total counter
-# UNIT counter_double_924_bytes_total bytes
 counter_double_924_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_925_bytes_total counter
-# UNIT counter_double_925_bytes_total bytes
 counter_double_925_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_926_bytes_total counter
-# UNIT counter_double_926_bytes_total bytes
 counter_double_926_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_927_bytes_total counter
-# UNIT counter_double_927_bytes_total bytes
 counter_double_927_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_928_bytes_total counter
-# UNIT counter_double_928_bytes_total bytes
 counter_double_928_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_929_bytes_total counter
-# UNIT counter_double_929_bytes_total bytes
 counter_double_929_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_92_bytes_total counter
-# UNIT counter_double_92_bytes_total bytes
 counter_double_92_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_930_bytes_total counter
-# UNIT counter_double_930_bytes_total bytes
 counter_double_930_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_931_bytes_total counter
-# UNIT counter_double_931_bytes_total bytes
 counter_double_931_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_932_bytes_total counter
-# UNIT counter_double_932_bytes_total bytes
 counter_double_932_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_933_bytes_total counter
-# UNIT counter_double_933_bytes_total bytes
 counter_double_933_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_934_bytes_total counter
-# UNIT counter_double_934_bytes_total bytes
 counter_double_934_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_935_bytes_total counter
-# UNIT counter_double_935_bytes_total bytes
 counter_double_935_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_936_bytes_total counter
-# UNIT counter_double_936_bytes_total bytes
 counter_double_936_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_937_bytes_total counter
-# UNIT counter_double_937_bytes_total bytes
 counter_double_937_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_938_bytes_total counter
-# UNIT counter_double_938_bytes_total bytes
 counter_double_938_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_939_bytes_total counter
-# UNIT counter_double_939_bytes_total bytes
 counter_double_939_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_93_bytes_total counter
-# UNIT counter_double_93_bytes_total bytes
 counter_double_93_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_940_bytes_total counter
-# UNIT counter_double_940_bytes_total bytes
 counter_double_940_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_941_bytes_total counter
-# UNIT counter_double_941_bytes_total bytes
 counter_double_941_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_942_bytes_total counter
-# UNIT counter_double_942_bytes_total bytes
 counter_double_942_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_943_bytes_total counter
-# UNIT counter_double_943_bytes_total bytes
 counter_double_943_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_944_bytes_total counter
-# UNIT counter_double_944_bytes_total bytes
 counter_double_944_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_945_bytes_total counter
-# UNIT counter_double_945_bytes_total bytes
 counter_double_945_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_946_bytes_total counter
-# UNIT counter_double_946_bytes_total bytes
 counter_double_946_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_947_bytes_total counter
-# UNIT counter_double_947_bytes_total bytes
 counter_double_947_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_948_bytes_total counter
-# UNIT counter_double_948_bytes_total bytes
 counter_double_948_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_949_bytes_total counter
-# UNIT counter_double_949_bytes_total bytes
 counter_double_949_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_94_bytes_total counter
-# UNIT counter_double_94_bytes_total bytes
 counter_double_94_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_950_bytes_total counter
-# UNIT counter_double_950_bytes_total bytes
 counter_double_950_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_951_bytes_total counter
-# UNIT counter_double_951_bytes_total bytes
 counter_double_951_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_952_bytes_total counter
-# UNIT counter_double_952_bytes_total bytes
 counter_double_952_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_953_bytes_total counter
-# UNIT counter_double_953_bytes_total bytes
 counter_double_953_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_954_bytes_total counter
-# UNIT counter_double_954_bytes_total bytes
 counter_double_954_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_955_bytes_total counter
-# UNIT counter_double_955_bytes_total bytes
 counter_double_955_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_956_bytes_total counter
-# UNIT counter_double_956_bytes_total bytes
 counter_double_956_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_957_bytes_total counter
-# UNIT counter_double_957_bytes_total bytes
 counter_double_957_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_958_bytes_total counter
-# UNIT counter_double_958_bytes_total bytes
 counter_double_958_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_959_bytes_total counter
-# UNIT counter_double_959_bytes_total bytes
 counter_double_959_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_95_bytes_total counter
-# UNIT counter_double_95_bytes_total bytes
 counter_double_95_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_960_bytes_total counter
-# UNIT counter_double_960_bytes_total bytes
 counter_double_960_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_961_bytes_total counter
-# UNIT counter_double_961_bytes_total bytes
 counter_double_961_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_962_bytes_total counter
-# UNIT counter_double_962_bytes_total bytes
 counter_double_962_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_963_bytes_total counter
-# UNIT counter_double_963_bytes_total bytes
 counter_double_963_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_964_bytes_total counter
-# UNIT counter_double_964_bytes_total bytes
 counter_double_964_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_965_bytes_total counter
-# UNIT counter_double_965_bytes_total bytes
 counter_double_965_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_966_bytes_total counter
-# UNIT counter_double_966_bytes_total bytes
 counter_double_966_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_967_bytes_total counter
-# UNIT counter_double_967_bytes_total bytes
 counter_double_967_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_968_bytes_total counter
-# UNIT counter_double_968_bytes_total bytes
 counter_double_968_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_969_bytes_total counter
-# UNIT counter_double_969_bytes_total bytes
 counter_double_969_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_96_bytes_total counter
-# UNIT counter_double_96_bytes_total bytes
 counter_double_96_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_970_bytes_total counter
-# UNIT counter_double_970_bytes_total bytes
 counter_double_970_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_971_bytes_total counter
-# UNIT counter_double_971_bytes_total bytes
 counter_double_971_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_972_bytes_total counter
-# UNIT counter_double_972_bytes_total bytes
 counter_double_972_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_973_bytes_total counter
-# UNIT counter_double_973_bytes_total bytes
 counter_double_973_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_974_bytes_total counter
-# UNIT counter_double_974_bytes_total bytes
 counter_double_974_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_975_bytes_total counter
-# UNIT counter_double_975_bytes_total bytes
 counter_double_975_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_976_bytes_total counter
-# UNIT counter_double_976_bytes_total bytes
 counter_double_976_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_977_bytes_total counter
-# UNIT counter_double_977_bytes_total bytes
 counter_double_977_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_978_bytes_total counter
-# UNIT counter_double_978_bytes_total bytes
 counter_double_978_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_979_bytes_total counter
-# UNIT counter_double_979_bytes_total bytes
 counter_double_979_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_97_bytes_total counter
-# UNIT counter_double_97_bytes_total bytes
 counter_double_97_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_980_bytes_total counter
-# UNIT counter_double_980_bytes_total bytes
 counter_double_980_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_981_bytes_total counter
-# UNIT counter_double_981_bytes_total bytes
 counter_double_981_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_982_bytes_total counter
-# UNIT counter_double_982_bytes_total bytes
 counter_double_982_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_983_bytes_total counter
-# UNIT counter_double_983_bytes_total bytes
 counter_double_983_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_984_bytes_total counter
-# UNIT counter_double_984_bytes_total bytes
 counter_double_984_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_985_bytes_total counter
-# UNIT counter_double_985_bytes_total bytes
 counter_double_985_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_986_bytes_total counter
-# UNIT counter_double_986_bytes_total bytes
 counter_double_986_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_987_bytes_total counter
-# UNIT counter_double_987_bytes_total bytes
 counter_double_987_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_988_bytes_total counter
-# UNIT counter_double_988_bytes_total bytes
 counter_double_988_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_989_bytes_total counter
-# UNIT counter_double_989_bytes_total bytes
 counter_double_989_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_98_bytes_total counter
-# UNIT counter_double_98_bytes_total bytes
 counter_double_98_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_990_bytes_total counter
-# UNIT counter_double_990_bytes_total bytes
 counter_double_990_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_991_bytes_total counter
-# UNIT counter_double_991_bytes_total bytes
 counter_double_991_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_992_bytes_total counter
-# UNIT counter_double_992_bytes_total bytes
 counter_double_992_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_993_bytes_total counter
-# UNIT counter_double_993_bytes_total bytes
 counter_double_993_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_994_bytes_total counter
-# UNIT counter_double_994_bytes_total bytes
 counter_double_994_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_995_bytes_total counter
-# UNIT counter_double_995_bytes_total bytes
 counter_double_995_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_996_bytes_total counter
-# UNIT counter_double_996_bytes_total bytes
 counter_double_996_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_997_bytes_total counter
-# UNIT counter_double_997_bytes_total bytes
 counter_double_997_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_998_bytes_total counter
-# UNIT counter_double_998_bytes_total bytes
 counter_double_998_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_999_bytes_total counter
-# UNIT counter_double_999_bytes_total bytes
 counter_double_999_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_99_bytes_total counter
-# UNIT counter_double_99_bytes_total bytes
 counter_double_99_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
 # TYPE counter_double_9_bytes_total counter
-# UNIT counter_double_9_bytes_total bytes
 counter_double_9_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1"} 1
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.DuplicateMetricMetadataIsWrittenOncePerScrape.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.DuplicateMetricMetadataIsWrittenOncePerScrape.verified.txt
@@ -2,8 +2,6 @@
 # HELP target_info Target metadata
 target_info{service_name="prometheus",telemetry_sdk_name="opentelemetry",telemetry_sdk_language="dotnet",telemetry_sdk_version="<VERSION>"} 1
 # TYPE test_metric_bytes_total counter
-# UNIT test_metric_bytes_total bytes
 # HELP test_metric_bytes_total Test help
 test_metric_bytes_total{otel_scope_name="DuplicateMetricMetadataIsWrittenOncePerScrape",source="b"} 2
 test_metric_bytes_total{otel_scope_name="DuplicateMetricMetadataIsWrittenOncePerScrape",source="a"} 1
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.ExponentialHistogramsAreIgnored.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.ExponentialHistogramsAreIgnored.verified.txt
@@ -3,4 +3,3 @@
 target_info{service_name="prometheus",telemetry_sdk_name="opentelemetry",telemetry_sdk_language="dotnet",telemetry_sdk_version="<VERSION>"} 1
 # TYPE test_counter_total counter
 test_counter_total{otel_scope_name="ExponentialHistogramsAreIgnored"} 43
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.GaugeZeroDimensionWithDescriptionAndUnit.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.GaugeZeroDimensionWithDescriptionAndUnit.verified.txt
@@ -1,4 +1,3 @@
 ﻿# TYPE test_gauge_seconds gauge
-# UNIT test_gauge_seconds seconds
 # HELP test_gauge_seconds Hello, world!
 test_gauge_seconds{otel_scope_name="GaugeZeroDimensionWithDescriptionAndUnit"} 123

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.GaugeZeroDimensionWithUnit.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.GaugeZeroDimensionWithUnit.verified.txt
@@ -1,3 +1,2 @@
 ﻿# TYPE test_gauge_seconds gauge
-# UNIT test_gauge_seconds seconds
 test_gauge_seconds{otel_scope_name="GaugeZeroDimensionWithUnit"} 123

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.MetricHelpAndUnitDiscoveredTogetherLaterAreBothWrittenBeforeSamples.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.MetricHelpAndUnitDiscoveredTogetherLaterAreBothWrittenBeforeSamples.verified.txt
@@ -2,8 +2,6 @@
 # HELP target_info Target metadata
 target_info{service_name="prometheus",telemetry_sdk_name="opentelemetry",telemetry_sdk_language="dotnet",telemetry_sdk_version="<VERSION>"} 1
 # TYPE test_metric_bytes_total counter
-# UNIT test_metric_bytes_total bytes
 # HELP test_metric_bytes_total Test help
 test_metric_bytes_total{otel_scope_name="MetricHelpAndUnitDiscoveredTogetherLaterAreBothWrittenBeforeSamples",source="b"} 2
 test_metric_bytes_total{otel_scope_name="MetricHelpAndUnitDiscoveredTogetherLaterAreBothWrittenBeforeSamples",source="a"} 1
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.MetricMetadataDiscoveredLaterIsWrittenBeforeSamples.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.MetricMetadataDiscoveredLaterIsWrittenBeforeSamples.verified.txt
@@ -5,4 +5,3 @@ target_info{service_name="prometheus",telemetry_sdk_name="opentelemetry",telemet
 # HELP test_metric_total Test help
 test_metric_total{otel_scope_name="MetricMetadataDiscoveredLaterIsWrittenBeforeSamples",source="b"} 2
 test_metric_total{otel_scope_name="MetricMetadataDiscoveredLaterIsWrittenBeforeSamples",source="a"} 1
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.MetricUnitDiscoveredLaterIsWrittenBeforeSamples.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.MetricUnitDiscoveredLaterIsWrittenBeforeSamples.verified.txt
@@ -2,7 +2,5 @@
 # HELP target_info Target metadata
 target_info{service_name="prometheus",telemetry_sdk_name="opentelemetry",telemetry_sdk_language="dotnet",telemetry_sdk_version="<VERSION>"} 1
 # TYPE test_metric_bytes_total counter
-# UNIT test_metric_bytes_total bytes
 test_metric_bytes_total{otel_scope_name="MetricUnitDiscoveredLaterIsWrittenBeforeSamples",source="b"} 2
 test_metric_bytes_total{otel_scope_name="MetricUnitDiscoveredLaterIsWrittenBeforeSamples",source="a"} 1
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunHttpServerWithNoAcceptHeader.verified.text
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunHttpServerWithNoAcceptHeader.verified.text
@@ -2,6 +2,4 @@
 # HELP target_info Target metadata
 target_info{service_name="my_service",service_instance_id="id1"} 1
 # TYPE counter_double_bytes_total counter
-# UNIT counter_double_bytes_total bytes
 counter_double_bytes_total{otel_scope_name="PrometheusHttpListenerTests",otel_scope_version="1.0.1",key1="value1",key2="value2"} 101.17
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunHttpServerWithNoAcceptHeaderAndMeterTags.verified.text
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunHttpServerWithNoAcceptHeaderAndMeterTags.verified.text
@@ -2,6 +2,4 @@
 # HELP target_info Target metadata
 target_info{service_name="my_service",service_instance_id="id1"} 1
 # TYPE counter_double_bytes_total counter
-# UNIT counter_double_bytes_total bytes
 counter_double_bytes_total{otel_scope_name="PrometheusHttpListenerTests",otel_scope_version="1.0.1",otel_scope_meter1="value1",otel_scope_meter2="value2",key1="value1",key2="value2"} 101.17
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithTextPlainResponse.verified.text
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithTextPlainResponse.verified.text
@@ -2,6 +2,4 @@
 # HELP target_info Target metadata
 target_info{service_name="my_service",service_instance_id="id1"} 1
 # TYPE counter_double_bytes_total counter
-# UNIT counter_double_bytes_total bytes
 counter_double_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1",key1="value1",key2="value2"} 101.17
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithTextPlainResponseAndMeterTags.verified.text
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithTextPlainResponseAndMeterTags.verified.text
@@ -2,6 +2,4 @@
 # HELP target_info Target metadata
 target_info{service_name="my_service",service_instance_id="id1"} 1
 # TYPE counter_double_bytes_total counter
-# UNIT counter_double_bytes_total bytes
 counter_double_bytes_total{otel_scope_name="PrometheusExporterMiddlewareTests",otel_scope_version="1.0.1",otel_scope_meterKey1="value1",otel_scope_meterKey2="value2",key1="value1",key2="value2"} 101.17
-# EOF

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=allow-utf-8_useOpenMetrics=False.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=allow-utf-8_useOpenMetrics=False.verified.txt
@@ -1,5 +1,4 @@
 # TYPE "http.花火.🚀.requests_seconds" histogram
-# UNIT "http.花火.🚀.requests_seconds" seconds
 # HELP "http.花火.🚀.requests_seconds" Duration of HTTP server requests.
 {"http.花火.🚀.requests_seconds_bucket",otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView","http.method"="GET",le="5"} 1
 {"http.花火.🚀.requests_seconds_bucket",otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView","http.method"="GET",le="10"} 2

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=dots_useOpenMetrics=False.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=dots_useOpenMetrics=False.verified.txt
@@ -1,5 +1,4 @@
 # TYPE http_dot____dot___dot_requests__seconds histogram
-# UNIT http_dot____dot___dot_requests__seconds seconds
 # HELP http_dot____dot___dot_requests__seconds Duration of HTTP server requests.
 http_dot____dot___dot_requests__seconds_bucket{otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView",http_dot_method="GET",le="5"} 1
 http_dot____dot___dot_requests__seconds_bucket{otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView",http_dot_method="GET",le="10"} 2

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=underscores_useOpenMetrics=False.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=underscores_useOpenMetrics=False.verified.txt
@@ -1,5 +1,4 @@
 # TYPE http_requests_seconds histogram
-# UNIT http_requests_seconds seconds
 # HELP http_requests_seconds Duration of HTTP server requests.
 http_requests_seconds_bucket{otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView",http_method="GET",le="5"} 1
 http_requests_seconds_bucket{otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView",http_method="GET",le="10"} 2

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=values_useOpenMetrics=False.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView_escaping=values_useOpenMetrics=False.verified.txt
@@ -1,5 +1,4 @@
 # TYPE U__http_2e__82b1__706b__2e__1f680__2e_requests__seconds histogram
-# UNIT U__http_2e__82b1__706b__2e__1f680__2e_requests__seconds seconds
 # HELP U__http_2e__82b1__706b__2e__1f680__2e_requests__seconds Duration of HTTP server requests.
 U__http_2e__82b1__706b__2e__1f680__2e_requests__seconds_bucket{otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView",U__http_2e_method="GET",le="5"} 1
 U__http_2e__82b1__706b__2e__1f680__2e_requests__seconds_bucket{otel_scope_name="WriteMetric_SerializesMultibyteUtf8MetricNameProvidedByView",U__http_2e_method="GET",le="10"} 2


### PR DESCRIPTION
## Changes

Fix some minor findings from checking the Prometheus exporters against the specifications with Claude and Copilot:

- Do not emit redundant comments for PrometheusText format.
- Make `Accept` header parsing consistent between AspNetCore and HttpListener implementations.
- Fix incorrect fallback version for OpenMetrics.
- Fix incorrect quotation mark escaping for `HELP` metadata.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
