### PR TITLE
[Exporter.Prometheus] Extend UTF test coverage

### DIFF
--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.FuzzTests/PrometheusSerializerFuzzTests.cs
@@ -67,6 +67,23 @@ public class PrometheusSerializerFuzzTests
             SerializeEscapeName(value, EscapingScheme.Values).SequenceEqual(Encoding.ASCII.GetBytes(PrometheusEscaping.EscapeName(value, EscapingScheme.Values))));
 
     [Property(MaxTest = MaxTests)]
+    public Property EscapeNameWithMalformedUtf16DotsMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.SurrogateHeavyStringArbitrary(),
+        static (value) => PrometheusEscaping.EscapeName(value, EscapingScheme.Dots) == ReferenceEscapeName(value, EscapingScheme.Dots));
+
+    [Property(MaxTest = MaxTests)]
+    public Property EscapeNameWithMalformedUtf16ValuesMatchesReferenceImplementation() => Prop.ForAll(
+        Generators.SurrogateHeavyStringArbitrary(),
+        static (value) => PrometheusEscaping.EscapeName(value, EscapingScheme.Values) == ReferenceEscapeName(value, EscapingScheme.Values));
+
+    [Property(MaxTest = MaxTests)]
+    public Property EscapeNameToBufferWithMalformedUtf16DoesNotOverrunProductionBuffer() => Prop.ForAll(
+        Generators.SurrogateHeavyStringArbitrary(),
+        static (value) =>
+            EscapeIntoProductionSizedBuffer(value, EscapingScheme.Dots) &&
+            EscapeIntoProductionSizedBuffer(value, EscapingScheme.Values));
+
+    [Property(MaxTest = MaxTests)]
     public Property IsValidLegacyNameMatchesReferenceImplementation() => Prop.ForAll(
         Generators.PrometheusStringArbitrary(),
         static (value) => PrometheusEscaping.IsValidLegacyName(value) == ReferenceIsValidLegacyName(value));
@@ -100,6 +117,19 @@ public class PrometheusSerializerFuzzTests
         var buffer = new byte[(value.Length * 8) + 16];
         var cursor = PrometheusEscaping.EscapeName(buffer, 0, value, scheme);
         return buffer.AsSpan(0, cursor).ToArray();
+    }
+
+    private static bool EscapeIntoProductionSizedBuffer(string value, EscapingScheme scheme)
+    {
+        // The buffer is sized exactly for an upper bound of six bytes per character,
+        // plus the three-byte "U__" values prefix. A non-advancing decoder would write
+        // past the end and throw IndexOutOfRangeException.
+        const int MaxBytesPerCharacter = 6;
+
+        var buffer = new byte[(scheme == EscapingScheme.Values ? 3 : 0) + (value.Length * MaxBytesPerCharacter)];
+        var cursor = PrometheusEscaping.EscapeName(buffer, 0, value, scheme);
+
+        return cursor >= 0 && cursor <= buffer.Length;
     }
 
     private static byte[] SerializeLong(long value)
@@ -362,6 +392,21 @@ public class PrometheusSerializerFuzzTests
         {
             var charGen = Gen.Choose(0, 0xFFFF).Select(static c => (char)c);
             return CreateString(charGen, maxLength: 128).ToArbitrary();
+        }
+
+        public static Arbitrary<string> SurrogateHeavyStringArbitrary()
+        {
+            var surrogate = Gen.Choose(0xD800, 0xDFFF).Select(static c => (char)c);
+            var ascii = Gen.Choose(0, 0x7F).Select(static c => (char)c);
+            var anyBmp = Gen.Choose(0, 0xFFFF).Select(static c => (char)c);
+
+            // Including the surrogate generator twice weights code units in the 0xD800-0xDFFF range
+            // heavily, so lone and reversed (low-then-high) surrogates are common in the generated body.
+            var charGen = Gen.OneOf(surrogate, surrogate, ascii, anyBmp);
+            var body = CreateString(charGen, maxLength: 128);
+
+            // Frequently append a trailing lone high surrogate
+            return Gen.OneOf(body, body.Select(static value => value + "\uD800")).ToArbitrary();
         }
 
         public static Arbitrary<double> DoubleArbitrary()

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusEscapingTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusEscapingTests.cs
@@ -155,4 +155,30 @@ public static class PrometheusEscapingTests
     [InlineData("values", EscapingScheme.Values)]
     internal static void FromString_MapsEscapingScheme(string? escaping, EscapingScheme expected)
         => Assert.Equal(expected, PrometheusEscaping.FromString(escaping));
+
+    // The malformed inputs are built in code rather than passed via [InlineData]
+    // because xUnit's theory-data serialization does not round-trip lone surrogates
+    // (they are replaced with the U+FFFD replacement character).
+
+    [Fact]
+    internal static void EscapeName_Dots_EncodesUnpairedSurrogatesWithoutOverrun()
+    {
+        Assert.Equal("_", PrometheusEscaping.EscapeName("\uD800", EscapingScheme.Dots));
+        Assert.Equal("abc_", PrometheusEscaping.EscapeName("abc\uD800", EscapingScheme.Dots));
+        Assert.Equal("abc_", PrometheusEscaping.EscapeName("abc\uDC00", EscapingScheme.Dots));
+        Assert.Equal("_abc", PrometheusEscaping.EscapeName("\uD800abc", EscapingScheme.Dots));
+        Assert.Equal("___", PrometheusEscaping.EscapeName("\uD800\uD800\uD800", EscapingScheme.Dots));
+    }
+
+    [Fact]
+    internal static void EscapeName_Values_EncodesUnpairedSurrogatesWithoutOverrun()
+    {
+        Assert.Equal("U___FFFD_", PrometheusEscaping.EscapeName("\uD800", EscapingScheme.Values));
+        Assert.Equal("U__abc_FFFD_", PrometheusEscaping.EscapeName("abc\uD800", EscapingScheme.Values));
+        Assert.Equal("U__abc_FFFD_", PrometheusEscaping.EscapeName("abc\uDC00", EscapingScheme.Values));
+        Assert.Equal("U___FFFD_abc", PrometheusEscaping.EscapeName("\uD800abc", EscapingScheme.Values));
+
+        // A valid astral pair (U+10000) followed by a trailing lone high surrogate.
+        Assert.Equal("U___10000__FFFD_", PrometheusEscaping.EscapeName("\U00010000\uD800", EscapingScheme.Values));
+    }
 }


### PR DESCRIPTION
## Changes

Extend unit and fuzz testing coverage for malformed UTF-16 strings containing surrogate characters.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
