### PR TITLE
[Exporter.Prometheus] Support translation strategy configuration

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -16,6 +16,13 @@ OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.ScrapeResponseCacheDurationMi
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.ScrapeResponseCacheDurationMilliseconds.set -> void
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.TargetInfoEnabled.get -> bool
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.TargetInfoEnabled.set -> void
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.TranslationStrategy.get -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.TranslationStrategy.set -> void
+OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.NoTranslation = 3 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.NoUTF8EscapingWithSuffixes = 2 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes = 0 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.UnderscoreEscapingWithoutSuffixes = 1 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
 OpenTelemetry.Metrics.PrometheusExporterMeterProviderBuilderExtensions
 static Microsoft.AspNetCore.Builder.PrometheusExporterApplicationBuilderExtensions.UseOpenTelemetryPrometheusScrapingEndpoint(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Microsoft.AspNetCore.Builder.PrometheusExporterApplicationBuilderExtensions.UseOpenTelemetryPrometheusScrapingEndpoint(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, OpenTelemetry.Metrics.MeterProvider? meterProvider, System.Func<Microsoft.AspNetCore.Http.HttpContext!, bool>? predicate, string? path, System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder!>? configureBranchedPipeline, string? optionsName) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -66,7 +66,7 @@ Notes](../../RELEASENOTES.md).
 
 * Added `PrometheusAspNetCoreOptions.TranslationStrategy` to control how
   OpenTelemetry metric and label names are translated into Prometheus names.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7507))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -64,6 +64,10 @@ Notes](../../RELEASENOTES.md).
   specify a `version` parameter.
   ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
+* Added `PrometheusAspNetCoreOptions.TranslationStrategy` to control how
+  OpenTelemetry metric and label names are translated into Prometheus names.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
@@ -85,5 +85,15 @@ public class PrometheusAspNetCoreOptions
         set => this.ExporterOptions.MaxScrapeResponseSizeBytes = value;
     }
 
+    /// <summary>
+    /// Gets or sets the strategy used to translate OpenTelemetry metric and label names into
+    /// Prometheus names. Default value: <see cref="PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes"/>.
+    /// </summary>
+    public PrometheusTranslationStrategy TranslationStrategy
+    {
+        get => this.ExporterOptions.TranslationStrategy;
+        set => this.ExporterOptions.TranslationStrategy = value;
+    }
+
     internal PrometheusExporterOptions ExporterOptions { get; } = new();
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -77,7 +77,7 @@ internal sealed class PrometheusExporterMiddleware
 
             var requestHeaders = httpContext.Request.GetTypedHeaders();
 
-            var protocol = Negotiate(requestHeaders);
+            var protocol = Negotiate(requestHeaders, this.exporter.DefaultEscapingScheme);
 
             var collectionResponse = await this.exporter.CollectionManager.EnterCollect(protocol);
 
@@ -156,7 +156,7 @@ internal sealed class PrometheusExporterMiddleware
         }
     }
 
-    internal static PrometheusProtocol Negotiate(RequestHeaders headers)
+    internal static PrometheusProtocol Negotiate(RequestHeaders headers, EscapingScheme defaultEscaping = EscapingScheme.Underscores)
     {
         var acceptHeader = headers.Accept;
 
@@ -173,7 +173,7 @@ internal sealed class PrometheusExporterMiddleware
 
         foreach (var mediaType in acceptHeader)
         {
-            if (TryParse(mediaType, out var protocol, out var quality) &&
+            if (TryParse(mediaType, defaultEscaping, out var protocol, out var quality) &&
                 (preferred is null || quality > preferredQuality))
             {
                 preferred = protocol;
@@ -186,6 +186,7 @@ internal sealed class PrometheusExporterMiddleware
 
     private static bool TryParse(
         MediaTypeHeaderValue value,
+        EscapingScheme defaultEscaping,
         [NotNullWhen(true)] out PrometheusProtocol? protocol,
         out double quality)
     {
@@ -285,7 +286,10 @@ internal sealed class PrometheusExporterMiddleware
         }
         else
         {
-            escaping ??= PrometheusProtocol.UnderscoresEscaping;
+            // When the client does not negotiate an escaping scheme, fall back to the exporter's
+            // configured default (from its translation strategy) rather than always underscores.
+            // Any client-specified escaping value takes precedence.
+            escaping ??= PrometheusEscaping.GetName(defaultEscaping);
         }
 
         protocol = new(mediaType, escaping, version, isOpenMetrics);

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -268,15 +268,12 @@ internal sealed class PrometheusExporterMiddleware
             }
         }
 
-        if (version is null)
-        {
-            // Use the oldest version if no version preference was specified. Per the OpenMetrics
-            // specification's negotiation rules (https://prometheus.io/docs/specs/om/open_metrics_spec/#protocol-negotiation),
-            // "the standard" begins at 1.0.0 (0.0.1 predates the standard being ratified), so servers
-            // MUST default to OpenMetrics 1.0.0 for an unversioned "application/openmetrics-text" entry.
-            // The Prometheus text media type is unaffected by that rule and still falls back to 0.0.4.
-            version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV0;
-        }
+        // Use the oldest version if no version preference was specified. Per the OpenMetrics
+        // specification's negotiation rules (https://prometheus.io/docs/specs/om/open_metrics_spec/#protocol-negotiation),
+        // "the standard" begins at 1.0.0 (0.0.1 predates the standard being ratified), so servers
+        // MUST default to OpenMetrics 1.0.0 for an unversioned "application/openmetrics-text" entry.
+        // The Prometheus text media type is unaffected by that rule and still falls back to 0.0.4.
+        version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV0;
 
         if (version.Major is not > 0)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -273,7 +273,7 @@ internal sealed class PrometheusExporterMiddleware
         // "the standard" begins at 1.0.0 (0.0.1 predates the standard being ratified), so servers
         // MUST default to OpenMetrics 1.0.0 for an unversioned "application/openmetrics-text" entry.
         // The Prometheus text media type is unaffected by that rule and still falls back to 0.0.4.
-        version = isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV0;
+        version ??= isOpenMetrics ? PrometheusProtocol.OpenMetricsV1 : PrometheusProtocol.PrometheusV0;
 
         if (version.Major is not > 0)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md
@@ -168,6 +168,28 @@ services.AddOpenTelemetry()
         }));
 ```
 
+### TranslationStrategy
+
+Controls how OpenTelemetry metric and label names are translated into Prometheus
+names, following the OpenTelemetry specification's `translation_strategy` option.
+The strategy combines two independent choices: whether discouraged characters are
+escaped to `_` or UTF-8 names are passed through unaltered, and whether unit and
+type (e.g. `_total`) suffixes are appended.
+
+| Strategy | Escaping | Suffixes |
+| -------- | -------- | -------- |
+| `UnderscoreEscapingWithSuffixes` (default) | Escape to `_` | Appended |
+| `UnderscoreEscapingWithoutSuffixes` | Escape to `_` | Not appended |
+| `NoUTF8EscapingWithSuffixes` | UTF-8 passthrough | Appended |
+| `NoTranslation` | UTF-8 passthrough | Not appended |
+
+The escaping choice only sets the default escaping scheme. A scrape request that
+negotiates an escaping scheme (via the `escaping` parameter of the `Accept` header,
+supported by the version 1.0.0 and later text formats) always takes precedence over
+the configured strategy. The classic (pre-1.0.0) text formats do not support
+escaping negotiation and are always emitted using underscore escaping; the suffix
+choice applies to every format.
+
 ## Troubleshooting
 
 This component uses an

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
@@ -20,6 +20,13 @@ OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeResponseCacheDuration
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.ScrapeResponseCacheDurationMilliseconds.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TargetInfoEnabled.get -> bool
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TargetInfoEnabled.set -> void
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TranslationStrategy.get -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.TranslationStrategy.set -> void
+OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.NoTranslation = 3 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.NoUTF8EscapingWithSuffixes = 2 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes = 0 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
+OpenTelemetry.Exporter.PrometheusTranslationStrategy.UnderscoreEscapingWithoutSuffixes = 1 -> OpenTelemetry.Exporter.PrometheusTranslationStrategy
 OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions
 static OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions.AddPrometheusHttpListener(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Metrics.PrometheusHttpListenerMeterProviderBuilderExtensions.AddPrometheusHttpListener(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, string? name, System.Action<OpenTelemetry.Exporter.PrometheusHttpListenerOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -66,6 +66,10 @@ Notes](../../RELEASENOTES.md).
   specify a `version` parameter.
   ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
+* Added `PrometheusAspNetCoreOptions.TranslationStrategy` to control how
+  OpenTelemetry metric and label names are translated into Prometheus names.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -66,7 +66,7 @@ Notes](../../RELEASENOTES.md).
   specify a `version` parameter.
   ([#7491](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7491))
 
-* Added `PrometheusAspNetCoreOptions.TranslationStrategy` to control how
+* Added `PrometheusHttpListenerOptions.TranslationStrategy` to control how
   OpenTelemetry metric and label names are translated into Prometheus names.
   ([#7507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7507))
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -68,7 +68,7 @@ Notes](../../RELEASENOTES.md).
 
 * Added `PrometheusAspNetCoreOptions.TranslationStrategy` to control how
   OpenTelemetry metric and label names are translated into Prometheus names.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7507))
 
 ## 1.16.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusHeadersParser.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusHeadersParser.cs
@@ -13,7 +13,7 @@ namespace OpenTelemetry.Exporter.Prometheus;
 
 internal static class PrometheusHeadersParser
 {
-    internal static PrometheusProtocol Negotiate(string? contentType)
+    internal static PrometheusProtocol Negotiate(string? contentType, EscapingScheme defaultEscaping = EscapingScheme.Underscores)
     {
         if (string.IsNullOrWhiteSpace(contentType))
         {
@@ -124,7 +124,10 @@ internal static class PrometheusHeadersParser
             }
             else
             {
-                escaping ??= PrometheusProtocol.UnderscoresEscaping;
+                // When the client does not negotiate an escaping scheme, fall back to the
+                // exporter's configured default (from its translation strategy) rather than
+                // always underscores. Any client-specified escaping value takes precedence.
+                escaping ??= PrometheusEscaping.GetName(defaultEscaping);
             }
 
             var protocol = new PrometheusProtocol(

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusEscaping.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusEscaping.cs
@@ -31,6 +31,14 @@ internal static class PrometheusEscaping
         _ => EscapingScheme.Underscores,
     };
 
+    public static string GetName(EscapingScheme escaping) => escaping switch
+    {
+        EscapingScheme.AllowUtf8 => PrometheusProtocol.AllowUtf8Escaping,
+        EscapingScheme.Dots => PrometheusProtocol.DotsEscaping,
+        EscapingScheme.Values => PrometheusProtocol.ValuesEscaping,
+        EscapingScheme.Underscores or _ => PrometheusProtocol.UnderscoresEscaping,
+    };
+
     /// <summary>
     /// Escapes a fully-constructed metric or label name (including any unit and type-specific
     /// suffixes) according to the supplied scheme. The name MUST be escaped as a single unit

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporter.cs
@@ -59,6 +59,8 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
 
     internal bool AppendSuffixes => this.TranslationStrategy.AppendSuffixes();
 
+    internal EscapingScheme DefaultEscapingScheme => this.TranslationStrategy.GetDefaultEscapingScheme();
+
     internal Func<string, bool>? ResourceConstantLabels { get; }
 
     internal int MaxScrapeResponseSizeBytes { get; }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusTranslationStrategy.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusTranslationStrategy.cs
@@ -1,15 +1,17 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-namespace OpenTelemetry.Exporter.Prometheus;
+namespace OpenTelemetry.Exporter;
 
 /// <summary>
 /// Controls how OpenTelemetry metric and label names are translated into Prometheus names.
 /// </summary>
 /// <remarks>
-/// This enum models the OpenTelemetry specification's <c>translation_strategy</c> option.
+/// This models the OpenTelemetry specification's <c>translation_strategy</c> option as a 2×2 matrix
+/// over an escaping axis (escape discouraged characters to <c>_</c> versus pass UTF-8 through
+/// unaltered) and a suffix axis (append unit and type suffixes versus not).
 /// </remarks>
-internal enum PrometheusTranslationStrategy
+public enum PrometheusTranslationStrategy
 {
     /// <summary>
     /// Discouraged characters are escaped to <c>_</c> and unit and type (e.g. <c>_total</c>)
@@ -20,15 +22,15 @@ internal enum PrometheusTranslationStrategy
     /// <summary>
     /// Discouraged characters are escaped to <c>_</c> but no unit or type suffixes are appended.
     /// </summary>
-    UnderscoreEscapingWithoutSuffixes,
+    UnderscoreEscapingWithoutSuffixes = 1,
 
     /// <summary>
     /// Names are not escaped (UTF-8 is passed through) and unit and type suffixes are appended.
     /// </summary>
-    NoUTF8EscapingWithSuffixes,
+    NoUTF8EscapingWithSuffixes = 2,
 
     /// <summary>
     /// Names are passed through completely unaltered: names are not escaped and no suffixes are appended.
     /// </summary>
-    NoTranslation,
+    NoTranslation = 3,
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusTranslationStrategy.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusTranslationStrategy.cs
@@ -7,7 +7,7 @@ namespace OpenTelemetry.Exporter;
 /// Controls how OpenTelemetry metric and label names are translated into Prometheus names.
 /// </summary>
 /// <remarks>
-/// This models the OpenTelemetry specification's <c>translation_strategy</c> option as a 2×2 matrix
+/// This models the OpenTelemetry specification's <c>translation_strategy</c> option as a 2x2 matrix
 /// over an escaping axis (escape discouraged characters to <c>_</c> versus pass UTF-8 through
 /// unaltered) and a suffix axis (append unit and type suffixes versus not).
 /// </remarks>

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -126,10 +126,10 @@ internal sealed class PrometheusHttpListener : IDisposable
         }
     }
 
-    private static PrometheusProtocol Negotiate(HttpListenerRequest request)
+    private static PrometheusProtocol Negotiate(HttpListenerRequest request, EscapingScheme defaultEscaping)
     {
         var acceptHeader = request.Headers["Accept"];
-        return PrometheusHeadersParser.Negotiate(acceptHeader);
+        return PrometheusHeadersParser.Negotiate(acceptHeader, defaultEscaping);
     }
 
     /// <summary>
@@ -252,7 +252,7 @@ internal sealed class PrometheusHttpListener : IDisposable
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(requestCancelled.Token, cancellationToken);
 
-            var protocol = Negotiate(context.Request);
+            var protocol = Negotiate(context.Request, this.exporter.DefaultEscapingScheme);
 
             var collectionResponse = await this.exporter.CollectionManager.EnterCollect(protocol).ConfigureAwait(false);
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
@@ -73,6 +73,7 @@ public static class PrometheusHttpListenerMeterProviderBuilderExtensions
             DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters,
             ResourceConstantLabels = options.ResourceConstantLabels,
             MaxScrapeResponseSizeBytes = options.MaxScrapeResponseSizeBytes,
+            TranslationStrategy = options.TranslationStrategy,
         });
 
         var reader = new BaseExportingMetricReader(exporter)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -73,6 +73,12 @@ public class PrometheusHttpListenerOptions
     public bool DisableTotalNameSuffixForCounters { get; set; }
 
     /// <summary>
+    /// Gets or sets the strategy used to translate OpenTelemetry metric and label names into
+    /// Prometheus names. Default value: <see cref="PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes"/>.
+    /// </summary>
+    public PrometheusTranslationStrategy TranslationStrategy { get; set; } = PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes;
+
+    /// <summary>
     /// Gets or sets a value indicating whether the scope information (name, version, schema URL) is added to the scrape response.
     /// Default value: <see langword="true"/>.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md
@@ -68,6 +68,9 @@ variables.
   added to each metric as constant labels (default `null`).
 * `DisableTotalNameSuffixForCounters`: Whether to disable the `_total` suffix for
   counter metrics (default `false`).
+* `TranslationStrategy`: Controls how OpenTelemetry metric and label names are
+  translated into Prometheus names (default `UnderscoreEscapingWithSuffixes`).
+  See [TranslationStrategy](#translationstrategy) below.
 * `DisableTimestamp`: Whether to disable the timestamp for metrics (default `false`).
 * `ConfigureHttpListener`: A delegate that can be used to apply custom configuration
   to the `HttpListener` instance used by the exporter before use.
@@ -139,6 +142,28 @@ var meterProvider = Sdk.CreateMeterProviderBuilder()
     })
     .Build();
 ```
+
+### TranslationStrategy
+
+Controls how OpenTelemetry metric and label names are translated into Prometheus
+names, following the OpenTelemetry specification's `translation_strategy` option.
+The strategy combines two independent choices: whether discouraged characters are
+escaped to `_` or UTF-8 names are passed through unaltered, and whether unit and
+type (e.g. `_total`) suffixes are appended.
+
+| Strategy | Escaping | Suffixes |
+| -------- | -------- | -------- |
+| `UnderscoreEscapingWithSuffixes` (default) | Escape to `_` | Appended |
+| `UnderscoreEscapingWithoutSuffixes` | Escape to `_` | Not appended |
+| `NoUTF8EscapingWithSuffixes` | UTF-8 passthrough | Appended |
+| `NoTranslation` | UTF-8 passthrough | Not appended |
+
+The escaping choice only sets the default escaping scheme. A scrape request that
+negotiates an escaping scheme (via the `escaping` parameter of the `Accept` header,
+supported by the version 1.0.0 and later text formats) always takes precedence over
+the configured strategy. The classic (pre-1.0.0) text formats do not support
+escaping negotiation and are always emitted using underscore escaping; the suffix
+choice applies to every format.
 
 ## Troubleshooting
 

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
@@ -28,4 +28,19 @@ public sealed class PrometheusExporterMeterProviderBuilderExtensionsTests
         Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
         Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
     }
+
+    [Fact]
+    public void TranslationStrategy_DefaultsToUnderscoreEscapingWithSuffixes()
+        => Assert.Equal(PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes, new PrometheusAspNetCoreOptions().TranslationStrategy);
+
+    [Fact]
+    public void TranslationStrategy_DelegatesToExporterOptions()
+    {
+        var options = new PrometheusAspNetCoreOptions
+        {
+            TranslationStrategy = PrometheusTranslationStrategy.NoTranslation,
+        };
+
+        Assert.Equal(PrometheusTranslationStrategy.NoTranslation, options.ExporterOptions.TranslationStrategy);
+    }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -367,6 +367,41 @@ public sealed class PrometheusExporterMiddlewareTests
         Assert.Equivalent(PrometheusProtocol.Fallback, actual);
     }
 
+    [Theory]
+    [InlineData("text/plain; version=1.0.0")]
+    [InlineData("application/openmetrics-text; version=1.0.0")]
+    public void Negotiate_UsesDefaultEscaping_ForV1_WhenClientDoesNotNegotiateOne(string accept)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Accept = accept;
+
+        var actual = PrometheusExporterMiddleware.Negotiate(context.Request.GetTypedHeaders(), EscapingScheme.AllowUtf8);
+
+        Assert.Equal(PrometheusProtocol.AllowUtf8Escaping, actual.Escaping);
+    }
+
+    [Fact]
+    public void Negotiate_ClientEscaping_TakesPrecedence_OverDefault()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Accept = "text/plain; version=1.0.0; escaping=underscores";
+
+        var actual = PrometheusExporterMiddleware.Negotiate(context.Request.GetTypedHeaders(), EscapingScheme.AllowUtf8);
+
+        Assert.Equal(PrometheusProtocol.UnderscoresEscaping, actual.Escaping);
+    }
+
+    [Fact]
+    public void Negotiate_DefaultEscaping_IsIgnored_ForV0()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Accept = "text/plain; version=0.0.4";
+
+        var actual = PrometheusExporterMiddleware.Negotiate(context.Request.GetTypedHeaders(), EscapingScheme.AllowUtf8);
+
+        Assert.Null(actual.Escaping);
+    }
+
     [Fact]
     public async Task RunWithTextPlainResponseAndMeterTags()
     {
@@ -418,6 +453,106 @@ public sealed class PrometheusExporterMiddlewareTests
         };
 
         await RunPrometheusExporterMiddlewareIntegrationTestWithMultipleContentTypes(meterTags);
+    }
+
+    [Fact]
+    public async Task RunWithNoTranslationStrategy()
+    {
+        using var host = await StartTestHostAsync(
+            app => app.UseOpenTelemetryPrometheusScrapingEndpoint(),
+            configureOptions: o =>
+            {
+                o.TranslationStrategy = PrometheusTranslationStrategy.NoTranslation;
+
+                // Disabled to keep the snapshot focused on name translation.
+                o.ScopeInfoEnabled = false;
+                o.TargetInfoEnabled = false;
+            });
+
+        using var meter = new Meter(MeterName, MeterVersion);
+
+        // A dotted (non-legacy) metric name, a dotted label key and a unit together exercise
+        // both axes: with NoTranslation the names pass through as UTF-8 (written in the quoted
+        // exposition format) and no unit or '_total' suffixes are appended.
+        meter.CreateCounter<long>("http.server.requests", unit: "By")
+            .Add(5, new KeyValuePair<string, object?>("http.host", "localhost"));
+
+        host.Services.GetRequiredService<MeterProvider>().ForceFlush();
+
+        using var client = host.GetTestClient();
+
+        // version=1.0.0 with no escaping negotiated, so the strategy's default (UTF-8 passthrough)
+        // escaping applies.
+        client.DefaultRequestHeaders.Add("Accept", "text/plain; version=1.0.0");
+
+        using var response = await client.GetAsync(new Uri("/metrics", UriKind.Relative));
+        var output = (await response.Content.ReadAsStringAsync()).ReplaceLineEndings();
+
+        await host.StopAsync();
+
+        Assert.Equal(
+            "text/plain; version=1.0.0; charset=utf-8; escaping=allow-utf-8",
+            response.Content.Headers.ContentType!.ToString());
+
+        await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
+    }
+
+    [Fact]
+    public async Task RunWithUnderscoreEscapingWithoutSuffixesStrategy_OmitsUnitAndTotalSuffixes()
+    {
+        using var host = await StartTestHostAsync(
+            app => app.UseOpenTelemetryPrometheusScrapingEndpoint(),
+            configureOptions: o =>
+            {
+                o.TranslationStrategy = PrometheusTranslationStrategy.UnderscoreEscapingWithoutSuffixes;
+                o.ScopeInfoEnabled = false;
+                o.TargetInfoEnabled = false;
+            });
+
+        using var meter = new Meter(MeterName, MeterVersion);
+        meter.CreateCounter<long>("http.server.requests", unit: "By")
+            .Add(5, new KeyValuePair<string, object?>("host", "localhost"));
+
+        host.Services.GetRequiredService<MeterProvider>().ForceFlush();
+
+        using var client = host.GetTestClient();
+        using var response = await client.GetAsync(new Uri("/metrics", UriKind.Relative));
+        var output = await response.Content.ReadAsStringAsync();
+
+        await host.StopAsync();
+
+        await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
+    }
+
+    [Fact]
+    public async Task RunWithNoUtf8EscapingWithSuffixesStrategy_KeepsUtf8NameWithSuffixes()
+    {
+        using var host = await StartTestHostAsync(
+            app => app.UseOpenTelemetryPrometheusScrapingEndpoint(),
+            configureOptions: o =>
+            {
+                o.TranslationStrategy = PrometheusTranslationStrategy.NoUTF8EscapingWithSuffixes;
+                o.ScopeInfoEnabled = false;
+                o.TargetInfoEnabled = false;
+            });
+
+        using var meter = new Meter(MeterName, MeterVersion);
+        meter.CreateCounter<long>("http.server.requests", unit: "By").Add(5);
+
+        host.Services.GetRequiredService<MeterProvider>().ForceFlush();
+
+        using var client = host.GetTestClient();
+
+        // version=1.0.0 with no escaping negotiated, so the strategy's default (UTF-8 passthrough)
+        // escaping applies.
+        client.DefaultRequestHeaders.Add("Accept", "text/plain; version=1.0.0");
+
+        using var response = await client.GetAsync(new Uri("/metrics", UriKind.Relative));
+        var output = await response.Content.ReadAsStringAsync();
+
+        await host.StopAsync();
+
+        await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -556,6 +556,84 @@ public sealed class PrometheusExporterMiddlewareTests
     }
 
     [Fact]
+    public async Task RunWithNoTranslationStrategyAndNegotiatedUnderscoreEscaping()
+    {
+        using var host = await StartTestHostAsync(
+            app => app.UseOpenTelemetryPrometheusScrapingEndpoint(),
+            configureOptions: o =>
+            {
+                o.TranslationStrategy = PrometheusTranslationStrategy.NoTranslation;
+                o.ScopeInfoEnabled = false;
+                o.TargetInfoEnabled = false;
+            });
+
+        using var meter = new Meter(MeterName, MeterVersion);
+        meter.CreateCounter<long>("http.server.requests", unit: "By")
+            .Add(5, new KeyValuePair<string, object?>("http.host", "localhost"));
+
+        host.Services.GetRequiredService<MeterProvider>().ForceFlush();
+
+        using var client = host.GetTestClient();
+
+        // The exporter is configured with NoTranslation (UTF-8 passthrough), but the client
+        // negotiates escaping=underscores. Content negotiation must take precedence for the
+        // rendered escaping, so the metric and label names are underscore-escaped even though the
+        // configured strategy would otherwise pass them through as UTF-8. The suffix axis is not
+        // negotiated, so no unit or '_total' suffixes are added.
+        client.DefaultRequestHeaders.Add("Accept", "text/plain; version=1.0.0; escaping=underscores");
+
+        using var response = await client.GetAsync(new Uri("/metrics", UriKind.Relative));
+        var output = (await response.Content.ReadAsStringAsync()).ReplaceLineEndings();
+
+        await host.StopAsync();
+
+        Assert.Equal(
+            "text/plain; version=1.0.0; charset=utf-8; escaping=underscores",
+            response.Content.Headers.ContentType!.ToString());
+
+        await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
+    }
+
+    [Fact]
+    public async Task RunWithUnderscoreEscapingWithSuffixesStrategyAndNegotiatedAllowUtf8Escaping()
+    {
+        using var host = await StartTestHostAsync(
+            app => app.UseOpenTelemetryPrometheusScrapingEndpoint(),
+            configureOptions: o =>
+            {
+                o.TranslationStrategy = PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes;
+                o.ScopeInfoEnabled = false;
+                o.TargetInfoEnabled = false;
+            });
+
+        using var meter = new Meter(MeterName, MeterVersion);
+        meter.CreateCounter<long>("http.server.requests", unit: "By")
+            .Add(5, new KeyValuePair<string, object?>("http.host", "localhost"));
+
+        host.Services.GetRequiredService<MeterProvider>().ForceFlush();
+
+        using var client = host.GetTestClient();
+
+        // The exporter is configured with UnderscoreEscapingWithSuffixes, but the client negotiates
+        // escaping=allow-utf-8. Content negotiation must take precedence for the rendered escaping,
+        // so the names pass through as UTF-8 even though the configured strategy would otherwise
+        // underscore-escape them. The suffix axis is not negotiated, so the unit and '_total'
+        // suffixes (the configured translation) are retained.
+        client.DefaultRequestHeaders.Add("Accept", "text/plain; version=1.0.0; escaping=allow-utf-8");
+
+        using var response = await client.GetAsync(new Uri("/metrics", UriKind.Relative));
+        var output = (await response.Content.ReadAsStringAsync()).ReplaceLineEndings();
+
+        await host.StopAsync();
+
+        Assert.Equal(
+            "text/plain; version=1.0.0; charset=utf-8; escaping=allow-utf-8",
+            response.Content.Headers.ContentType!.ToString());
+
+        await Verify(output, "txt", PrometheusSerializerTests.VerifySettings);
+    }
+
+    [Fact]
     public async Task BufferSizeIncreasesWithLotOfMetrics()
     {
         using var host = await StartTestHostAsync(

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHeadersParserTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHeadersParserTests.cs
@@ -31,4 +31,38 @@ public class PrometheusHeadersParserTests
 
         Assert.Equal(PrometheusProtocol.Fallback, actual);
     }
+
+    [Theory]
+    [InlineData("text/plain; version=1.0.0")]
+    [InlineData("application/openmetrics-text; version=1.0.0")]
+    public void Negotiate_UsesDefaultEscaping_ForV1_WhenClientDoesNotNegotiateOne(string accept)
+    {
+        var actual = PrometheusHeadersParser.Negotiate(accept, EscapingScheme.AllowUtf8);
+
+        Assert.Equal(PrometheusProtocol.AllowUtf8Escaping, actual.Escaping);
+    }
+
+    [Fact]
+    public void Negotiate_ClientEscaping_TakesPrecedence_OverDefault()
+    {
+        var actual = PrometheusHeadersParser.Negotiate("text/plain; version=1.0.0; escaping=underscores", EscapingScheme.AllowUtf8);
+
+        Assert.Equal(PrometheusProtocol.UnderscoresEscaping, actual.Escaping);
+    }
+
+    [Fact]
+    public void Negotiate_DefaultEscaping_IsIgnored_ForV0()
+    {
+        var actual = PrometheusHeadersParser.Negotiate("text/plain; version=0.0.4", EscapingScheme.AllowUtf8);
+
+        Assert.Null(actual.Escaping);
+    }
+
+    [Fact]
+    public void Negotiate_DefaultEscaping_DoesNotAffectFallback_WhenNoAcceptHeader()
+    {
+        var actual = PrometheusHeadersParser.Negotiate(contentType: null, EscapingScheme.AllowUtf8);
+
+        Assert.Equal(PrometheusProtocol.Fallback, actual);
+    }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusTranslationStrategyTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusTranslationStrategyTests.cs
@@ -18,6 +18,10 @@ public sealed class PrometheusTranslationStrategyTests
         Assert.True(exporter.AppendSuffixes);
     }
 
+    [Fact]
+    public void HttpListenerOptions_DefaultTranslationStrategy_IsUnderscoreEscapingWithSuffixes()
+        => Assert.Equal(PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes, new PrometheusHttpListenerOptions().TranslationStrategy);
+
     [Theory]
     [InlineData(PrometheusTranslationStrategy.NoTranslation, EscapingScheme.AllowUtf8)]
     [InlineData(PrometheusTranslationStrategy.NoUTF8EscapingWithSuffixes, EscapingScheme.AllowUtf8)]
@@ -45,5 +49,17 @@ public sealed class PrometheusTranslationStrategyTests
 
         Assert.Equal(strategy, exporter.TranslationStrategy);
         Assert.Equal(expected, exporter.AppendSuffixes);
+    }
+
+    [Theory]
+    [InlineData(PrometheusTranslationStrategy.NoTranslation, EscapingScheme.AllowUtf8)]
+    [InlineData(PrometheusTranslationStrategy.NoUTF8EscapingWithSuffixes, EscapingScheme.AllowUtf8)]
+    [InlineData(PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes, EscapingScheme.Underscores)]
+    [InlineData(PrometheusTranslationStrategy.UnderscoreEscapingWithoutSuffixes, EscapingScheme.Underscores)]
+    internal void Exporter_DefaultEscapingScheme_ReflectsConfiguredStrategy(PrometheusTranslationStrategy strategy, EscapingScheme expected)
+    {
+        using var exporter = new PrometheusExporter(new() { TranslationStrategy = strategy });
+
+        Assert.Equal(expected, exporter.DefaultEscapingScheme);
     }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithNoTranslationStrategy.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithNoTranslationStrategy.verified.txt
@@ -1,0 +1,2 @@
+﻿# TYPE "http.server.requests" counter
+{"http.server.requests","http.host"="localhost"} 5

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithNoTranslationStrategyAndNegotiatedUnderscoreEscaping.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithNoTranslationStrategyAndNegotiatedUnderscoreEscaping.verified.txt
@@ -1,0 +1,2 @@
+﻿# TYPE http_server_requests counter
+http_server_requests{http_host="localhost"} 5

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithNoUtf8EscapingWithSuffixesStrategy_KeepsUtf8NameWithSuffixes.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithNoUtf8EscapingWithSuffixesStrategy_KeepsUtf8NameWithSuffixes.verified.txt
@@ -1,0 +1,2 @@
+﻿# TYPE "http.server.requests_bytes_total" counter
+{"http.server.requests_bytes_total"} 5

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithUnderscoreEscapingWithSuffixesStrategyAndNegotiatedAllowUtf8Escaping.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithUnderscoreEscapingWithSuffixesStrategyAndNegotiatedAllowUtf8Escaping.verified.txt
@@ -1,0 +1,2 @@
+﻿# TYPE "http.server.requests_bytes_total" counter
+{"http.server.requests_bytes_total","http.host"="localhost"} 5

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithUnderscoreEscapingWithoutSuffixesStrategy_OmitsUnitAndTotalSuffixes.verified.txt
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/snapshots/PrometheusSerializer.RunWithUnderscoreEscapingWithoutSuffixesStrategy_OmitsUnitAndTotalSuffixes.verified.txt
@@ -1,0 +1,2 @@
+﻿# TYPE http_server_requests counter
+http_server_requests{host="localhost"} 5


### PR DESCRIPTION
- Fixes #7156
- Fixes #7159

## Changes

Add support for configuring the OpenTelemetry to Prometheus metric name translation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
