### PR TITLE
[Infra] Add Blazor integration tests

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -30,6 +30,10 @@ on:
       trigger:
         required: true
         type: string
+      install-wasm-tools:
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   contents: read
@@ -80,6 +84,11 @@ jobs:
 
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+
+    - name: Install wasm-tools workload
+      if: ${{ inputs.install-wasm-tools }}
+      shell: pwsh
+      run: dotnet workload install wasm-tools
 
     - name: dotnet restore ${{ inputs.project-name }}
       shell: pwsh

--- a/.github/workflows/blazor-wasm-integration-test.yml
+++ b/.github/workflows/blazor-wasm-integration-test.yml
@@ -1,0 +1,63 @@
+name: Blazor WASM integration tests
+
+on:
+  workflow_call:
+    inputs:
+      trigger:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  run-blazor-wasm-integration-test:
+    name: Blazor WASM integration tests
+
+    strategy:
+      fail-fast: ${{ inputs.trigger == 'merge_group' }}
+      matrix:
+        os:
+          # renovate: datasource=github-runners depType=github-runner
+          - ubuntu-24.04
+          # renovate: datasource=github-runners depType=github-runner
+          - windows-2025
+        # Add further modern TFMs (e.g. net11.0) here as they are supported.
+        version: [ net10.0 ]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        filter: 'tree:0'
+        persist-credentials: false
+        show-progress: false
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+
+    - name: Install wasm-tools workload
+      shell: pwsh
+      run: dotnet workload install wasm-tools
+
+    - name: Run Blazor WASM end-to-end tests
+      shell: pwsh
+      run: >
+        dotnet test test/OpenTelemetry.BlazorWasm.Tests/OpenTelemetry.BlazorWasm.Tests.csproj
+        --configuration Release
+        --framework ${env:TARGET_FRAMEWORK}
+        --logger:"GitHubActions;report-warnings=false"
+      env:
+        TARGET_FRAMEWORK: ${{ matrix.version }}
+
+    - name: Upload Playwright artifacts
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: blazor-playwright-artifacts-${{ matrix.os }}-${{ matrix.version }}
+        path: '**/playwright/**'
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/workflows/blazor-wasm-integration-test.yml
+++ b/.github/workflows/blazor-wasm-integration-test.yml
@@ -22,7 +22,6 @@ jobs:
           - ubuntu-24.04
           # renovate: datasource=github-runners depType=github-runner
           - windows-2025
-        # Add further modern TFMs (e.g. net11.0) here as they are supported.
         version: [ net10.0 ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           sdk-package: ['src/OpenTelemetry/**', '!**/*.md']
           unstable-core-packages: ['src/OpenTelemetry.Exporter.Prometheus.AspNetCore/**', 'src/OpenTelemetry.Exporter.Prometheus.HttpListener/**', 'src/OpenTelemetry.Shims.OpenTracing/**', '!**/*.md']
           otlp: ['*/OpenTelemetry.Exporter.OpenTelemetryProtocol*/**', '!**/*.md']
+          blazor: ['test/OpenTelemetry.BlazorWasm.*/**', '.github/workflows/blazor-wasm-integration-test.yml']
 
   lint-actions:
     needs: detect-changes
@@ -116,6 +117,7 @@ jobs:
       project-name: 'OpenTelemetry.slnx'
       code-cov-name: 'Solution'
       trigger: ${{ github.event_name }}
+      install-wasm-tools: true
 
   build-test-project-stable:
     needs: detect-changes
@@ -184,6 +186,18 @@ jobs:
         run: docker compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml "--file=build/docker-compose.${FRAMEWORK_VERSION}.yml" --project-directory=. --profile build build build-image
       - name: Run OTLP Exporter docker compose
         run: docker compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml "--file=build/docker-compose.${FRAMEWORK_VERSION}.yml" --project-directory=. up --exit-code-from=tests --no-build
+
+  blazor-wasm-integration-test:
+    needs: detect-changes
+    if: |
+      contains(needs.detect-changes.outputs.changes, 'blazor')
+      || contains(needs.detect-changes.outputs.changes, 'sdk-package')
+      || contains(needs.detect-changes.outputs.changes, 'otlp')
+      || contains(needs.detect-changes.outputs.changes, 'build')
+      || contains(needs.detect-changes.outputs.changes, 'shared')
+    uses: ./.github/workflows/blazor-wasm-integration-test.yml
+    with:
+      trigger: ${{ github.event_name }}
 
   w3c-trace-context-integration-test:
     name: W3C Trace Context integration tests
@@ -299,6 +313,7 @@ jobs:
       build-test-project-stable,
       build-test-project-experimental,
       build-test-unstable-core,
+      blazor-wasm-integration-test,
       otlp-integration-test,
       w3c-trace-context-integration-test,
       validate-benchmarks,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -116,6 +116,7 @@
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.10.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" Condition="$(OS) != 'Windows_NT'" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
@@ -140,6 +141,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
   </ItemGroup>
 

--- a/OpenTelemetry.slnx
+++ b/OpenTelemetry.slnx
@@ -222,6 +222,8 @@
   <Project Path="test/OpenTelemetry.Api.FuzzTests/OpenTelemetry.Api.FuzzTests.csproj" />
   <Project Path="test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/OpenTelemetry.Api.ProviderBuilderExtensions.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Api.Tests/OpenTelemetry.Api.Tests.csproj" />
+  <Project Path="test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj" />
+  <Project Path="test/OpenTelemetry.BlazorWasm.Tests/OpenTelemetry.BlazorWasm.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.Console.Tests/OpenTelemetry.Exporter.Console.Tests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests.csproj" />
   <Project Path="test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj" />

--- a/build/OpenTelemetry.proj
+++ b/build/OpenTelemetry.proj
@@ -7,6 +7,15 @@
     <SolutionProjects Include="$(RepoRoot)\**\*.csproj" />
     <PackProjects Include="$(RepoRoot)\src\**\*.csproj" />
     <TestProjects Include="$(RepoRoot)\test\**\*.csproj" />
+
+    <!--
+      The Blazor WebAssembly test app and its end-to-end tests require the
+      wasm-tools workload (and a browser) and are covered by the dedicated
+      blazor-wasm-integration-test workflow, so exclude them from the general
+      build/test to avoid imposing that on every contributor and CI job.
+    -->
+    <SolutionProjects Remove="$(RepoRoot)\test\OpenTelemetry.BlazorWasm.*\**\*.csproj" />
+    <TestProjects Remove="$(RepoRoot)\test\OpenTelemetry.BlazorWasm.*\**\*.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == 'true'">

--- a/test/OpenTelemetry.BlazorWasm.TestApp/App.razor
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/App.razor
@@ -1,0 +1,4 @@
+@* Copyright The OpenTelemetry Authors *@
+@* SPDX-License-Identifier: Apache-2.0 *@
+
+<Home />

--- a/test/OpenTelemetry.BlazorWasm.TestApp/InstrumentationSource.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/InstrumentationSource.cs
@@ -29,8 +29,9 @@ public sealed class InstrumentationSource : IDisposable
 
     public InstrumentationSource()
     {
-        this.activitySource = new ActivitySource(ActivitySourceName);
-        this.meter = new Meter(MeterName);
+        var version = typeof(InstrumentationSource).Assembly.GetName().Version?.ToString();
+        this.activitySource = new(new ActivitySourceOptions(ActivitySourceName) { Version = version });
+        this.meter = new(new MeterOptions(MeterName) { Version = version });
         this.Counter = this.meter.CreateCounter<long>(CounterName);
         this.Histogram = this.meter.CreateHistogram<double>(HistogramName);
     }

--- a/test/OpenTelemetry.BlazorWasm.TestApp/InstrumentationSource.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/InstrumentationSource.cs
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace OpenTelemetry.BlazorWasm.TestApp;
+
+/// <summary>
+/// Holds the <see cref="ActivitySource"/> and <see cref="Meter"/> (plus their
+/// instruments) exercised by the application. The names and values defined here
+/// are the contract asserted by the end-to-end test.
+/// </summary>
+public sealed class InstrumentationSource : IDisposable
+{
+    public const string ServiceName = "otel-blazor-wasm-testapp";
+
+    public const string ActivitySourceName = "OpenTelemetry.BlazorWasm.TestApp.Traces";
+    public const string ActivityName = "BlazorWasmScenario";
+    public const string ActivityTagKey = "otel.blazor.scenario";
+    public const string ActivityTagValue = "end-to-end";
+
+    public const string MeterName = "OpenTelemetry.BlazorWasm.TestApp.Metrics";
+    public const string CounterName = "blazor.wasm.scenario.count";
+    public const string HistogramName = "blazor.wasm.scenario.duration";
+
+    private readonly ActivitySource activitySource;
+    private readonly Meter meter;
+
+    public InstrumentationSource()
+    {
+        this.activitySource = new ActivitySource(ActivitySourceName);
+        this.meter = new Meter(MeterName);
+        this.Counter = this.meter.CreateCounter<long>(CounterName);
+        this.Histogram = this.meter.CreateHistogram<double>(HistogramName);
+    }
+
+    public ActivitySource ActivitySource => this.activitySource;
+
+    public Counter<long> Counter { get; }
+
+    public Histogram<double> Histogram { get; }
+
+    public void Dispose()
+    {
+        this.meter.Dispose();
+        this.activitySource.Dispose();
+    }
+}

--- a/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <Description>Blazor WebAssembly application used to validate that the OpenTelemetry SDK works end-to-end under the browser WASM runtime.</Description>
+    <NoWarn>$(NoWarn);CA1515</NoWarn>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EventSourceSupport>true</EventSourceSupport>
+    <HttpActivityPropagationSupport>true</HttpActivityPropagationSupport>
+    <MetricsSupport>true</MetricsSupport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
     <Description>Blazor WebAssembly application used to validate that the OpenTelemetry SDK works end-to-end under the browser WASM runtime.</Description>
     <NoWarn>$(NoWarn);CA1515</NoWarn>
+    <!--
+      Because we use project references to projects that multi-target to TFMs
+      that do not support trimming we cannot publish the application as trimmed.
+    -->
     <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Pages/Home.razor
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Pages/Home.razor
@@ -1,0 +1,110 @@
+@* Copyright The OpenTelemetry Authors *@
+@* SPDX-License-Identifier: Apache-2.0 *@
+
+@using System.Collections.Generic
+@using System.Net.Http
+
+@inject InstrumentationSource Instrumentation
+@inject TracerProvider TracerProvider
+@inject MeterProvider MeterProvider
+@inject HttpClient HttpClient
+@inject ILogger<Home> Logger
+
+<h1>OpenTelemetry Blazor WebAssembly end-to-end test</h1>
+
+<p>
+    This page emits a trace, a metric and a log through the OpenTelemetry SDK
+    running under the browser WebAssembly runtime.
+</p>
+
+<p>Status: <span id="status">@this.status</span></p>
+
+<button id="increment-counter" @onclick="this.IncrementCounter">Increment counter</button>
+<p>Counter clicks: <span id="counter-value">@this.counterClicks</span></p>
+
+<button id="call-http" @onclick="this.FetchAsync">Call HTTP endpoint</button>
+<p>HTTP status: <span id="http-status">@this.httpStatus</span></p>
+<p>HTTP done: <span id="http-done">@this.httpDone</span></p>
+
+<pre id="error">@this.error</pre>
+
+@code {
+    private string status = "running";
+    private string error = string.Empty;
+    private int counterClicks;
+    private string httpStatus = string.Empty;
+    private bool httpDone;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        try
+        {
+            using (var activity = this.Instrumentation.ActivitySource.StartActivity(InstrumentationSource.ActivityName))
+            {
+                activity?.SetTag(InstrumentationSource.ActivityTagKey, InstrumentationSource.ActivityTagValue);
+            }
+
+            this.Instrumentation.Counter.Add(1, new KeyValuePair<string, object?>("signal", "metric"));
+            this.Instrumentation.Histogram.Record(42d);
+
+            this.Logger.LogInformation("Blazor WASM end-to-end {Signal}", "log");
+
+            this.MeterProvider.ForceFlush();
+            this.TracerProvider.ForceFlush();
+
+            this.status = "completed";
+        }
+        catch (Exception ex)
+        {
+            this.error = ex.ToString();
+            this.status = "failed";
+        }
+
+        this.StateHasChanged();
+    }
+
+    private void IncrementCounter()
+    {
+        try
+        {
+            this.counterClicks++;
+
+            this.Instrumentation.Counter.Add(1, new KeyValuePair<string, object?>("signal", "button"));
+            this.Logger.LogInformation("Counter button clicked {Count} time(s)", this.counterClicks);
+
+            this.MeterProvider.ForceFlush();
+        }
+        catch (Exception ex)
+        {
+            this.error = ex.ToString();
+            this.status = "failed";
+        }
+    }
+
+    private async Task FetchAsync()
+    {
+        try
+        {
+            using var response = await this.HttpClient.GetAsync("api/ping");
+
+            this.httpStatus = ((int)response.StatusCode).ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            this.MeterProvider.ForceFlush();
+            this.TracerProvider.ForceFlush();
+        }
+        catch (Exception ex)
+        {
+            this.error = ex.ToString();
+            this.status = "failed";
+        }
+        finally
+        {
+            this.httpDone = true;
+        }
+    }
+}

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Pages/Home.razor
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Pages/Home.razor
@@ -5,8 +5,6 @@
 @using System.Net.Http
 
 @inject InstrumentationSource Instrumentation
-@inject TracerProvider TracerProvider
-@inject MeterProvider MeterProvider
 @inject HttpClient HttpClient
 @inject ILogger<Home> Logger
 
@@ -54,9 +52,6 @@
 
             this.Logger.LogInformation("Blazor WASM end-to-end {Signal}", "log");
 
-            this.MeterProvider.ForceFlush();
-            this.TracerProvider.ForceFlush();
-
             this.status = "completed";
         }
         catch (Exception ex)
@@ -76,8 +71,6 @@
 
             this.Instrumentation.Counter.Add(1, new KeyValuePair<string, object?>("signal", "button"));
             this.Logger.LogInformation("Counter button clicked {Count} time(s)", this.counterClicks);
-
-            this.MeterProvider.ForceFlush();
         }
         catch (Exception ex)
         {
@@ -93,9 +86,6 @@
             using var response = await this.HttpClient.GetAsync("api/ping");
 
             this.httpStatus = ((int)response.StatusCode).ToString(System.Globalization.CultureInfo.InvariantCulture);
-
-            this.MeterProvider.ForceFlush();
-            this.TracerProvider.ForceFlush();
         }
         catch (Exception ex)
         {

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
@@ -14,6 +14,10 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
 builder.RootComponents.Add<App>("#app");
 
+Environment.SetEnvironmentVariable("OTEL_BSP_SCHEDULE_DELAY", "1000");
+Environment.SetEnvironmentVariable("OTEL_BLRP_SCHEDULE_DELAY", "1000");
+Environment.SetEnvironmentVariable("OTEL_METRIC_EXPORT_INTERVAL", "1000");
+
 // The OTLP receiver is served from the same origin as the application, so the
 // export endpoints are resolved relative to the host base address. This keeps
 // the export a genuine cross-process HTTP/protobuf call while avoiding CORS.
@@ -32,7 +36,7 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddSource(InstrumentationSource.ActivitySourceName)
     .AddSource("System.Net.Http")
     .SetSampler(new AlwaysOnSampler())
-    .AddOtlpExporter(options =>
+    .AddOtlpExporter((options) =>
     {
         options.Protocol = OtlpExportProtocol.HttpProtobuf;
         options.Endpoint = new Uri(baseAddress, "v1/traces");
@@ -45,22 +49,21 @@ var meterProvider = Sdk.CreateMeterProviderBuilder()
     .SetResourceBuilder(resourceBuilder)
     .AddMeter(InstrumentationSource.MeterName)
     .AddMeter("System.Net.Http")
-    .AddOtlpExporter((exporterOptions, metricReaderOptions) =>
+    .AddOtlpExporter((options) =>
     {
-        exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;
-        exporterOptions.Endpoint = new Uri(baseAddress, "v1/metrics");
-        metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 1000;
+        options.Protocol = OtlpExportProtocol.HttpProtobuf;
+        options.Endpoint = new Uri(baseAddress, "v1/metrics");
     })
     .Build();
 
 builder.Services.AddSingleton(meterProvider);
 
-builder.Logging.AddOpenTelemetry(options =>
+builder.Logging.AddOpenTelemetry((options) =>
 {
     options.SetResourceBuilder(resourceBuilder);
     options.IncludeFormattedMessage = true;
 
-    options.AddOtlpExporter(exporterOptions =>
+    options.AddOtlpExporter((exporterOptions) =>
     {
         exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;
         exporterOptions.Endpoint = new Uri(baseAddress, "v1/logs");

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
@@ -30,7 +30,7 @@ builder.Services.AddScoped(_ => new HttpClient { BaseAddress = baseAddress });
 var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .SetResourceBuilder(resourceBuilder)
     .AddSource(InstrumentationSource.ActivitySourceName)
-    .AddHttpClientInstrumentation()
+    .AddSource("System.Net.Http")
     .SetSampler(new AlwaysOnSampler())
     .AddOtlpExporter(options =>
     {
@@ -44,7 +44,7 @@ builder.Services.AddSingleton(tracerProvider);
 var meterProvider = Sdk.CreateMeterProviderBuilder()
     .SetResourceBuilder(resourceBuilder)
     .AddMeter(InstrumentationSource.MeterName)
-    .AddHttpClientInstrumentation()
+    .AddMeter("System.Net.Http")
     .AddOtlpExporter((exporterOptions, metricReaderOptions) =>
     {
         exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.BlazorWasm.TestApp;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.RootComponents.Add<App>("#app");
+
+// The OTLP receiver is served from the same origin as the application, so the
+// export endpoints are resolved relative to the host base address. This keeps
+// the export a genuine cross-process HTTP/protobuf call while avoiding CORS.
+var baseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+
+var resourceBuilder = ResourceBuilder.CreateDefault()
+    .AddService(InstrumentationSource.ServiceName);
+
+using var instrumentation = new InstrumentationSource();
+builder.Services.AddSingleton(instrumentation);
+
+builder.Services.AddScoped(_ => new HttpClient { BaseAddress = baseAddress });
+
+var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .SetResourceBuilder(resourceBuilder)
+    .AddSource(InstrumentationSource.ActivitySourceName)
+    .AddHttpClientInstrumentation()
+    .SetSampler(new AlwaysOnSampler())
+    .AddOtlpExporter(options =>
+    {
+        options.Protocol = OtlpExportProtocol.HttpProtobuf;
+        options.Endpoint = new Uri(baseAddress, "v1/traces");
+    })
+    .Build();
+
+builder.Services.AddSingleton(tracerProvider);
+
+var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .SetResourceBuilder(resourceBuilder)
+    .AddMeter(InstrumentationSource.MeterName)
+    .AddHttpClientInstrumentation()
+    .AddOtlpExporter((exporterOptions, metricReaderOptions) =>
+    {
+        exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;
+        exporterOptions.Endpoint = new Uri(baseAddress, "v1/metrics");
+        metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 1000;
+    })
+    .Build();
+
+builder.Services.AddSingleton(meterProvider);
+
+builder.Logging.AddOpenTelemetry(options =>
+{
+    options.SetResourceBuilder(resourceBuilder);
+    options.IncludeFormattedMessage = true;
+
+    options.AddOtlpExporter(exporterOptions =>
+    {
+        exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;
+        exporterOptions.Endpoint = new Uri(baseAddress, "v1/logs");
+    });
+});
+
+var app = builder.Build();
+
+await app.RunAsync().ConfigureAwait(false);

--- a/test/OpenTelemetry.BlazorWasm.TestApp/_Imports.razor
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/_Imports.razor
@@ -1,0 +1,7 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.Extensions.Logging
+@using OpenTelemetry.BlazorWasm.TestApp
+@using OpenTelemetry.BlazorWasm.TestApp.Pages
+@using OpenTelemetry.Metrics
+@using OpenTelemetry.Trace

--- a/test/OpenTelemetry.BlazorWasm.TestApp/_Imports.razor
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/_Imports.razor
@@ -3,5 +3,3 @@
 @using Microsoft.Extensions.Logging
 @using OpenTelemetry.BlazorWasm.TestApp
 @using OpenTelemetry.BlazorWasm.TestApp.Pages
-@using OpenTelemetry.Metrics
-@using OpenTelemetry.Trace

--- a/test/OpenTelemetry.BlazorWasm.TestApp/wwwroot/index.html
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/wwwroot/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenTelemetry Blazor WASM test app</title>
+    <base href="/" />
+</head>
+
+<body>
+    <div id="app">Loading...</div>
+
+    <div id="blazor-error-ui" style="display: none">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+    </div>
+
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
@@ -37,7 +37,7 @@ public sealed class BlazorWasmAppFixture : IAsyncLifetime
             {
                 Directory.Delete(this.publishDirectory, recursive: true);
             }
-            catch (IOException)
+            catch (Exception)
             {
                 // Best effort cleanup of the temporary publish output.
             }

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
@@ -1,0 +1,156 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Text;
+
+namespace OpenTelemetry.BlazorWasm.Tests;
+
+public sealed class BlazorWasmAppFixture : IAsyncLifetime
+{
+    private string? publishDirectory;
+
+    internal OtlpHttpCollector Collector { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        InstallPlaywright();
+
+        this.publishDirectory = PublishClient();
+        this.Collector = await OtlpHttpCollector.StartAsync(Path.Combine(this.publishDirectory, "wwwroot"));
+    }
+
+    public async Task DisposeAsync()
+    {
+        await this.Collector.DisposeAsync();
+
+        if (this.publishDirectory is not null && Directory.Exists(this.publishDirectory))
+        {
+            try
+            {
+                Directory.Delete(this.publishDirectory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best effort cleanup of the temporary publish output.
+            }
+        }
+    }
+
+    private static void InstallPlaywright()
+    {
+        string[] arguments = OperatingSystem.IsLinux()
+            ? ["install", "chromium", "--with-deps"]
+            : ["install", "chromium"];
+
+        var exitCode = Microsoft.Playwright.Program.Main(arguments);
+
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException($"Playwright browser install exited with code {exitCode}.");
+        }
+    }
+
+    private static string CurrentTargetFramework()
+    {
+        // Derive the moniker (e.g. "net10.0") from the framework the tests were
+        // built against so the published client matches the current test TFM.
+        var frameworkName = Assembly.GetExecutingAssembly().GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+
+        if (frameworkName is not null)
+        {
+            const string Marker = "Version=v";
+            var index = frameworkName.IndexOf(Marker, StringComparison.Ordinal);
+            if (index >= 0)
+            {
+                return $"net{frameworkName[(index + Marker.Length)..]}";
+            }
+        }
+
+        var version = Environment.Version;
+        return $"net{version.Major}.{version.Minor}";
+    }
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "OpenTelemetry.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repository root (OpenTelemetry.slnx).");
+    }
+
+    private static string PublishClient()
+    {
+        var repoRoot = RepoRoot();
+        var project = Path.Combine(repoRoot, "test", "OpenTelemetry.BlazorWasm.TestApp", "OpenTelemetry.BlazorWasm.TestApp.csproj");
+        var output = Path.Combine(Path.GetTempPath(), "otel-blazor-wasm-" + Guid.NewGuid().ToString("N"));
+
+#if DEBUG
+        const string Configuration = "Debug";
+#else
+        const string Configuration = "Release";
+#endif
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = repoRoot,
+        };
+
+        startInfo.ArgumentList.Add("publish");
+        startInfo.ArgumentList.Add(project);
+        startInfo.ArgumentList.Add("--configuration");
+        startInfo.ArgumentList.Add(Configuration);
+
+        // Publish the client for the same target framework the test is running
+        // under so the suite works unchanged when run against multiple TFMs.
+        startInfo.ArgumentList.Add("--framework");
+        startInfo.ArgumentList.Add(CurrentTargetFramework());
+        startInfo.ArgumentList.Add("--output");
+        startInfo.ArgumentList.Add(output);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start 'dotnet publish' for the Blazor client.");
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'dotnet publish' failed with exit code {process.ExitCode}.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+        }
+
+        return output;
+    }
+}

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
@@ -24,7 +24,10 @@ public sealed class BlazorWasmAppFixture : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        await this.Collector.DisposeAsync();
+        if (this.Collector is not null)
+        {
+            await this.Collector.DisposeAsync();
+        }
 
         if (this.publishDirectory is not null && Directory.Exists(this.publishDirectory))
         {

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
@@ -10,6 +10,8 @@ namespace OpenTelemetry.BlazorWasm.Tests;
 
 public sealed class BlazorWasmAppFixture : IAsyncLifetime
 {
+    private static readonly TimeSpan PublishTimeout = TimeSpan.FromMinutes(5);
+
     private string? publishDirectory;
 
     internal OtlpHttpCollector Collector { get; private set; } = null!;
@@ -109,10 +111,19 @@ public sealed class BlazorWasmAppFixture : IAsyncLifetime
             WorkingDirectory = repoRoot,
         };
 
+        // Disable the persistent .NET build servers and MSBuild node reuse for
+        // this invocation. Otherwise, on a cold machine (e.g. CI) 'dotnet publish'
+        // spawns a build server child that inherits the redirected stdout/stderr
+        // handles, so WaitForExit would block until that server idle-times-out
+        // (~15 minutes) even though the publish itself finished.
+        startInfo.Environment["DOTNET_CLI_USE_MSBUILD_SERVER"] = "0";
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
         startInfo.ArgumentList.Add("publish");
         startInfo.ArgumentList.Add(project);
         startInfo.ArgumentList.Add("--configuration");
         startInfo.ArgumentList.Add(Configuration);
+        startInfo.ArgumentList.Add("--disable-build-servers");
 
         // Publish the client for the same target framework the test is running
         // under so the suite works unchanged when run against multiple TFMs.
@@ -146,6 +157,14 @@ public sealed class BlazorWasmAppFixture : IAsyncLifetime
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
+        if (!process.WaitForExit(PublishTimeout))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new InvalidOperationException(
+                $"'dotnet publish' timed out after {PublishTimeout}.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+        }
+
+        // Wait (again, with no timeout) for the async output handlers to flush.
         process.WaitForExit();
 
         if (process.ExitCode != 0)

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmEndToEndTests.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmEndToEndTests.cs
@@ -134,12 +134,14 @@ public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture
             await WaitForAsync(
                 () => HasHttpClientSpan(collector) && HasMetric(collector, HttpClientDurationMetric),
                 () => Detail(collector));
+
+            Assert.True(HasServiceName(collector), $"Expected resource attribute service.name='{ServiceName}'.");
         });
     }
 
     private static async Task NavigateAndWaitForStartupAsync(IPage page, string url)
     {
-        for (var attempt = 0; attempt <= StartupAttempts; attempt++)
+        for (var attempt = 0; attempt < StartupAttempts; attempt++)
         {
             try
             {

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmEndToEndTests.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmEndToEndTests.cs
@@ -1,0 +1,217 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Playwright;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Logs.V1;
+
+namespace OpenTelemetry.BlazorWasm.Tests;
+
+public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture>
+{
+    // Contract shared with OpenTelemetry.BlazorWasm.TestApp (kept in sync by hand
+    // to avoid a project reference that would require the wasm workload to build).
+    private const string ServiceName = "otel-blazor-wasm-testapp";
+    private const string ActivityName = "BlazorWasmScenario";
+    private const string ActivityTagKey = "otel.blazor.scenario";
+    private const string ActivityTagValue = "end-to-end";
+    private const string CounterName = "blazor.wasm.scenario.count";
+    private const string HistogramName = "blazor.wasm.scenario.duration";
+    private const string HttpClientSourceName = "System.Net.Http";
+    private const string HttpClientDurationMetric = "http.client.request.duration";
+
+    private const int TestTimeoutMilliseconds = 90_000;
+
+    private static readonly TimeSpan CollectTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly BlazorWasmAppFixture wasmFixture;
+    private readonly BrowserFixture browserFixture;
+
+    public BlazorWasmEndToEndTests(BlazorWasmAppFixture fixture, ITestOutputHelper outputHelper)
+    {
+        this.wasmFixture = fixture;
+        this.browserFixture = new BrowserFixture(outputHelper);
+    }
+
+    [Fact(Timeout = TestTimeoutMilliseconds)]
+    public async Task LogsAreExported()
+    {
+        // Arrange
+        var collector = this.wasmFixture.Collector;
+
+        await this.browserFixture.WithPageAsync(async page =>
+        {
+            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+
+            // Act
+            await page.Locator("#increment-counter").ClickAsync();
+
+            // Assert
+            await Assertions.Expect(page.Locator("#counter-value")).ToHaveTextAsync("1", new() { Timeout = 10_000 });
+
+            AssertNoAppErrors(await GetErrorAsync(page));
+
+            await WaitForAsync(
+                () => HasLog(collector, "Blazor WASM end-to-end") && HasLog(collector, "Counter button clicked"),
+                () => Detail(collector));
+
+            Assert.True(HasServiceName(collector), $"Expected resource attribute service.name='{ServiceName}'.");
+
+            var scenarioLog = GetLogRecords(collector).First(l => Body(l).Contains("Blazor WASM end-to-end", StringComparison.Ordinal));
+
+            Assert.Equal((int)SeverityNumber.Info, (int)scenarioLog.SeverityNumber);
+        });
+    }
+
+    [Fact(Timeout = TestTimeoutMilliseconds)]
+    public async Task MetricsAreExported()
+    {
+        // Arrange
+        var collector = this.wasmFixture.Collector;
+
+        await this.browserFixture.WithPageAsync(async page =>
+        {
+            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+
+            // Act
+            await page.Locator("#increment-counter").ClickAsync();
+
+            // Assert
+            AssertNoAppErrors(await GetErrorAsync(page));
+
+            await WaitForAsync(
+                () => HasMetric(collector, CounterName) && HasMetric(collector, HistogramName),
+                () => Detail(collector));
+
+            Assert.True(HasServiceName(collector), $"Expected resource attribute service.name='{ServiceName}'.");
+        });
+    }
+
+    [Fact(Timeout = TestTimeoutMilliseconds)]
+    public async Task TracesAreExported()
+    {
+        // Arrange
+        var collector = this.wasmFixture.Collector;
+
+        await this.browserFixture.WithPageAsync(async (page) =>
+        {
+            // Act
+            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+
+            // Assert
+            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+
+            AssertNoAppErrors(await GetErrorAsync(page));
+
+            await WaitForAsync(() => HasScenarioTrace(collector), () => Detail(collector));
+
+            Assert.True(HasServiceName(collector), $"Expected resource attribute service.name='{ServiceName}'.");
+        });
+    }
+
+    [Fact(Timeout = TestTimeoutMilliseconds)]
+    public async Task HttpClientInstrumentationIsExported()
+    {
+        // Arrange
+        var collector = this.wasmFixture.Collector;
+
+        await this.browserFixture.WithPageAsync(async page =>
+        {
+            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+
+            // Act
+            await page.Locator("#call-http").ClickAsync();
+
+            // Assert
+            await Assertions.Expect(page.Locator("#http-done")).ToHaveTextAsync("True", new() { Timeout = 30_000 });
+            await Assertions.Expect(page.Locator("#http-status")).ToHaveTextAsync("200", new() { Timeout = 10_000 });
+
+            AssertNoAppErrors(await GetErrorAsync(page));
+
+            await WaitForAsync(
+                () => HasHttpClientSpan(collector) && HasMetric(collector, HttpClientDurationMetric),
+                () => Detail(collector));
+        });
+    }
+
+    private static async Task<string> GetErrorAsync(IPage page)
+        => await page.Locator("#error").InnerTextAsync();
+
+    private static void AssertNoAppErrors(string error)
+        => Assert.True(string.IsNullOrWhiteSpace(error), $"The app reported an error:{Environment.NewLine}{error}");
+
+    private static async Task WaitForAsync(Func<bool> condition, Func<string> failureDetail)
+    {
+        var deadline = DateTime.UtcNow + CollectTimeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(500);
+        }
+
+        Assert.True(condition(), "Timed out waiting for telemetry to be exported. " + failureDetail());
+    }
+
+    private static string Body(LogRecord logRecord) => logRecord.Body?.StringValue ?? string.Empty;
+
+    private static bool HasScenarioTrace(OtlpHttpCollector collector) =>
+        GetSpans(collector)
+            .Any((p) => p.Span.Name == ActivityName &&
+                        p.Span.Attributes.Any((r) => r.Key == ActivityTagKey && r.Value?.StringValue == ActivityTagValue));
+
+    private static bool HasHttpClientSpan(OtlpHttpCollector collector) =>
+        GetSpans(collector)
+            .Any((p) => p.Scope == HttpClientSourceName);
+
+    private static bool HasLog(OtlpHttpCollector collector, string bodyContains) =>
+        GetLogRecords(collector)
+            .Any((p) => Body(p).Contains(bodyContains, StringComparison.Ordinal));
+
+    private static bool HasMetric(OtlpHttpCollector collector, string name) =>
+        GetMetricNames(collector).Contains(name);
+
+    private static bool HasServiceName(OtlpHttpCollector collector)
+    {
+        static bool Matches(IEnumerable<KeyValue> attributes) =>
+            attributes.Any((p) => p.Key == "service.name" && p.Value?.StringValue == ServiceName);
+
+        return
+            collector.GetLogsRequests().SelectMany((p) => p.ResourceLogs).Any((r) => Matches(r.Resource.Attributes)) ||
+            collector.GetMetricsRequests().SelectMany((p) => p.ResourceMetrics).Any((r) => Matches(r.Resource.Attributes)) ||
+            collector.GetTraceRequests().SelectMany((p) => p.ResourceSpans).Any((r) => Matches(r.Resource.Attributes));
+    }
+
+    private static List<(string Scope, Proto.Trace.V1.Span Span)> GetSpans(OtlpHttpCollector collector) =>
+        [.. collector.GetTraceRequests()
+            .SelectMany((p) => p.ResourceSpans)
+            .SelectMany((p) => p.ScopeSpans)
+            .SelectMany((p) => p.Spans.Select((r) => (p.Scope?.Name ?? string.Empty, r)))];
+
+    private static HashSet<string> GetMetricNames(OtlpHttpCollector collector) =>
+        collector.GetMetricsRequests()
+            .SelectMany((p) => p.ResourceMetrics)
+            .SelectMany((p) => p.ScopeMetrics)
+            .SelectMany((p) => p.Metrics)
+            .Select((p) => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static List<LogRecord> GetLogRecords(OtlpHttpCollector collector) =>
+        [.. collector.GetLogsRequests()
+            .SelectMany((p) => p.ResourceLogs)
+            .SelectMany((p) => p.ScopeLogs)
+            .SelectMany((p) => p.LogRecords)];
+
+    private static string Detail(OtlpHttpCollector collector) =>
+        $"Spans seen: {string.Join(", ", GetSpans(collector).Select(t => $"{t.Scope}/{t.Span.Name}"))}." +
+        $"{Environment.NewLine}Metrics seen: {string.Join(", ", GetMetricNames(collector))}." +
+        $"{Environment.NewLine}Logs seen: {GetLogRecords(collector).Count}." +
+        $"{Environment.NewLine}{collector.GetRawHitSummary()}";
+}

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmEndToEndTests.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmEndToEndTests.cs
@@ -22,6 +22,11 @@ public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture
 
     private const int TestTimeoutMilliseconds = 90_000;
 
+    // Number of cold-boot attempts. The Blazor client fetches many framework
+    // assets on first load, and a transient browser network error can abort
+    // those downloads and leave the app stuck loading, so some retries are allowed.
+    private const int StartupAttempts = 3;
+
     private static readonly TimeSpan CollectTimeout = TimeSpan.FromSeconds(60);
 
     private readonly BlazorWasmAppFixture wasmFixture;
@@ -41,8 +46,7 @@ public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture
 
         await this.browserFixture.WithPageAsync(async page =>
         {
-            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
-            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+            await NavigateAndWaitForStartupAsync(page, collector.BaseUrl);
 
             // Act
             await page.Locator("#increment-counter").ClickAsync();
@@ -72,8 +76,7 @@ public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture
 
         await this.browserFixture.WithPageAsync(async page =>
         {
-            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
-            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+            await NavigateAndWaitForStartupAsync(page, collector.BaseUrl);
 
             // Act
             await page.Locator("#increment-counter").ClickAsync();
@@ -98,11 +101,9 @@ public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture
         await this.browserFixture.WithPageAsync(async (page) =>
         {
             // Act
-            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+            await NavigateAndWaitForStartupAsync(page, collector.BaseUrl);
 
             // Assert
-            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
-
             AssertNoAppErrors(await GetErrorAsync(page));
 
             await WaitForAsync(() => HasScenarioTrace(collector), () => Detail(collector));
@@ -119,8 +120,7 @@ public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture
 
         await this.browserFixture.WithPageAsync(async page =>
         {
-            await page.GotoAsync(collector.BaseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
-            await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+            await NavigateAndWaitForStartupAsync(page, collector.BaseUrl);
 
             // Act
             await page.Locator("#call-http").ClickAsync();
@@ -135,6 +135,28 @@ public sealed class BlazorWasmEndToEndTests : IClassFixture<BlazorWasmAppFixture
                 () => HasHttpClientSpan(collector) && HasMetric(collector, HttpClientDurationMetric),
                 () => Detail(collector));
         });
+    }
+
+    private static async Task NavigateAndWaitForStartupAsync(IPage page, string url)
+    {
+        for (var attempt = 0; attempt <= StartupAttempts; attempt++)
+        {
+            try
+            {
+                await page.GotoAsync(url, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+                await Assertions.Expect(page.Locator("#status")).ToHaveTextAsync("completed", new() { Timeout = 30_000 });
+                return;
+            }
+            catch (PlaywrightException) when (attempt < StartupAttempts)
+            {
+                // A transient network error (e.g. ERR_NETWORK_CHANGED) can abort the
+                // WASM asset downloads on a cold boot, leaving the app stuck loading.
+                // Reload and try again.
+                await Task.Delay(1_000);
+            }
+        }
+
+        throw new InvalidOperationException("Failed to navigate to the page after multiple attempts.");
     }
 
     private static async Task<string> GetErrorAsync(IPage page)

--- a/test/OpenTelemetry.BlazorWasm.Tests/BrowserFixture.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BrowserFixture.cs
@@ -1,0 +1,144 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Microsoft.Playwright;
+
+namespace OpenTelemetry.BlazorWasm.Tests;
+
+/// <summary>
+/// Manages the Playwright browser lifecycle for a single test and captures a
+/// screenshot, trace and video when the test fails to aid debugging.
+/// </summary>
+internal sealed class BrowserFixture(ITestOutputHelper outputHelper)
+{
+    private readonly ITestOutputHelper outputHelper = outputHelper;
+
+    private static bool IsRunningInGitHubActions
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+
+    private static string ArtifactsDirectory
+        => Path.Combine(AppContext.BaseDirectory, "playwright");
+
+    public async Task WithPageAsync(Func<IPage, Task> action, [CallerMemberName] string? testName = null)
+    {
+        var name = testName ?? "test";
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await CreateBrowserAsync(playwright);
+
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            RecordVideoDir = Path.Combine(ArtifactsDirectory, "videos"),
+        });
+
+        await context.Tracing.StartAsync(new TracingStartOptions
+        {
+            Screenshots = true,
+            Snapshots = true,
+            Sources = true,
+            Title = name,
+        });
+
+        var page = await context.NewPageAsync();
+
+        page.Console += (_, e) => this.outputHelper.WriteLine(e.Text);
+        page.PageError += (_, e) => this.outputHelper.WriteLine(e);
+
+        var failed = false;
+
+        try
+        {
+            await action(page);
+        }
+        catch (Exception)
+        {
+            failed = true;
+            await this.TryCaptureScreenshotAsync(page, name);
+            throw;
+        }
+        finally
+        {
+            var tracePath = failed ? Path.Combine(ArtifactsDirectory, "traces", GenerateFileName(name, ".zip")) : null;
+            await context.Tracing.StopAsync(new TracingStopOptions { Path = tracePath });
+
+            if (tracePath is not null)
+            {
+                this.outputHelper.WriteLine($"Trace saved to {tracePath}.");
+            }
+
+            await this.TryCaptureVideoAsync(page, name, failed);
+        }
+    }
+
+    private static async Task<IBrowser> CreateBrowserAsync(IPlaywright playwright)
+    {
+        var options = new BrowserTypeLaunchOptions { Headless = true };
+
+        if (OperatingSystem.IsLinux() && IsRunningInGitHubActions)
+        {
+            // Workaround for Chromium crashes on Linux CI runners with a limited /dev/shm.
+            options.Args = ["--disable-dev-shm-usage", "--no-sandbox"];
+        }
+
+        return await playwright.Chromium.LaunchAsync(options);
+    }
+
+    private static string GenerateFileName(string testName, string extension)
+    {
+        var os =
+            OperatingSystem.IsLinux() ? "linux" :
+            OperatingSystem.IsMacOS() ? "macos" :
+            OperatingSystem.IsWindows() ? "windows" :
+            "other";
+
+        var utcNow = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
+        return $"{testName}_chromium_{os}_{utcNow}{extension}";
+    }
+
+    private async Task TryCaptureScreenshotAsync(IPage page, string testName)
+    {
+        try
+        {
+            var path = Path.Combine(ArtifactsDirectory, "screenshots", GenerateFileName(testName, ".png"));
+            await page.ScreenshotAsync(new PageScreenshotOptions { Path = path });
+            this.outputHelper.WriteLine($"Screenshot saved to {path}.");
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            this.outputHelper.WriteLine("Failed to capture screenshot: " + ex);
+        }
+    }
+
+    private async Task TryCaptureVideoAsync(IPage page, string testName, bool failed)
+    {
+        if (page.Video is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await page.CloseAsync();
+
+            if (!failed)
+            {
+                await page.Video.DeleteAsync();
+                return;
+            }
+
+            var path = Path.Combine(ArtifactsDirectory, "videos", GenerateFileName(testName, ".webm"));
+            await page.Video.SaveAsAsync(path);
+            this.outputHelper.WriteLine($"Video saved to {path}.");
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            this.outputHelper.WriteLine("Failed to capture video: " + ex);
+        }
+    }
+}

--- a/test/OpenTelemetry.BlazorWasm.Tests/OpenTelemetry.BlazorWasm.Tests.csproj
+++ b/test/OpenTelemetry.BlazorWasm.Tests/OpenTelemetry.BlazorWasm.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <Description>End-to-end tests that drive the Blazor WebAssembly test app in a headless browser to validate the OpenTelemetry SDK under the WASM runtime.</Description>
+    <NoWarn>$(NoWarn);CA1515;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
+    <PackageReference Include="Microsoft.Playwright" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TcpPortProvider.cs" Link="Includes\TcpPortProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="$(RepoRoot)\src\Shared\Proto\**\*.proto" Link="Proto\%(RecursiveDir)%(Filename)%(Extension)" Access="internal" GrpcServices="None">
+      <ProtoRoot>$(RepoRoot)\src\Shared\Proto</ProtoRoot>
+    </Protobuf>
+  </ItemGroup>
+
+</Project>

--- a/test/OpenTelemetry.BlazorWasm.Tests/OtlpHttpCollector.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/OtlpHttpCollector.cs
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Google.Protobuf;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Proto.Collector.Logs.V1;
+using OpenTelemetry.Proto.Collector.Metrics.V1;
+using OpenTelemetry.Proto.Collector.Trace.V1;
+using OpenTelemetry.Tests;
+
+namespace OpenTelemetry.BlazorWasm.Tests;
+
+/// <summary>
+/// An in-process OTLP/HTTP receiver that also serves the published Blazor
+/// WebAssembly client from the same origin. Decoded OTLP requests are captured
+/// so the test can assert that traces, metrics and logs were exported by the
+/// SDK running under the browser WASM runtime.
+/// </summary>
+internal sealed class OtlpHttpCollector : IAsyncDisposable
+{
+    private readonly Lock lockObject = new();
+    private readonly List<ExportLogsServiceRequest> logsRequests = [];
+    private readonly List<ExportMetricsServiceRequest> metricsRequests = [];
+    private readonly List<ExportTraceServiceRequest> traceRequests = [];
+    private readonly WebApplication app;
+    private int rawLogHits;
+    private int rawMetricHits;
+    private int rawTraceHits;
+
+    private OtlpHttpCollector(WebApplication app, string baseUrl)
+    {
+        this.app = app;
+        this.BaseUrl = baseUrl;
+    }
+
+    public string BaseUrl { get; }
+
+    public static async Task<OtlpHttpCollector> StartAsync(string webRootPath)
+    {
+        var port = TcpPortProvider.GetOpenPort();
+        var baseUrl = $"http://localhost:{port}";
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            ContentRootPath = Path.GetDirectoryName(webRootPath),
+            WebRootPath = webRootPath,
+        });
+
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls(baseUrl);
+
+        var app = builder.Build();
+
+        var collector = new OtlpHttpCollector(app, baseUrl);
+
+        // OTLP receiver endpoints. These must be mapped before the Blazor
+        // fallback so the export requests are not served the index page.
+        app.MapPost("/v1/logs", collector.HandleLogsAsync);
+        app.MapPost("/v1/metrics", collector.HandleMetricsAsync);
+        app.MapPost("/v1/traces", collector.HandleTracesAsync);
+
+        // A simple endpoint the app's "Call HTTP endpoint" button targets so
+        // that HTTP client instrumentation can be exercised from the browser.
+        app.MapGet("/api/ping", () => Results.Text("pong"));
+
+        // Serve the published Blazor WebAssembly client.
+        app.UseBlazorFrameworkFiles();
+        app.UseStaticFiles();
+        app.MapFallbackToFile("index.html");
+
+        await app.StartAsync();
+
+        return collector;
+    }
+
+    public IReadOnlyList<ExportLogsServiceRequest> GetLogsRequests()
+    {
+        lock (this.lockObject)
+        {
+            return [.. this.logsRequests];
+        }
+    }
+
+    public IReadOnlyList<ExportMetricsServiceRequest> GetMetricsRequests()
+    {
+        lock (this.lockObject)
+        {
+            return [.. this.metricsRequests];
+        }
+    }
+
+    public IReadOnlyList<ExportTraceServiceRequest> GetTraceRequests()
+    {
+        lock (this.lockObject)
+        {
+            return [.. this.traceRequests];
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (this.app is not null)
+        {
+            await this.app.StopAsync();
+            await this.app.DisposeAsync();
+        }
+    }
+
+    public string GetRawHitSummary()
+    {
+        lock (this.lockObject)
+        {
+            return $"Raw endpoint hits: /v1/traces={this.rawTraceHits}, /v1/metrics={this.rawMetricHits}, /v1/logs={this.rawLogHits}.";
+        }
+    }
+
+    private static async Task<byte[]> ReadBodyAsync(HttpRequest request)
+    {
+        using var memory = new MemoryStream();
+
+        await request.Body.CopyToAsync(memory);
+
+        return memory.ToArray();
+    }
+
+    private static async Task WriteResponseAsync(HttpContext context, IMessage response)
+    {
+        context.Response.ContentType = "application/x-protobuf";
+        await context.Response.Body.WriteAsync(response.ToByteArray());
+    }
+
+    private async Task HandleLogsAsync(HttpContext context)
+    {
+        var body = await ReadBodyAsync(context.Request);
+        var request = ExportLogsServiceRequest.Parser.ParseFrom(body);
+
+        lock (this.lockObject)
+        {
+            this.rawLogHits++;
+            this.logsRequests.Add(request);
+        }
+
+        await WriteResponseAsync(context, new ExportLogsServiceResponse());
+    }
+
+    private async Task HandleMetricsAsync(HttpContext context)
+    {
+        var body = await ReadBodyAsync(context.Request);
+        var request = ExportMetricsServiceRequest.Parser.ParseFrom(body);
+        lock (this.lockObject)
+        {
+            this.rawMetricHits++;
+            this.metricsRequests.Add(request);
+        }
+
+        await WriteResponseAsync(context, new ExportMetricsServiceResponse());
+    }
+
+    private async Task HandleTracesAsync(HttpContext context)
+    {
+        var body = await ReadBodyAsync(context.Request);
+        var request = ExportTraceServiceRequest.Parser.ParseFrom(body);
+
+        lock (this.lockObject)
+        {
+            this.rawTraceHits++;
+            this.traceRequests.Add(request);
+        }
+
+        await WriteResponseAsync(context, new ExportTraceServiceResponse());
+    }
+}

--- a/test/OpenTelemetry.BlazorWasm.Tests/README.md
+++ b/test/OpenTelemetry.BlazorWasm.Tests/README.md
@@ -1,0 +1,51 @@
+# OpenTelemetry Blazor WebAssembly end-to-end tests
+
+These tests validate that the OpenTelemetry SDK works end-to-end in an ASP.NET
+Core Blazor WebAssembly application running under the browser WASM runtime.
+
+## What is covered
+
+[`OpenTelemetry.BlazorWasm.TestApp`](../OpenTelemetry.BlazorWasm.TestApp) is a
+Blazor WebAssembly app that wires up the SDK (logs, metrics and traces) with the
+real OTLP/HTTP exporter and exercises each signal, including HTTP client
+instrumentation.
+
+The test:
+
+1. Publishes the app and serves it, together with an in-process OTLP/HTTP
+   receiver from the same origin.
+2. Loads the app in headless Chromium using
+   [Playwright](https://playwright.dev/dotnet/).
+3. Asserts the receiver decoded the expected traces, metrics and logs.
+
+## Required runtime feature switches
+
+Blazor WebAssembly disables several runtime features by default to reduce the
+download size. For OpenTelemetry to work these must be enabled in the app project
+(see [`OpenTelemetry.BlazorWasm.TestApp.csproj`](../OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj)):
+
+```xml
+<EventSourceSupport>true</EventSourceSupport>
+<HttpActivityPropagationSupport>true</HttpActivityPropagationSupport>
+<MetricsSupport>true</MetricsSupport>
+```
+
+## Running locally
+
+The [`wasm-tools`](https://learn.microsoft.com/aspnet/core/blazor/tooling)
+workload is required to publish the Blazor client:
+
+```shell
+dotnet workload install wasm-tools
+```
+
+Then run the tests. The Playwright browser is installed automatically by the test
+fixture on first run:
+
+```shell
+dotnet test test/OpenTelemetry.BlazorWasm.Tests/OpenTelemetry.BlazorWasm.Tests.csproj
+```
+
+On failure a screenshot, a Playwright trace (`.zip`, viewable at
+<https://trace.playwright.dev>) and a video are written to a `playwright`
+directory under the test output.

--- a/test/OpenTelemetry.BlazorWasm.Tests/README.md
+++ b/test/OpenTelemetry.BlazorWasm.Tests/README.md
@@ -5,10 +5,9 @@ Core Blazor WebAssembly application running under the browser WASM runtime.
 
 ## What is covered
 
-[`OpenTelemetry.BlazorWasm.TestApp`](../OpenTelemetry.BlazorWasm.TestApp) is a
-Blazor WebAssembly app that wires up the SDK (logs, metrics and traces) with the
-real OTLP/HTTP exporter and exercises each signal, including HTTP client
-instrumentation.
+`OpenTelemetry.BlazorWasm.TestApp` is a Blazor WebAssembly app that wires up the
+SDK (logs, metrics and traces) with the real OTLP/HTTP exporter and exercises
+each signal, including HTTP client instrumentation.
 
 The test:
 
@@ -21,8 +20,8 @@ The test:
 ## Required runtime feature switches
 
 Blazor WebAssembly disables several runtime features by default to reduce the
-download size. For OpenTelemetry to work these must be enabled in the app project
-(see [`OpenTelemetry.BlazorWasm.TestApp.csproj`](../OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj)):
+download size. For OpenTelemetry to work these must be enabled in the
+`OpenTelemetry.BlazorWasm.TestApp.csproj` project file:
 
 ```xml
 <EventSourceSupport>true</EventSourceSupport>


### PR DESCRIPTION
Contributes to #5831.

## Changes

Add end-to-end/integration tests for logs, metrics and traces using the OTel SDK with Blazor WASM.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
