### PR TITLE
[Infra] Wait for NuGet packages to be published

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -23,6 +23,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: false
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+  DOTNET_NOLOGO: true
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  FORCE_COLOR: 3
+  TERM: xterm
+
 jobs:
   automation:
     uses: ./.github/workflows/automation.yml
@@ -34,6 +42,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     needs: automation
+
+    outputs:
+      dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
 
     permissions:
       id-token: write # Publish NuGet packages with trusted GitHub OIDC
@@ -68,6 +79,7 @@ jobs:
 
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+      id: setup-dotnet
 
     - name: NuGet log in
       uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
@@ -103,6 +115,9 @@ jobs:
 
     needs:
     - automation
+
+    outputs:
+      pr-number: ${{ steps.post-notice.outputs.pr-number }}
 
     if: |
       needs.automation.outputs.enabled &&
@@ -155,6 +170,7 @@ jobs:
           -gitUserEmail ${env:BOT_USER_EMAIL}
 
     - name: Post notice when release is published
+      id: post-notice
       shell: pwsh
       env:
         GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
@@ -164,8 +180,85 @@ jobs:
       run: |
         Import-Module .\build\scripts\post-release.psm1
 
-        TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
+        $prNumber = TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
           -gitRepository ${env:GITHUB_REPOSITORY} `
           -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME} `
           -expectedCommentAuthorUserName ${env:EXPECTED_COMMENT_AUTHOR_USER_NAME} `
           -tag ${env:TAG}
+
+        "pr-number=${prNumber}" >> ${env:GITHUB_OUTPUT}
+
+  wait-nuget:
+    name: Wait for NuGet package publishing
+    needs: [automation, push-packages-and-publish-release, post-release-published]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    if: needs.post-release-published.outputs.pr-number != ''
+
+    permissions:
+      contents: read # Download the published artifacts
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: ${{ needs.push-packages-and-publish-release.outputs.dotnet-sdk-version }}
+
+      - name: Install WaitForNuGetPackage tool
+        shell: pwsh
+        env:
+          # renovate: datasource=nuget depName=MartinCostello.WaitForNuGetPackage
+          WAIT_FOR_NUGET_PACKAGE_VERSION: '1.3.2'
+        run: |
+          dotnet tool install --global MartinCostello.WaitForNuGetPackage --version ${env:WAIT_FOR_NUGET_PACKAGE_VERSION} --allow-roll-forward
+
+      - name: Download NuGet packages
+        id: download-packages
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          $downloadDirectory = Join-Path ${env:GITHUB_WORKSPACE} "packages"
+          "download-path=${downloadDirectory}" >> ${env:GITHUB_OUTPUT}
+
+          gh release download ${env:RELEASE_TAG} --pattern "*.nupkg" --dir ${env:downloadDirectory}
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to download NuGet packages from release ${env:RELEASE_TAG}."
+          }
+
+      - name: Wait for NuGet packages to be published
+        id: wait-for-publish
+        shell: pwsh
+        env:
+          PACKAGES_DIRECTORY: ${{ steps.download-packages.outputs.download-path }}
+          PUBLISH_TIMEOUT: '00:45:00'
+        run: |
+          dotnet wait-for-package --directory ${env:PACKAGES_DIRECTORY} --timeout ${env:PUBLISH_TIMEOUT}
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::warning::Failed to wait for NuGet packages to be published and indexed."
+            exit 0
+          }
+
+          "published=true" >> ${env:GITHUB_OUTPUT}
+
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_DOTNET_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_DOTNET_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Post comment on release PR
+        if: steps.wait-for-publish.outputs.published == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          PR_NUMBER: ${{ needs.post-release-published.outputs.pr-number }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_URL: ${{ format('{0}/{1}/releases/tag/{2}', github.server_url, github.repository, github.ref_name) }}
+        run: |
+          gh pr comment ${env:PR_NUMBER} --body "The packages for the [${env:RELEASE_TAG}](${env:RELEASE_URL}) release are now available from NuGet.org :package:" --repo ${env:GITHUB_REPOSITORY}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -217,12 +217,12 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           $downloadDirectory = Join-Path ${env:GITHUB_WORKSPACE} "packages"
           "download-path=${downloadDirectory}" >> ${env:GITHUB_OUTPUT}
 
-          gh release download ${env:RELEASE_TAG} --pattern "*.nupkg" --dir ${env:downloadDirectory}
+          gh release download ${env:RELEASE_TAG} --pattern "*.nupkg" --dir ${downloadDirectory}
 
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to download NuGet packages from release ${env:RELEASE_TAG}."
@@ -258,7 +258,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           PR_NUMBER: ${{ needs.post-release-published.outputs.pr-number }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
           RELEASE_URL: ${{ format('{0}/{1}/releases/tag/{2}', github.server_url, github.repository, github.ref_name) }}
         run: |
           gh pr comment ${env:PR_NUMBER} --body "The packages for the [${env:RELEASE_TAG}](${env:RELEASE_URL}) release are now available from NuGet.org :package:" --repo ${env:GITHUB_REPOSITORY}

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -570,7 +570,7 @@ function TryPostReleasePublishedNoticeOnPrepareReleasePullRequest {
   if ($prListResponse.Length -eq 0)
   {
     Write-Information 'No prepare release PR found for tag & commit skipping post notice'
-    return
+    return $null
   }
 
   foreach ($pr in $prListResponse)
@@ -604,11 +604,12 @@ Have a nice day!
 
     $pullRequestNumber = $pr.number
 
-    gh pr comment $pullRequestNumber --body $body
-    return
+    gh pr comment $pullRequestNumber --body $body | Out-Null
+    return $pullRequestNumber
   }
 
   Write-Information 'No prepare release PR found matched author and title with a valid comment'
+  return $null
 }
 
 Export-ModuleMember -Function TryPostReleasePublishedNoticeOnPrepareReleasePullRequest

--- a/build/scripts/tests/post-release.Tests.ps1
+++ b/build/scripts/tests/post-release.Tests.ps1
@@ -190,7 +190,7 @@ Describe "InvokeCoreVersionUpdateWorkflowInRemoteRepository" {
 
 Describe "TryPostReleasePublishedNoticeOnPrepareReleasePullRequest" {
 
-    It "posts a published notice on the matching prepare release pull request" {
+    It "posts a published notice on the matching prepare release pull request and returns its number" {
         Mock -CommandName "git" -ModuleName "post-release" -MockWith {
             $global:LASTEXITCODE = 0
             return "abc123"
@@ -199,21 +199,27 @@ Describe "TryPostReleasePublishedNoticeOnPrepareReleasePullRequest" {
             if ($args -contains "list") {
                 return '[{"number":42,"author":{"login":"otelbot"},"title":"[release] Prepare release core-1.2.3","comments":[{"author":{"login":"otelbot-comment"},"body":"The packages for [core-1.2.3](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.3) are now available: [Download](https://example.com)."}]}]'
             }
+            if ($args -contains "comment") {
+                return "https://github.com/open-telemetry/opentelemetry-dotnet/pull/42#issuecomment-1"
+            }
             return $null
         }
 
-        TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
+        $result = TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
             -gitRepository "open-telemetry/opentelemetry-dotnet" `
             -expectedPrAuthorUserName "otelbot" `
             -expectedCommentAuthorUserName "otelbot-comment" `
             -tag "core-1.2.3" 6>$null
+
+        @($result).Count | Should-Be 1 -Because "the GitHub CLI output must be piped to Out-Null so it does not leak into the return value"
+        $result | Should-Be 42 -Because "the function should return the number of the pull request the notice was posted on"
 
         Should-Invoke -CommandName "gh" -ModuleName "post-release" -Exactly -Times 1 -ParameterFilter {
             $args -contains "comment" -and (($args -join " ") -match "has been published")
         } -Because "a published notice should be posted on the matching prepare release PR"
     }
 
-    It "does nothing when no prepare release pull request is found" {
+    It "does nothing and returns null when no prepare release pull request is found" {
         Mock -CommandName "git" -ModuleName "post-release" -MockWith {
             $global:LASTEXITCODE = 0
             return "abc123"
@@ -223,18 +229,20 @@ Describe "TryPostReleasePublishedNoticeOnPrepareReleasePullRequest" {
             return $null
         }
 
-        TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
+        $result = TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
             -gitRepository "open-telemetry/opentelemetry-dotnet" `
             -expectedPrAuthorUserName "otelbot" `
             -expectedCommentAuthorUserName "otelbot-comment" `
             -tag "core-1.2.3" 6>$null
+
+        $result | Should-BeNull -Because "the function should return null when the search finds no pull requests"
 
         Should-NotInvoke -CommandName "gh" -ModuleName "post-release" -ParameterFilter {
             $args -contains "comment"
         } -Because "no notice should be posted when there is no matching pull request"
     }
 
-    It "does nothing when the matching pull request has no packages-ready comment" {
+    It "does nothing and returns null when the matching pull request has no packages-ready comment" {
         Mock -CommandName "git" -ModuleName "post-release" -MockWith {
             $global:LASTEXITCODE = 0
             return "abc123"
@@ -246,11 +254,13 @@ Describe "TryPostReleasePublishedNoticeOnPrepareReleasePullRequest" {
             return $null
         }
 
-        TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
+        $result = TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
             -gitRepository "open-telemetry/opentelemetry-dotnet" `
             -expectedPrAuthorUserName "otelbot" `
             -expectedCommentAuthorUserName "otelbot-comment" `
             -tag "core-1.2.3" 6>$null
+
+        $result | Should-BeNull -Because "the function should return null when no matching pull request has a packages-ready comment"
 
         Should-NotInvoke -CommandName "gh" -ModuleName "post-release" -ParameterFilter {
             $args -contains "comment"


### PR DESCRIPTION
Based on https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4728 (plus https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4737)

## Changes

Wait for NuGet packages to be published/indexed in NuGet.org and post a comment to the release PR once they are available for download using [this tool I built](https://github.com/martincostello/wait-for-nuget-package?tab=readme-ov-file).

The experience looks something [like this](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/actions/runs/27961760256/job/82744884162#step:6:25) and [this](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/actions/runs/27961760256#summary-82744884162).

Alternatively (or later in a follow-up) we could change the workflow to instead:

1. Publish the packages to NuGet.org
2. Wait for the packages to publish (or timeout due to publishing delays)
3. Open the post-release PR

That would avoid the _"PR fails, re-run when packages actually available"_ process we have today.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
