### PR TITLE
[Exporter.Prometheus] Fix stack overflow

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -68,6 +68,9 @@ Notes](../../RELEASENOTES.md).
   OpenTelemetry metric and label names are translated into Prometheus names.
   ([#7507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7507))
 
+* Fix stack overflow during metric collection when under load.
+  ([#7524](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7524))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -70,6 +70,9 @@ Notes](../../RELEASENOTES.md).
   OpenTelemetry metric and label names are translated into Prometheus names.
   ([#7507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7507))
 
+* Fix stack overflow during metric collection when under load.
+  ([#7524](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7524))
+
 ## 1.16.0-beta.1
 
 Released 2026-Jun-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -75,7 +75,7 @@ internal sealed class PrometheusCollectionManager
 #endif
         }
 
-        return this.WaitForCollectionResponseAsync(protocol, step.PendingCollectionTask, step.ProtocolWasRegistered);
+        return this.WaitForCollectionResponseAsync(protocol, step.PendingCollectionTask, step.JoinedActiveCollection);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -259,22 +259,22 @@ internal sealed class PrometheusCollectionManager
     }
 
 #if NET
-    private async ValueTask<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
+    private async ValueTask<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool joinedActiveCollection)
 #else
-    private async Task<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
+    private async Task<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool joinedActiveCollection)
 #endif
     {
         for (var attempt = 0; attempt < MaxCollectAttempts; attempt++)
         {
             var collectionResult = await pendingCollectionTask.ConfigureAwait(false);
 
-            if (protocolWasRegistered &&
+            if (joinedActiveCollection &&
                 collectionResult.TryGetResponse(protocol, out var response))
             {
                 return response;
             }
 
-            if (protocolWasRegistered)
+            if (joinedActiveCollection)
             {
                 this.ExitCollect(protocol);
             }
@@ -293,13 +293,19 @@ internal sealed class PrometheusCollectionManager
             }
 
             pendingCollectionTask = step.PendingCollectionTask;
-            protocolWasRegistered = step.ProtocolWasRegistered;
+            joinedActiveCollection = step.JoinedActiveCollection;
         }
 
         // The retry budget was exhausted while contending with concurrent scrapes;
         // give up on this pending collection and degrade to a failed (empty)
         // response instead of awaiting/retrying indefinitely.
-        if (!protocolWasRegistered)
+        //
+        // Leave exactly one reader slot outstanding for the caller's ExitCollect to
+        // release: when the last step joined the active collection, TryEnterCollect
+        // already took that slot, so take one only otherwise - taking a second here
+        // would leak, taking none would drive the count negative and hang every
+        // later scrape.
+        if (!joinedActiveCollection)
         {
             this.IncrementReaderCount(protocol);
         }
@@ -750,11 +756,11 @@ internal sealed class PrometheusCollectionManager
 
     private readonly struct CollectStep
     {
-        private CollectStep(CollectionResponse response, Task<CollectionResult>? pendingCollectionTask, bool protocolWasRegistered)
+        private CollectStep(CollectionResponse response, Task<CollectionResult>? pendingCollectionTask, bool joinedActiveCollection)
         {
             this.Response = response;
             this.PendingCollectionTask = pendingCollectionTask;
-            this.ProtocolWasRegistered = protocolWasRegistered;
+            this.JoinedActiveCollection = joinedActiveCollection;
         }
 
         // A non-null task means the caller must await the in-flight collection;
@@ -763,13 +769,17 @@ internal sealed class PrometheusCollectionManager
 
         public CollectionResponse Response { get; }
 
-        public bool ProtocolWasRegistered { get; }
+        // True when this scrape registered the protocol with the in-flight
+        // collection and took a reader slot for it (so the awaiting caller owns a
+        // reader count that must be released), false when it is only observing a
+        // collection it could not join.
+        public bool JoinedActiveCollection { get; }
 
         public static CollectStep Completed(CollectionResponse response)
-            => new(response, pendingCollectionTask: null, protocolWasRegistered: false);
+            => new(response, pendingCollectionTask: null, joinedActiveCollection: false);
 
-        public static CollectStep Pending(Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
-            => new(default, pendingCollectionTask, protocolWasRegistered);
+        public static CollectStep Pending(Task<CollectionResult> pendingCollectionTask, bool joinedActiveCollection)
+            => new(default, pendingCollectionTask, joinedActiveCollection);
     }
 
     private readonly struct CollectionResult

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -222,6 +222,8 @@ internal sealed class PrometheusCollectionManager
             // scrapes. Degrade to a failed (empty) response rather than spinning
             // forever - this mirrors how an unsuccessful collection is reported.
             this.IncrementReaderCount(protocol);
+            PrometheusExporterEventSource.Log.CollectFailed();
+
             return CollectStep.Completed(default);
         }
 
@@ -308,6 +310,7 @@ internal sealed class PrometheusCollectionManager
         if (!joinedActiveCollection)
         {
             this.IncrementReaderCount(protocol);
+            PrometheusExporterEventSource.Log.CollectFailed();
         }
 
         return default;

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -13,6 +13,14 @@ internal sealed class PrometheusCollectionManager
 {
     private const int MaxCachedMetrics = 1024;
 
+    // Upper bound on how many times entering a collection will retry while
+    // resolving races with concurrent scrapes (a collection completing, active
+    // readers draining, or a shared collection that did not serve this protocol).
+    // In practice only a couple of iterations ever run; the cap exists purely so
+    // a pathological interleaving of concurrent scrapes cannot starve one into
+    // looping forever.
+    private const int MaxCollectAttempts = 1024;
+
     private readonly ConcurrentDictionary<PrometheusProtocol, PrometheusProtocolState> protocolStates = new();
 
     private readonly PrometheusExporter exporter;
@@ -56,12 +64,43 @@ internal sealed class PrometheusCollectionManager
     public Task<CollectionResponse> EnterCollect(in PrometheusProtocol protocol)
 #endif
     {
+        var step = this.TryEnterCollect(protocol);
+
+        if (step.PendingCollectionTask is null)
+        {
+#if NET
+            return new ValueTask<CollectionResponse>(step.Response);
+#else
+            return Task.FromResult(step.Response);
+#endif
+        }
+
+        return this.WaitForCollectionResponseAsync(protocol, step.PendingCollectionTask, step.ProtocolWasRegistered);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ExitCollect(in PrometheusProtocol protocol)
+        => this.GetProtocolState(protocol).DecrementReaderCount();
+
+    /// <summary>
+    /// Performs a single synchronous attempt to enter a collection. Returns a
+    /// completed response when one is immediately available (served from the
+    /// cache, or produced by a collection executed on this thread), otherwise
+    /// returns the in-flight collection task the caller must await.
+    /// </summary>
+    /// <param name="protocol">The protocol for which the collection is being attempted.</param>
+    /// <returns>
+    /// The <see cref="CollectStep"/> result of the attempt.
+    /// </returns>
+    private CollectStep TryEnterCollect(in PrometheusProtocol protocol)
+    {
         CollectionResponse? cachedResponse = null;
         Task<CollectionResult>? pendingCollectionTask = null;
         CollectionContext? activeCollectionContext = null;
         var joinedActiveCollection = false;
+        var resolved = false;
 
-        while (true)
+        for (var attempt = 0; attempt < MaxCollectAttempts; attempt++)
         {
             pendingCollectionTask = null;
             joinedActiveCollection = false;
@@ -77,6 +116,7 @@ internal sealed class PrometheusCollectionManager
                 {
                     cachedResponse = response;
                     this.IncrementReaderCount(protocol);
+                    resolved = true;
                     break;
                 }
 
@@ -88,6 +128,7 @@ internal sealed class PrometheusCollectionManager
                     if (joinedActiveCollection)
                     {
                         this.IncrementReaderCount(protocol);
+                        resolved = true;
                         break;
                     }
 
@@ -103,6 +144,7 @@ internal sealed class PrometheusCollectionManager
                     }
                     else
                     {
+                        resolved = true;
                         break;
                     }
                 }
@@ -130,6 +172,7 @@ internal sealed class PrometheusCollectionManager
                 {
                     cachedResponse = response;
                     this.IncrementReaderCount(protocol);
+                    resolved = true;
                     break;
                 }
 
@@ -141,6 +184,7 @@ internal sealed class PrometheusCollectionManager
                     if (joinedActiveCollection)
                     {
                         this.IncrementReaderCount(protocol);
+                        resolved = true;
                         break;
                     }
 
@@ -151,9 +195,11 @@ internal sealed class PrometheusCollectionManager
                             this.collectionContext = null;
                         }
 
+                        pendingCollectionTask = null;
                         continue;
                     }
 
+                    resolved = true;
                     break;
                 }
 
@@ -161,6 +207,7 @@ internal sealed class PrometheusCollectionManager
                 this.collectionContext = activeCollectionContext;
 
                 this.IncrementReaderCount(protocol);
+                resolved = true;
                 break;
             }
             finally
@@ -169,22 +216,23 @@ internal sealed class PrometheusCollectionManager
             }
         }
 
+        if (!resolved)
+        {
+            // The attempt budget was exhausted while contending with concurrent
+            // scrapes. Degrade to a failed (empty) response rather than spinning
+            // forever - this mirrors how an unsuccessful collection is reported.
+            this.IncrementReaderCount(protocol);
+            return CollectStep.Completed(default);
+        }
+
         if (cachedResponse is { } collectionResponse)
         {
-#if NET
-            return new ValueTask<CollectionResponse>(collectionResponse);
-#else
-            return Task.FromResult(collectionResponse);
-#endif
+            return CollectStep.Completed(collectionResponse);
         }
 
         if (pendingCollectionTask is not null)
         {
-#if NET
-            return this.WaitForCollectionResponseAsync(protocol, pendingCollectionTask, joinedActiveCollection);
-#else
-            return this.WaitForCollectionResponseAsync(protocol, pendingCollectionTask, joinedActiveCollection);
-#endif
+            return CollectStep.Pending(pendingCollectionTask, joinedActiveCollection);
         }
 
         var result = this.ExecuteCollect(activeCollectionContext!);
@@ -205,25 +253,10 @@ internal sealed class PrometheusCollectionManager
             this.ExitGlobalLock();
         }
 
-        if (result.TryGetResponse(protocol, out collectionResponse))
-        {
-#if NET
-            return new ValueTask<CollectionResponse>(collectionResponse);
-#else
-            return Task.FromResult(collectionResponse);
-#endif
-        }
-
-#if NET
-        return new ValueTask<CollectionResponse>(default(CollectionResponse));
-#else
-        return Task.FromResult(default(CollectionResponse));
-#endif
+        return result.TryGetResponse(protocol, out var collectedResponse)
+            ? CollectStep.Completed(collectedResponse)
+            : CollectStep.Completed(default);
     }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void ExitCollect(in PrometheusProtocol protocol)
-        => this.GetProtocolState(protocol).DecrementReaderCount();
 
 #if NET
     private async ValueTask<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
@@ -231,20 +264,47 @@ internal sealed class PrometheusCollectionManager
     private async Task<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
 #endif
     {
-        var collectionResult = await pendingCollectionTask.ConfigureAwait(false);
-
-        if (protocolWasRegistered &&
-            collectionResult.TryGetResponse(protocol, out var response))
+        for (var attempt = 0; attempt < MaxCollectAttempts; attempt++)
         {
-            return response;
+            var collectionResult = await pendingCollectionTask.ConfigureAwait(false);
+
+            if (protocolWasRegistered &&
+                collectionResult.TryGetResponse(protocol, out var response))
+            {
+                return response;
+            }
+
+            if (protocolWasRegistered)
+            {
+                this.ExitCollect(protocol);
+            }
+
+            // The shared collection did not produce a response for this protocol,
+            // so make another attempt. Loop here (bounded by MaxCollectAttempts)
+            // rather than recursing back into EnterCollect: when the awaited
+            // collection completes synchronously the continuation runs inline,
+            // so a recursive retry would grow the stack on every iteration
+            // and eventually overflow under contention.
+            var step = this.TryEnterCollect(protocol);
+
+            if (step.PendingCollectionTask is null)
+            {
+                return step.Response;
+            }
+
+            pendingCollectionTask = step.PendingCollectionTask;
+            protocolWasRegistered = step.ProtocolWasRegistered;
         }
 
-        if (protocolWasRegistered)
+        // The retry budget was exhausted while contending with concurrent scrapes;
+        // give up on this pending collection and degrade to a failed (empty)
+        // response instead of awaiting/retrying indefinitely.
+        if (!protocolWasRegistered)
         {
-            this.ExitCollect(protocol);
+            this.IncrementReaderCount(protocol);
         }
 
-        return await this.EnterCollect(protocol).ConfigureAwait(false);
+        return default;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -686,6 +746,30 @@ internal sealed class PrometheusCollectionManager
         /// and a failed collection that produced no response.
         /// </remarks>
         public readonly bool Succeeded { get; }
+    }
+
+    private readonly struct CollectStep
+    {
+        private CollectStep(CollectionResponse response, Task<CollectionResult>? pendingCollectionTask, bool protocolWasRegistered)
+        {
+            this.Response = response;
+            this.PendingCollectionTask = pendingCollectionTask;
+            this.ProtocolWasRegistered = protocolWasRegistered;
+        }
+
+        // A non-null task means the caller must await the in-flight collection;
+        // a null task means Response already holds the answer.
+        public Task<CollectionResult>? PendingCollectionTask { get; }
+
+        public CollectionResponse Response { get; }
+
+        public bool ProtocolWasRegistered { get; }
+
+        public static CollectStep Completed(CollectionResponse response)
+            => new(response, pendingCollectionTask: null, protocolWasRegistered: false);
+
+        public static CollectStep Pending(Task<CollectionResult> pendingCollectionTask, bool protocolWasRegistered)
+            => new(default, pendingCollectionTask, protocolWasRegistered);
     }
 
     private readonly struct CollectionResult

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
@@ -107,4 +107,8 @@ internal sealed class PrometheusExporterEventSource : EventSource, IConfiguratio
     [Event(11, Message = "Failed to collect metrics for a scrape request; the response may have exceeded the configured maximum size.", Level = EventLevel.Error)]
     public void ScrapeFailed()
         => this.WriteEvent(11);
+
+    [Event(12, Message = "Failed to collect metrics for a scrape request; the scrape endpoint may be under heavy load.", Level = EventLevel.Error)]
+    public void CollectFailed()
+        => this.WriteEvent(12);
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -528,7 +528,9 @@ public sealed class PrometheusCollectionManagerTests
 
         var protocol = GetProtocol(openMetricsRequested: false);
 
-        var workerCount = Math.Max(Environment.ProcessorCount * 2, 8);
+        // Enough concurrency to reliably drive the contended retry path, but capped so the
+        // test does not spawn an unreasonable number of hot tasks on high-core CI agents.
+        var workerCount = Math.Min(Math.Max(Environment.ProcessorCount * 2, 8), 32);
 
         async Task ScrapeUntilStoppedAsync()
         {
@@ -536,10 +538,16 @@ public sealed class PrometheusCollectionManagerTests
             {
                 cts.Token.ThrowIfCancellationRequested();
 
-                // The collection fails, so the response is empty; we only care that
-                // the (possibly heavily retried) call returns without overflowing.
-                _ = await EnterCollectAsync(exporter, protocol);
-                exporter.CollectionManager.ExitCollect(protocol);
+                var response = await EnterCollectAsync(exporter, protocol);
+
+                try
+                {
+                    Assert.False(response.Succeeded, "Expected the forced-failure collection to report failure.");
+                }
+                finally
+                {
+                    exporter.CollectionManager.ExitCollect(protocol);
+                }
             }
         }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -495,6 +495,70 @@ public sealed class PrometheusCollectionManagerTests
     }
 
     [Fact]
+    public async Task EnterCollectRetryPathDoesNotOverflowStackUnderContention()
+    {
+        var testTimeout = TimeSpan.FromMinutes(2);
+        using var cts = new CancellationTokenSource(testTimeout);
+        using var stopScraping = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        using var meter = CreateMeter();
+#if PROMETHEUS_HTTP_LISTENER
+        using var provider = CreateMeterProviderWithRandomPort(meter);
+#elif PROMETHEUS_ASPNETCORE
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 0)
+            .Build();
+#endif
+
+#pragma warning disable CA2000 // MeterProvider owns exporter lifecycle
+        if (!provider.TryFindExporter(out PrometheusExporter? exporter))
+#pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
+        {
+            throw new InvalidOperationException("PrometheusExporter could not be found on MeterProvider.");
+        }
+
+        meter.CreateCounter<int>("counter_int").Add(100);
+
+        // Make every collection fail immediately, without invoking the real collect
+        // pipeline. A failed collection produces no response for any waiting scrape,
+        // so joiners are always unsatisfied and must retry, and because it returns
+        // synchronously the awaited collection is already complete when the retry resumes.
+        exporter.Collect = _ => false;
+
+        var protocol = GetProtocol(openMetricsRequested: false);
+
+        var workerCount = Math.Max(Environment.ProcessorCount * 2, 8);
+
+        async Task ScrapeUntilStoppedAsync()
+        {
+            while (!stopScraping.IsCancellationRequested)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+
+                // The collection fails, so the response is empty; we only care that
+                // the (possibly heavily retried) call returns without overflowing.
+                _ = await EnterCollectAsync(exporter, protocol);
+                exporter.CollectionManager.ExitCollect(protocol);
+            }
+        }
+
+        var workers = new Task[workerCount];
+        for (var i = 0; i < workers.Length; i++)
+        {
+            workers[i] = Task.Run(ScrapeUntilStoppedAsync, cts.Token);
+        }
+
+        var all = Task.WhenAll(workers);
+        var completion = await Task.WhenAny(all, Task.Delay(testTimeout, cts.Token));
+
+        Assert.Same(all, completion);
+
+        // Observe any faults from the workers.
+        await all;
+    }
+
+    [Fact]
     public async Task EnterCollectSharesFailedSerializationResult()
     {
         using var meter = CreateMeter();


### PR DESCRIPTION
## Changes

Fix [stack overflow](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/29414046552/job/87347736141?pr=6899#step:7:96) caused by recursion if `EnterCollect()` failed and then completed synchronously introduced by refactoring in #7371.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
