### PR TITLE
[OTLP] Respect configured options in UseOtlpExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilder.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilder.cs
@@ -175,6 +175,7 @@ internal sealed class OtlpExporterBuilder
 
         services.RegisterOptionsFactory((sp, configuration, name) => new OtlpExporterBuilderOptions(
             configuration,
+            sp.GetRequiredService<IOptionsMonitor<OtlpExporterOptions>>().Get(name),
             /* Note: We don't use name for SdkLimitOptions. There should only be
             one provider for a given service collection so SdkLimitOptions is
             treated as a single default instance. */

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilderOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilderOptions.cs
@@ -25,6 +25,7 @@ internal sealed class OtlpExporterBuilderOptions
 
     internal OtlpExporterBuilderOptions(
         IConfiguration configuration,
+        OtlpExporterOptions defaultOptions,
         SdkLimitOptions sdkLimitOptions,
         ExperimentalOptions experimentalOptions,
         LogRecordExportProcessorOptions? logRecordExportProcessorOptions,
@@ -32,6 +33,7 @@ internal sealed class OtlpExporterBuilderOptions
         ActivityExportProcessorOptions? activityExportProcessorOptions)
     {
         Debug.Assert(configuration != null, "configuration was null");
+        Debug.Assert(defaultOptions != null, "defaultOptions was null");
         Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
         Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
 
@@ -43,7 +45,7 @@ internal sealed class OtlpExporterBuilderOptions
 
         var defaultBatchOptions = this.ActivityExportProcessorOptions!.BatchExportProcessorOptions;
 
-        this.DefaultOptionsInstance = new OtlpExporterOptions(configuration!, OtlpExporterOptionsConfigurationType.Default, defaultBatchOptions);
+        this.DefaultOptionsInstance = defaultOptions!;
 
         this.LoggingOptionsInstance = new OtlpExporterOptions(configuration!, OtlpExporterOptionsConfigurationType.Logs, defaultBatchOptions);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed `UseOtlpExporter` to respect options configured through
+  `services.Configure<OtlpExporterOptions>(...)`.
+  ([#7540](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7540))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
@@ -49,6 +49,30 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
         Assert.False(((OtlpExporterOptions)exporterOptions.TracingOptions).HasData);
     }
 
+    [Fact]
+    public void UseOtlpExporterRespectsConfiguredOtlpExporterOptionsTest()
+    {
+        var services = new ServiceCollection();
+        var configuredEndpoint = new Uri("http://configured_endpoint/");
+
+        services.Configure<OtlpExporterOptions>(options => options.Endpoint = configuredEndpoint);
+        services.AddOpenTelemetry()
+            .UseOtlpExporter();
+
+        using var sp = services.BuildServiceProvider();
+
+        Assert.NotNull(sp.GetRequiredService<LoggerProvider>());
+        Assert.NotNull(sp.GetRequiredService<MeterProvider>());
+        Assert.NotNull(sp.GetRequiredService<TracerProvider>());
+
+        var exporterOptions = sp.GetRequiredService<IOptionsMonitor<OtlpExporterBuilderOptions>>().CurrentValue;
+
+        Assert.Equal(configuredEndpoint, exporterOptions.DefaultOptions.Endpoint);
+        Assert.Equal(configuredEndpoint, exporterOptions.LoggingOptions.Endpoint);
+        Assert.Equal(configuredEndpoint, exporterOptions.MetricsOptions.Endpoint);
+        Assert.Equal(configuredEndpoint, exporterOptions.TracingOptions.Endpoint);
+    }
+
     [Theory]
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
     [InlineData(OtlpExportProtocol.Grpc)]


### PR DESCRIPTION
Fixes #6231
Design discussion issue #6231

## Changes

I updated `UseOtlpExporter` to resolve its default `OtlpExporterOptions` through the registered options pipeline instead of constructing a separate instance. This makes `services.Configure<OtlpExporterOptions>(...)` apply to the cross-cutting exporter while preserving signal-specific configuration and fallback behavior.

I also added a regression test that builds all three providers and verifies the configured endpoint reaches logging, metrics, and tracing.

## Testing

- `dotnet test test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj --framework net10.0 --no-restore` (698 passed, 3 integration tests skipped)
- `dotnet format test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj --no-restore --verify-no-changes`
- `python3 ./build/scripts/sanitycheck.py`
- `git diff --check origin/main...HEAD`

The full solution matrix, including Windows/.NET Framework targets, is left to CI.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (not applicable; no public API change)
