### PR TITLE
[OpenTelemetry] Fixed dropped self-diagnostics

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,7 +9,7 @@ Notes](../../RELEASENOTES.md).
 * Fixed self-diagnostics log lines being silently dropped when an event message
   or parameter contained enough 3-byte UTF-8 characters to overflow the internal
   buffer estimate. Such content is now truncated.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7543](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7543))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed self-diagnostics log lines being silently dropped when an event message
+  or parameter contained enough 3-byte UTF-8 characters to overflow the internal
+  buffer estimate. Such content is now truncated.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -95,6 +95,53 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
             charCount = estimateOfCharacters;
         }
 
+        // The estimate above assumes at most 2 UTF-8 bytes per UTF-16 code unit.
+        // That holds for ASCII, 2-byte characters, and surrogate pairs (4 bytes
+        // for 2 code units), but a character in U+0800..U+FFFF encodes to 3 bytes
+        // for a single code unit. Without the walk below, Encoding.UTF8.GetBytes
+        // could be asked to write more bytes than the buffer has room for and
+        // throw, which WriteEvent swallows, dropping the entire log line. Reduce
+        // charCount to what actually fits (surrogate pairs are kept intact).
+        var availableBytes = buffer.Length - position - ellipses;
+        var utf8ByteCount = 0;
+        var charactersThatFit = 0;
+
+        while (charactersThatFit < charCount)
+        {
+            var c = str[charactersThatFit];
+            int characterBytes;
+            var step = 1;
+            if (c <= 0x7F)
+            {
+                characterBytes = 1;
+            }
+            else if (c <= 0x7FF)
+            {
+                characterBytes = 2;
+            }
+            else if (char.IsHighSurrogate(c) &&
+                     charactersThatFit + 1 < charCount &&
+                     char.IsLowSurrogate(str[charactersThatFit + 1]))
+            {
+                characterBytes = 4;
+                step = 2;
+            }
+            else
+            {
+                characterBytes = 3;
+            }
+
+            if (utf8ByteCount + characterBytes > availableBytes)
+            {
+                break;
+            }
+
+            utf8ByteCount += characterBytes;
+            charactersThatFit += step;
+        }
+
+        charCount = charactersThatFit;
+
         if (isParameter)
         {
             buffer[position++] = (byte)'{';

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -120,9 +120,13 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
                 characterBytes = 2;
             }
             else if (char.IsHighSurrogate(c) &&
-                     charactersThatFit + 1 < charCount &&
+                     charactersThatFit + 1 < str.Length &&
                      char.IsLowSurrogate(str[charactersThatFit + 1]))
             {
+                // Look ahead into the full string (not just charCount): a pair that
+                // straddles the estimate boundary is either taken whole here (if it
+                // fits) or excluded entirely by the byte check below - never split
+                // into a U+FFFD replacement character.
                 characterBytes = 4;
                 step = 2;
             }

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTests.cs
@@ -15,15 +15,13 @@ public class SelfDiagnosticsEventListenerTests
     private const string Ellipses = "...\n";
     private const string EllipsesWithBrackets = "{...}\n";
 
+    // U+4E2D is a CJK ideograph that encodes to 3 UTF-8 bytes for a single UTF-16
+    // code unit. Declared as an escape sequence to keep the source ASCII-only.
+    private const char ThreeByteChar = '\u4E2D';
+
     [Fact]
     public void SelfDiagnosticsEventListener_constructor_Invalid_Input()
-    {
-        // no configRefresher object
-        Assert.Throws<ArgumentNullException>(() =>
-        {
-            _ = new SelfDiagnosticsEventListener(EventLevel.Error, null!);
-        });
-    }
+        => Assert.Throws<ArgumentNullException>(() => new SelfDiagnosticsEventListener(EventLevel.Error, null!));
 
     [Fact]
     public void SelfDiagnosticsEventListener_EventSourceSetup_LowerSeverity()
@@ -264,6 +262,49 @@ public class SelfDiagnosticsEventListenerTests
         var startPos = buffer.Length - EllipsesWithBrackets.Length + 1;  // Not enough space for "{...}\n".
         var endPos = SelfDiagnosticsEventListener.EncodeInBuffer("abc", true, buffer, startPos);
         Assert.Equal(startPos, endPos);
+    }
+
+    [Fact]
+    public void SelfDiagnosticsEventListener_EncodeInBuffer_ThreeByteUtf8_TruncatesWithoutThrowing()
+    {
+        var buffer = new byte[20];
+        var str = new string(ThreeByteChar, 8); // 8 * 3 = 24 bytes, does not fit in 20.
+
+        var endPos = SelfDiagnosticsEventListener.EncodeInBuffer(str, false, buffer, 0);
+
+        var written = Encoding.UTF8.GetString(buffer, 0, endPos);
+        Assert.StartsWith(ThreeByteChar.ToString(), written, StringComparison.Ordinal);
+        Assert.EndsWith("...", written, StringComparison.Ordinal);
+
+        // The result, plus the '\n' the caller appends, must stay within the buffer.
+        Assert.True(endPos + 1 <= buffer.Length, $"endPos + 1 ({endPos + 1}) must be <= buffer.Length ({buffer.Length})");
+    }
+
+    [Fact]
+    public void SelfDiagnosticsEventListener_EncodeInBuffer_ThreeByteUtf8_IsParameter_TruncatesWithoutThrowing()
+    {
+        var buffer = new byte[20];
+        var str = new string(ThreeByteChar, 8);
+
+        var endPos = SelfDiagnosticsEventListener.EncodeInBuffer(str, true, buffer, 0);
+
+        var written = Encoding.UTF8.GetString(buffer, 0, endPos);
+        Assert.StartsWith("{" + ThreeByteChar, written, StringComparison.Ordinal);
+        Assert.EndsWith("...}", written, StringComparison.Ordinal);
+        Assert.True(endPos + 1 <= buffer.Length);
+    }
+
+    [Fact]
+    public void SelfDiagnosticsEventListener_EncodeInBuffer_ThreeByteUtf8_ThatFits_IsWrittenInFull()
+    {
+        // A short 3-byte-character string that fits must not be truncated.
+        var buffer = new byte[20];
+        var str = new string(ThreeByteChar, 3); // 3 * 3 = 9 bytes, fits.
+
+        var endPos = SelfDiagnosticsEventListener.EncodeInBuffer(str, false, buffer, 0);
+
+        var written = Encoding.UTF8.GetString(buffer, 0, endPos);
+        Assert.Equal(str, written);
     }
 
     private static void AssertFileOutput(string filePath, string eventMessage)

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTests.cs
@@ -19,6 +19,10 @@ public class SelfDiagnosticsEventListenerTests
     // code unit. Declared as an escape sequence to keep the source ASCII-only.
     private const char ThreeByteChar = '\u4E2D';
 
+    // U+1F600 is a surrogate pair (2 UTF-16 code units) that encodes to 4 UTF-8
+    // bytes. Declared as escape sequences to keep the source ASCII-only.
+    private const string FourByteChar = "\uD83D\uDE00";
+
     [Fact]
     public void SelfDiagnosticsEventListener_constructor_Invalid_Input()
         => Assert.Throws<ArgumentNullException>(() => new SelfDiagnosticsEventListener(EventLevel.Error, null!));
@@ -305,6 +309,24 @@ public class SelfDiagnosticsEventListenerTests
 
         var written = Encoding.UTF8.GetString(buffer, 0, endPos);
         Assert.Equal(str, written);
+    }
+
+    [Fact]
+    public void SelfDiagnosticsEventListener_EncodeInBuffer_SurrogatePairAtTruncationBoundary_IsNotSplit()
+    {
+        // With a 19-byte buffer the character estimate lands mid-way through a
+        // surrogate pair. The pair must be dropped whole (not split into a U+FFFD
+        // replacement character): the output should be the whole pairs that fit
+        // followed by "...", and must never contain U+FFFD.
+        var buffer = new byte[19];
+        var str = FourByteChar + FourByteChar + FourByteChar + FourByteChar; // 4 pairs, 16 bytes
+
+        var endPos = SelfDiagnosticsEventListener.EncodeInBuffer(str, false, buffer, 0);
+
+        var written = Encoding.UTF8.GetString(buffer, 0, endPos);
+        Assert.DoesNotContain('\uFFFD', written);
+        Assert.Equal(FourByteChar + FourByteChar + FourByteChar + "...", written);
+        Assert.True(endPos + 1 <= buffer.Length);
     }
 
     private static void AssertFileOutput(string filePath, string eventMessage)


### PR DESCRIPTION
## Changes

Fix self-diagnostic logs being dropped if they contained too many 3-byte characters. Now the content is only truncated.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
