### PR TITLE
[OTLP] Ignore negative retries

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -11,6 +11,11 @@ Notes](../../RELEASENOTES.md).
   `services.Configure<OtlpExporterOptions>(...)`.
   ([#7540](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7540))
 
+* Clamped the server-supplied OTLP/gRPC retry delay (`RetryInfo.retry_delay`) to
+  a non-negative value. A negative delay previously causing the telemetry batch
+  to be dropped.
+  ([#7544](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7544))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,7 +12,7 @@ Notes](../../RELEASENOTES.md).
   ([#7540](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7540))
 
 * Clamped the server-supplied OTLP/gRPC retry delay (`RetryInfo.retry_delay`) to
-  a non-negative value. A negative delay previously causing the telemetry batch
+  a non-negative value. A negative delay previously caused the telemetry batch
   to be dropped.
   ([#7544](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7544))
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/Grpc/GrpcStatusDeserializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/Grpc/GrpcStatusDeserializer.cs
@@ -24,8 +24,14 @@ internal static class GrpcStatusDeserializer
             var retryInfo = ExtractRetryInfo(grpcStatusDetailsHeader);
             if (retryInfo?.RetryDelay != null)
             {
-                return TimeSpan.FromSeconds(retryInfo.Value.RetryDelay.Value.Seconds) +
+                var retryDelay = TimeSpan.FromSeconds(retryInfo.Value.RetryDelay.Value.Seconds) +
                        TimeSpan.FromTicks(retryInfo.Value.RetryDelay.Value.Nanos / 100); // Convert nanos to ticks
+
+                // The retry delay is supplied by the server and cannot be trusted. A
+                // negative value is nonsensical and would otherwise flow into
+                // Thread.Sleep (see OtlpExporterRetryTransmissionHandler) and throw,
+                // dropping the batch. Clamp it to a non-negative duration.
+                return retryDelay < TimeSpan.Zero ? TimeSpan.Zero : retryDelay;
             }
         }
         catch (Exception ex)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
@@ -287,6 +287,34 @@ public class GrpcStatusDeserializerTests
         Assert.Equal(TimeSpan.FromSeconds(5), result);
     }
 
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(0, -1)]
+    [InlineData(-5, -500000000)]
+    public void TryGetGrpcRetryDelay_NegativeDuration_ClampedToZero(long seconds, int nanos)
+    {
+        var status = new Google.Rpc.Status
+        {
+            Code = 8, // ResourceExhausted
+            Message = "Negative retry delay",
+            Details =
+            {
+                Any.Pack(new Google.Rpc.RetryInfo
+                {
+                    RetryDelay = new Duration { Seconds = seconds, Nanos = nanos },
+                }),
+            },
+        };
+
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+
+        var result = GrpcStatusDeserializer.TryGetGrpcRetryDelay(grpcStatusDetailsBin);
+
+        Assert.NotNull(result);
+        Assert.Equal(TimeSpan.Zero, result);
+        Assert.Null(Record.Exception(() => Thread.Sleep(result!.Value)));
+    }
+
     [Fact]
     public void TryGetGrpcRetryDelay_OnlyNanos_ReturnsExpected()
     {
@@ -296,12 +324,12 @@ public class GrpcStatusDeserializerTests
             Code = 4,
             Message = "Only nanos",
             Details =
-        {
-            Any.Pack(new Google.Rpc.RetryInfo
             {
-                RetryDelay = new Duration { Nanos = 500000000 }, // 0.5 seconds
-            }),
-        },
+                Any.Pack(new Google.Rpc.RetryInfo
+                {
+                    RetryDelay = new Duration { Nanos = 500000000 }, // 0.5 seconds
+                }),
+            },
         };
 
         var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
@@ -288,9 +288,9 @@ public class GrpcStatusDeserializerTests
     }
 
     [Theory]
-    [InlineData(-1, 0)]
-    [InlineData(0, -1)]
-    [InlineData(-5, -500000000)]
+    [InlineData(-1, 0)] // -1s
+    [InlineData(0, -1_000_000)] // -1ms, which is also Timeout.InfiniteTimeSpan
+    [InlineData(-5, -500_000_000)] // -5.5s
     public void TryGetGrpcRetryDelay_NegativeDuration_ClampedToZero(long seconds, int nanos)
     {
         var status = new Google.Rpc.Status


### PR DESCRIPTION
## Changes

Clamp negative OTLP retry headers to zero to avoid an exception causing telemetry to be dropped.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
