### PR TITLE
[Propagators] Improve JaegerPropagator

### DIFF
--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -6,6 +6,10 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed inefficient parsing of the Jaeger `uber-trace-id` header when targeting
+  `net462` or`netstandard2.0` build.
+  ([#7545](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7545))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -7,7 +7,7 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Fixed inefficient parsing of the Jaeger `uber-trace-id` header when targeting
-  `net462` or`netstandard2.0` build.
+  `net462` or`netstandard2.0`.
   ([#7545](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7545))
 
 ## 1.17.0

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -7,7 +7,7 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Fixed inefficient parsing of the Jaeger `uber-trace-id` header when targeting
-  `net462` or`netstandard2.0`.
+  `net462` or `netstandard2.0`.
   ([#7545](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7545))
 
 ## 1.17.0

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -277,33 +277,31 @@ public class JaegerPropagator : TextMapPropagator
             scanOffset = delimiterIndex + 1;
         }
 #else
-        var colonIndex = header.IndexOf(JaegerDelimiter, position, StringComparison.Ordinal);
-        var encodedIndex = header.IndexOf(JaegerDelimiterEncoded, position, StringComparison.Ordinal);
-
-        var nextIndex = -1;
-        var delimiterLength = 0;
-
-        if (colonIndex >= 0 && (encodedIndex < 0 || colonIndex < encodedIndex))
+        for (var i = position; i < header.Length; i++)
         {
-            nextIndex = colonIndex;
-            delimiterLength = JaegerDelimiter.Length;
-        }
-        else if (encodedIndex >= 0)
-        {
-            nextIndex = encodedIndex;
-            delimiterLength = JaegerDelimiterEncoded.Length;
-        }
+            var current = header[i];
 
-        if (nextIndex < 0)
-        {
-            var result = header.AsSpan(position);
-            position = header.Length;
-            return result;
+            if (current == ':')
+            {
+                var component = header.AsSpan(position, i - position);
+                position = i + 1;
+                return component;
+            }
+
+            if (current == '%' &&
+                i + JaegerDelimiterEncoded.Length <= header.Length &&
+                header[i + 1] == '3' &&
+                header[i + 2] == 'A')
+            {
+                var component = header.AsSpan(position, i - position);
+                position = i + JaegerDelimiterEncoded.Length;
+                return component;
+            }
         }
 
-        var component = header.AsSpan(position, nextIndex - position);
-        position = nextIndex + delimiterLength;
-        return component;
+        var result = header.AsSpan(position);
+        position = header.Length;
+        return result;
 #endif
     }
 }

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
@@ -264,4 +264,18 @@ public class JaegerPropagatorTests
 
         Assert.Equal(default, result);
     }
+
+    [Theory]
+    [InlineData(JaegerDelimiter)]
+    [InlineData(JaegerDelimiterEncoded)]
+    public void ExtractHeaderOfOnlyDelimitersReturnsDefault(string delimiter)
+    {
+        // A header consisting solely of delimiters yields only empty components.
+        var formattedHeader = string.Concat(Enumerable.Repeat(delimiter, 50_000));
+        var headers = new Dictionary<string, string[]> { [JaegerHeader] = [formattedHeader] };
+
+        var result = new JaegerPropagator().Extract(default, headers, Getter);
+
+        Assert.Equal(default, result);
+    }
 }


### PR DESCRIPTION
## Changes

Fix inefficient parsing of the Jaeger `uber-trace-id` header when targeting `net462` or`netstandard2.0`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
