### PR TITLE
[Exporter.Prometheus] Increase code coverage

### DIFF
--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
@@ -43,4 +43,62 @@ public sealed class PrometheusExporterMeterProviderBuilderExtensionsTests
 
         Assert.Equal(PrometheusTranslationStrategy.NoTranslation, options.ExporterOptions.TranslationStrategy);
     }
+
+    [Fact]
+    public void DisableTotalNameSuffixForCounters_DelegatesToExporterOptions()
+    {
+        var options = new PrometheusAspNetCoreOptions { DisableTotalNameSuffixForCounters = true };
+
+        Assert.True(options.ExporterOptions.DisableTotalNameSuffixForCounters);
+        Assert.True(options.DisableTotalNameSuffixForCounters);
+    }
+
+    [Fact]
+    public void ScopeInfoEnabled_DelegatesToExporterOptions()
+    {
+        var options = new PrometheusAspNetCoreOptions { ScopeInfoEnabled = false };
+
+        Assert.False(options.ExporterOptions.ScopeInfoEnabled);
+        Assert.False(options.ScopeInfoEnabled);
+    }
+
+    [Fact]
+    public void ScrapeResponseCacheDurationMilliseconds_DelegatesToExporterOptions()
+    {
+        var options = new PrometheusAspNetCoreOptions { ScrapeResponseCacheDurationMilliseconds = 42 };
+
+        Assert.Equal(42, options.ExporterOptions.ScrapeResponseCacheDurationMilliseconds);
+        Assert.Equal(42, options.ScrapeResponseCacheDurationMilliseconds);
+    }
+
+    [Fact]
+    public void TargetInfoEnabled_DelegatesToExporterOptions()
+    {
+        var options = new PrometheusAspNetCoreOptions { TargetInfoEnabled = false };
+
+        Assert.False(options.ExporterOptions.TargetInfoEnabled);
+        Assert.False(options.TargetInfoEnabled);
+    }
+
+    [Fact]
+    public void ResourceConstantLabels_DelegatesToExporterOptions()
+    {
+        Func<string, bool> predicate = static _ => true;
+
+        var options = new PrometheusAspNetCoreOptions { ResourceConstantLabels = predicate };
+
+        Assert.Same(predicate, options.ExporterOptions.ResourceConstantLabels);
+        Assert.Same(predicate, options.ResourceConstantLabels);
+    }
+
+    [Fact]
+    public void MaxScrapeResponseSizeBytes_DelegatesToExporterOptions()
+    {
+        const int Value = PrometheusExporterOptions.InitialScrapeResponseSizeBytes * 4;
+
+        var options = new PrometheusAspNetCoreOptions { MaxScrapeResponseSizeBytes = Value };
+
+        Assert.Equal(Value, options.ExporterOptions.MaxScrapeResponseSizeBytes);
+        Assert.Equal(Value, options.MaxScrapeResponseSizeBytes);
+    }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/EventSourceTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/EventSourceTests.cs
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
@@ -10,4 +13,77 @@ public class EventSourceTests
     [Fact]
     public void EventSourceTests_PrometheusExporterEventSource() =>
         EventSourceTestHelper.ValidateEventSourceIds<PrometheusExporterEventSource>();
+
+    [Fact]
+    public void EventSource_EmitsEventsWhenInvoked()
+    {
+        using var listener = new TestEventListener();
+        listener.EnableEvents(PrometheusExporterEventSource.Log, EventLevel.Verbose, EventKeywords.All);
+
+        var log = PrometheusExporterEventSource.Log;
+        var exception = new InvalidOperationException("Something went wrong.");
+
+        log.FailedExport(exception);
+        log.CanceledExport(exception);
+        log.FailedShutdown(exception);
+        log.ConflictingType("test_metric", PrometheusType.Counter, PrometheusType.Gauge);
+        log.ConflictingHelp("test_metric", "First help.", "Second help.");
+        log.ConflictingUnit("test_metric", "bytes", "seconds");
+        log.CollectFailed();
+
+        var events = listener.Messages;
+
+        Assert.Contains(events, e => e.EventId == 1); // FailedExport
+        Assert.Contains(events, e => e.EventId == 2); // CanceledExport
+        Assert.Contains(events, e => e.EventId == 3); // FailedShutdown
+        Assert.Contains(events, e => e.EventId == 12); // CollectFailed
+
+        var conflictingType = Assert.Single(events, e => e.EventId == 6);
+        Assert.NotNull(conflictingType.Payload);
+        Assert.Equal("test_metric", conflictingType.Payload[0]);
+        Assert.Equal(nameof(PrometheusType.Counter), conflictingType.Payload[1]);
+        Assert.Equal(nameof(PrometheusType.Gauge), conflictingType.Payload[2]);
+
+        var conflictingHelp = Assert.Single(events, e => e.EventId == 7);
+        Assert.NotNull(conflictingHelp.Payload);
+        Assert.Equal("test_metric", conflictingHelp.Payload[0]);
+        Assert.Equal("First help.", conflictingHelp.Payload[1]);
+        Assert.Equal("Second help.", conflictingHelp.Payload[2]);
+
+        var conflictingUnit = Assert.Single(events, e => e.EventId == 8);
+        Assert.NotNull(conflictingUnit.Payload);
+        Assert.Equal("test_metric", conflictingUnit.Payload[0]);
+        Assert.Equal("bytes", conflictingUnit.Payload[1]);
+        Assert.Equal("seconds", conflictingUnit.Payload[2]);
+    }
+
+    [Fact]
+    public void EventSource_MetricIgnored_EmitsMetricNameAndType()
+    {
+        using var meter = new Meter(nameof(this.EventSource_MetricIgnored_EmitsMetricNameAndType));
+        var exportedMetrics = new List<Metric>();
+
+        using (var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddView(instrument => new Base2ExponentialBucketHistogramConfiguration())
+            .AddInMemoryExporter(exportedMetrics)
+            .Build())
+        {
+            meter.CreateHistogram<long>("exponential_histogram").Record(1);
+            provider.ForceFlush();
+        }
+
+        var metric = exportedMetrics.First(m => m.MetricType == MetricType.ExponentialHistogram);
+
+        using var listener = new TestEventListener();
+        listener.EnableEvents(PrometheusExporterEventSource.Log, EventLevel.Verbose, EventKeywords.All);
+
+        PrometheusExporterEventSource.Log.MetricIgnored(metric);
+
+        var metricIgnored = Assert.Single(listener.Messages, e => e.EventId == 10);
+
+        Assert.NotNull(metricIgnored.Payload);
+        Assert.Equal("exponential_histogram", metricIgnored.Payload[0]);
+        Assert.Equal(nameof(MetricType.ExponentialHistogram), metricIgnored.Payload[1]);
+    }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests;
 
@@ -179,5 +180,35 @@ public sealed class PrometheusHttpListenerMeterProviderBuilderExtensionsTests
         Assert.True(meterProvider.TryFindExporter(out PrometheusExporter? exporter));
 #pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
         Assert.Equal(123, exporter!.ScrapeResponseCacheDurationMilliseconds);
+    }
+
+    [Fact]
+    public void AddPrometheusHttpListener_WrapsListenerStartFailureInInvalidOperationException()
+    {
+        var port = TcpPortProvider.GetOpenPort();
+
+        using var first = Sdk.CreateMeterProviderBuilder()
+            .AddPrometheusHttpListener(options =>
+            {
+                options.Host = "localhost";
+                options.Port = port;
+            })
+            .Build();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var second = Sdk.CreateMeterProviderBuilder()
+                .AddPrometheusHttpListener(options =>
+                {
+                    options.Host = "localhost";
+                    options.Port = port;
+                })
+                .Build();
+        });
+
+        Assert.Contains(
+            "PrometheusExporter HttpListener could not be started.",
+            exception.ToString(),
+            StringComparison.Ordinal);
     }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -350,6 +350,36 @@ public class PrometheusHttpListenerTests
     }
 
     [Fact]
+    public void StartIsIdempotentWhenAlreadyStarted()
+    {
+        using var context = CreateListener();
+
+        var exception = Record.Exception(() => context.Listener.Start());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ScrapeEndpointPathWithoutLeadingSlashIsNormalized()
+    {
+        using var meter = new Meter(MeterName, MeterVersion);
+
+        using var context = CreateMeterProvider(meter, configureListener: (options) =>
+        {
+            options.Port = GetRandomPort();
+            options.ScrapeEndpointPath = "custom-metrics";
+            return options.Port;
+        });
+
+        meter.CreateCounter<int>("test_counter").Add(1);
+
+        using var client = new HttpClient { BaseAddress = context.BaseAddress };
+        using var response = await client.GetAsync(new Uri("custom-metrics", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public void Host_DefaultValue_Is_Localhost()
         => Assert.Equal("localhost", new PrometheusHttpListenerOptions().Host);
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusTranslationStrategyTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusTranslationStrategyTests.cs
@@ -27,6 +27,7 @@ public sealed class PrometheusTranslationStrategyTests
     [InlineData(PrometheusTranslationStrategy.NoUTF8EscapingWithSuffixes, EscapingScheme.AllowUtf8)]
     [InlineData(PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes, EscapingScheme.Underscores)]
     [InlineData(PrometheusTranslationStrategy.UnderscoreEscapingWithoutSuffixes, EscapingScheme.Underscores)]
+    [InlineData((PrometheusTranslationStrategy)int.MaxValue, EscapingScheme.Underscores)] // Unknown strategy falls back to underscores.
     internal void GetDefaultEscapingScheme_MapsEscapingAxis(PrometheusTranslationStrategy strategy, EscapingScheme expected)
         => Assert.Equal(expected, strategy.GetDefaultEscapingScheme());
 
@@ -35,6 +36,7 @@ public sealed class PrometheusTranslationStrategyTests
     [InlineData(PrometheusTranslationStrategy.NoUTF8EscapingWithSuffixes, true)]
     [InlineData(PrometheusTranslationStrategy.UnderscoreEscapingWithSuffixes, true)]
     [InlineData(PrometheusTranslationStrategy.UnderscoreEscapingWithoutSuffixes, false)]
+    [InlineData((PrometheusTranslationStrategy)int.MaxValue, true)] // Unknown strategy falls back to appending suffixes.
     internal void AppendSuffixes_MapsSuffixAxis(PrometheusTranslationStrategy strategy, bool expected)
         => Assert.Equal(expected, strategy.AppendSuffixes());
 


### PR DESCRIPTION
## Changes

Add some additional code coverage for the Prometheus exporters.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
