### PR TITLE
[OpenTelemetry] Handle duplicate sampler attributes

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -11,6 +11,9 @@ Notes](../../RELEASENOTES.md).
   buffer estimate. Such content is now truncated.
   ([#7543](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7543))
 
+* Fixed activity creation throwing when multiple tracer providers return a
+  sampler attribute with the same key.
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -13,6 +13,7 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed activity creation throwing when multiple tracer providers return a
   sampler attribute with the same key.
+  ([#7558](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7558))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -492,7 +492,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 foreach (var att in attributes)
                 {
-                    options.SamplingTags.Add(att.Key, att.Value);
+                    options.SamplingTags[att.Key] = att.Value;
                 }
             }
         }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTests.cs
@@ -251,6 +251,40 @@ public sealed class TracerProviderSdkTests : IDisposable
     }
 
     [Fact]
+    public void TracerProviderSdkDuplicateSamplerAttributesUseLastValue()
+    {
+        const string attributeKey = "duplicate-sampler-attribute";
+        var firstSampler = new TestSampler
+        {
+            SamplingAction = _ => new SamplingResult(
+                SamplingDecision.RecordAndSample,
+                [new(attributeKey, "first")]),
+        };
+        var secondSampler = new TestSampler
+        {
+            SamplingAction = _ => new SamplingResult(
+                SamplingDecision.RecordAndSample,
+                [new(attributeKey, "second")]),
+        };
+
+        var activitySourceName = Utils.GetCurrentMethodName();
+        using var activitySource = new ActivitySource(activitySourceName);
+        using var firstProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(activitySourceName)
+            .SetSampler(firstSampler)
+            .Build();
+        using var secondProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(activitySourceName)
+            .SetSampler(secondSampler)
+            .Build();
+
+        using var activity = activitySource.StartActivity("root");
+
+        Assert.NotNull(activity);
+        Assert.Equal("second", activity.GetTagItem(attributeKey));
+    }
+
+    [Fact]
     public void TracerSdkSetsActivitySamplingResultAsPropagationWhenParentIsRemote()
     {
         var activitySourceName = Utils.GetCurrentMethodName();


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/58948
Design discussion issue #

## Changes

Replaced `ActivityTagsCollection.Add` with indexer assignment when applying sampler attributes during Activity creation.

This prevents Activity creation from throwing when multiple matching `TracerProvider` instances return an attribute with the same key. The behavior now matches the existing legacy Activity path, which applies sampler attributes using `Activity.SetTag` replacement semantics.

When multiple samplers return different values for the same key, the value from the last invoked listener is retained.

Added a regression test with two providers that return the same attribute key.

## Motivation

OpenTelemetry supports multiple `TracerProvider` instances, and .NET `ActivitySource` invokes every matching `ActivityListener` while creating one Activity. These listeners contribute to the Activity's shared sampling-tag collection.

Previously, the second provider failed while adding a duplicate key:

> System.InvalidOperationException: The collection already contains item with same key 'duplicate-sampler-attribute'

This exception prevents Activity creation and, in ASP.NET Core TestHost, may present as a request timeout.

## Validation

Before the fix, the new regression test failed in `TracerProviderSdk.ComputeActivitySamplingResult`.

After the fix:

- `TracerProviderSdkDuplicateSamplerAttributesUseLastValue` passed.
- Full `TracerProviderSdkTests` class passed: 67 tests.
- Production source formatting verification passed.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
