### PR TITLE
[Exporter.Prometheus] Fix concurrency issue

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -8,6 +8,11 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Fix concurrent scrapes returning an empty response under contention.
+  Now the exporter will return an HTTP 500 error instead.
+  ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
+
+* Waiting for concurrent scrapes to finish before collecting no longer
+  blocks, which could stall concurrent scrapes being waited on.
   ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
 
 ## 1.17.0-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -7,8 +7,7 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Fix concurrent scrapes returning an empty response when they retried after
-  sharing a metric collection which failed.
+* Fix concurrent scrapes returning an empty response under contention.
   ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
 
 ## 1.17.0-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fix concurrent scrapes returning an empty response when they retried after
+  sharing a metric collection which failed.
+  ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
+
 ## 1.17.0-beta.1
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -8,6 +8,11 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Fix concurrent scrapes returning an empty response under contention.
+  Now the exporter will return an HTTP 500 error instead.
+  ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
+
+* Waiting for concurrent scrapes to finish before collecting no longer
+  blocks, which could stall concurrent scrapes being waited on.
   ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
 
 ## 1.17.0-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -7,8 +7,7 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Fix concurrent scrapes returning an empty response when they retried after
-  sharing a metric collection which failed.
+* Fix concurrent scrapes returning an empty response under contention.
   ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
 
 ## 1.17.0-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fix concurrent scrapes returning an empty response when they retried after
+  sharing a metric collection which failed.
+  ([#7571](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7571))
+
 ## 1.17.0-beta.1
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -281,6 +281,14 @@ internal sealed class PrometheusCollectionManager
                 this.ExitCollect(protocol);
             }
 
+            // Retire the collection that just completed. The thread which ran it
+            // publishes the result before clearing collectionContext, so without
+            // this a retry can observe - and re-join - the very same completed
+            // collection (TryRegisterProtocol accepts a protocol that is already
+            // registered, and a collection which failed before exporting never
+            // froze its protocol set) and spin without ever collecting again.
+            this.RetireCollection(pendingCollectionTask);
+
             // The shared collection did not produce a response for this protocol,
             // so make another attempt. Loop here (bounded by MaxCollectAttempts)
             // rather than recursing back into EnterCollect: when the awaited
@@ -314,6 +322,30 @@ internal sealed class PrometheusCollectionManager
         }
 
         return default;
+    }
+
+    /// <summary>
+    /// Clears the active collection if it is still the one which produced
+    /// <paramref name="completedCollectionTask"/>, so that the next attempt to
+    /// enter a collection starts a new one instead of joining a finished one.
+    /// </summary>
+    /// <param name="completedCollectionTask">The task of the collection which has completed.</param>
+    private void RetireCollection(Task<CollectionResult> completedCollectionTask)
+    {
+        this.EnterGlobalLock();
+
+        try
+        {
+            if (this.collectionContext is { } currentCollectionContext &&
+                ReferenceEquals(currentCollectionContext.Task, completedCollectionTask))
+            {
+                this.collectionContext = null;
+            }
+        }
+        finally
+        {
+            this.ExitGlobalLock();
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -66,7 +66,7 @@ internal sealed class PrometheusCollectionManager
     {
         var step = this.TryEnterCollect(protocol);
 
-        if (step.PendingCollectionTask is null)
+        if (step.IsCompleted)
         {
 #if NET
             return new ValueTask<CollectionResponse>(step.Response);
@@ -75,7 +75,7 @@ internal sealed class PrometheusCollectionManager
 #endif
         }
 
-        return this.WaitForCollectionResponseAsync(protocol, step.PendingCollectionTask, step.JoinedActiveCollection);
+        return this.WaitForCollectionResponseAsync(protocol, step);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -159,11 +159,6 @@ internal sealed class PrometheusCollectionManager
                 continue;
             }
 
-            if (this.WaitForReadersToComplete(protocol))
-            {
-                continue;
-            }
-
             this.EnterGlobalLock();
 
             try
@@ -201,6 +196,12 @@ internal sealed class PrometheusCollectionManager
 
                     resolved = true;
                     break;
+                }
+
+                // No collection is in flight, so this scrape has to start one
+                if (this.GetReadersDrainedTask(protocol) is { } readersDrainedTask)
+                {
+                    return CollectStep.WaitingForReaders(readersDrainedTask);
                 }
 
                 activeCollectionContext = new CollectionContext(protocol);
@@ -261,66 +262,72 @@ internal sealed class PrometheusCollectionManager
     }
 
 #if NET
-    private async ValueTask<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool joinedActiveCollection)
+    private async ValueTask<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, CollectStep step)
 #else
-    private async Task<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, Task<CollectionResult> pendingCollectionTask, bool joinedActiveCollection)
+    private async Task<CollectionResponse> WaitForCollectionResponseAsync(PrometheusProtocol protocol, CollectStep step)
 #endif
     {
         for (var attempt = 0; attempt < MaxCollectAttempts; attempt++)
         {
-            var collectionResult = await pendingCollectionTask.ConfigureAwait(false);
-
-            if (joinedActiveCollection)
+            if (step.PendingCollectionTask is { } pendingCollectionTask)
             {
-                // This scrape shared the collection, so the collection's outcome is
-                // this scrape's outcome. When it produced no response for this
-                // protocol it failed, and this scrape reports that failure rather
-                // than collecting again: a retry cannot reuse the collection it just
-                // shared, so it would have to start a new one, which cannot begin
-                // until every active reader of this protocol has drained. Under
-                // concurrent scrapes that wait can spin for an unbounded time while
-                // holding a thread, so retrying here risks starving the scrapes whose
-                // completion it is waiting on.
-                if (!collectionResult.TryGetResponse(protocol, out var response))
-                {
-                    PrometheusExporterEventSource.Log.CollectFailed();
+                var collectionResult = await pendingCollectionTask.ConfigureAwait(false);
 
-                    // The reader slot taken when joining is left outstanding for the
-                    // caller's ExitCollect to release.
-                    return default;
+                if (step.JoinedActiveCollection)
+                {
+                    // This scrape shared the collection, so the collection's outcome is
+                    // this scrape's outcome. When it produced no response for this
+                    // protocol it failed, and this scrape reports that failure rather
+                    // than collecting again: a retry cannot reuse the collection it just
+                    // shared, so it would have to start a new one, and every scrape
+                    // sharing the failure would queue up behind the active readers to do so.
+                    if (!collectionResult.TryGetResponse(protocol, out var response))
+                    {
+                        PrometheusExporterEventSource.Log.CollectFailed();
+
+                        // The reader slot taken when joining is left outstanding for the
+                        // caller's ExitCollect to release.
+                        return default;
+                    }
+
+                    return response;
                 }
 
-                return response;
+                // This scrape never registered with the collection it observed, so that
+                // collection was never going to produce a response for it: make another
+                // attempt. Loop here (bounded by MaxCollectAttempts) rather than
+                // recursing back into EnterCollect: when the awaited collection
+                // completes synchronously the continuation runs inline, so a recursive
+                // retry would grow the stack on every iteration and eventually overflow
+                // under contention.
+            }
+            else if (step.ReadersDrainedTask is { } readersDrainedTask)
+            {
+                // Awaiting the readers releases this thread while they finish. Spinning
+                // until they drain would instead hold it, and holding it can starve the
+                // very scrapes being waited on: each of them needs a thread to resume on
+                // before it can release its reader slot.
+                await readersDrainedTask.ConfigureAwait(false);
             }
 
-            // This scrape never registered with the collection it observed, so that
-            // collection was never going to produce a response for it: make another
-            // attempt. Loop here (bounded by MaxCollectAttempts) rather than recursing
-            // back into EnterCollect: when the awaited collection completes
-            // synchronously the continuation runs inline, so a recursive retry would
-            // grow the stack on every iteration and eventually overflow under
-            // contention.
-            var step = this.TryEnterCollect(protocol);
+            step = this.TryEnterCollect(protocol);
 
-            if (step.PendingCollectionTask is null)
+            if (step.IsCompleted)
             {
                 return step.Response;
             }
-
-            pendingCollectionTask = step.PendingCollectionTask;
-            joinedActiveCollection = step.JoinedActiveCollection;
         }
 
         // The retry budget was exhausted while contending with concurrent scrapes;
-        // give up on this pending collection and degrade to a failed (empty)
-        // response instead of awaiting/retrying indefinitely.
+        // give up and degrade to a failed (empty) response instead of
+        // awaiting/retrying indefinitely.
         //
         // Leave exactly one reader slot outstanding for the caller's ExitCollect to
         // release: when the last step joined the active collection, TryEnterCollect
         // already took that slot, so take one only otherwise - taking a second here
         // would leak, taking none would drive the count negative and hang every
         // later scrape.
-        if (!joinedActiveCollection)
+        if (!step.JoinedActiveCollection)
         {
             this.IncrementReaderCount(protocol);
             PrometheusExporterEventSource.Log.CollectFailed();
@@ -358,38 +365,8 @@ internal sealed class PrometheusCollectionManager
         => this.protocolStates.TryGetValue(protocol, out var state) && state.HasActiveReaders();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool WaitForReadersToComplete(in PrometheusProtocol protocol)
-    {
-        var state = this.GetProtocolState(protocol);
-        var didSpin = false;
-        SpinWait readWait = default;
-        while (true)
-        {
-            if (!state.HasActiveReaders())
-            {
-                break;
-            }
-
-            this.EnterGlobalLock();
-
-            try
-            {
-                if (this.collectionContext is not null)
-                {
-                    return true;
-                }
-            }
-            finally
-            {
-                this.ExitGlobalLock();
-            }
-
-            didSpin = true;
-            readWait.SpinOnce();
-        }
-
-        return didSpin;
-    }
+    private Task<bool>? GetReadersDrainedTask(in PrometheusProtocol protocol)
+        => this.GetProtocolState(protocol).GetReadersDrainedTask();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private CollectionResult ExecuteCollect(CollectionContext collectionContext)
@@ -772,18 +749,30 @@ internal sealed class PrometheusCollectionManager
 
     private readonly struct CollectStep
     {
-        private CollectStep(CollectionResponse response, Task<CollectionResult>? pendingCollectionTask, bool joinedActiveCollection)
+        private CollectStep(
+            CollectionResponse response,
+            Task<CollectionResult>? pendingCollectionTask,
+            Task<bool>? readersDrainedTask,
+            bool joinedActiveCollection)
         {
             this.Response = response;
             this.PendingCollectionTask = pendingCollectionTask;
+            this.ReadersDrainedTask = readersDrainedTask;
             this.JoinedActiveCollection = joinedActiveCollection;
         }
 
-        // A non-null task means the caller must await the in-flight collection;
-        // a null task means Response already holds the answer.
+        // A non-null task means the caller must await the in-flight collection.
         public Task<CollectionResult>? PendingCollectionTask { get; }
 
+        // A non-null task means a collection could not be started because this
+        // protocol still has active readers, and the caller must await them
+        // draining before attempting to enter a collection again.
+        public Task<bool>? ReadersDrainedTask { get; }
+
         public CollectionResponse Response { get; }
+
+        // True when there is nothing to await because Response already holds the answer.
+        public bool IsCompleted => this.PendingCollectionTask is null && this.ReadersDrainedTask is null;
 
         // True when this scrape registered the protocol with the in-flight
         // collection and took a reader slot for it (so the awaiting caller owns a
@@ -792,10 +781,13 @@ internal sealed class PrometheusCollectionManager
         public bool JoinedActiveCollection { get; }
 
         public static CollectStep Completed(CollectionResponse response)
-            => new(response, pendingCollectionTask: null, joinedActiveCollection: false);
+            => new(response, pendingCollectionTask: null, readersDrainedTask: null, joinedActiveCollection: false);
 
         public static CollectStep Pending(Task<CollectionResult> pendingCollectionTask, bool joinedActiveCollection)
-            => new(default, pendingCollectionTask, joinedActiveCollection);
+            => new(default, pendingCollectionTask, readersDrainedTask: null, joinedActiveCollection);
+
+        public static CollectStep WaitingForReaders(Task<bool> readersDrainedTask)
+            => new(default, pendingCollectionTask: null, readersDrainedTask, joinedActiveCollection: false);
     }
 
     private readonly struct CollectionResult
@@ -954,7 +946,9 @@ internal sealed class PrometheusCollectionManager
     {
         private const int InitialBufferSize = PrometheusExporterOptions.InitialScrapeResponseSizeBytes;
         private readonly int maxBufferSize;
+        private readonly Lock readersDrainedGate = new();
 
+        private TaskCompletionSource<bool>? readersDrained;
         private int readerCount;
 
         public PrometheusProtocolState(int maxBufferSize)
@@ -978,13 +972,56 @@ internal sealed class PrometheusCollectionManager
         public TimeSpan? GeneratedAtElapsed { get; private set; }
 
         public int DecrementReaderCount()
-            => Interlocked.Decrement(ref this.readerCount);
+        {
+            var readerCount = Interlocked.Decrement(ref this.readerCount);
+
+            if (readerCount < 1)
+            {
+                TaskCompletionSource<bool>? readersDrained;
+
+                lock (this.readersDrainedGate)
+                {
+                    readersDrained = this.readersDrained;
+                    this.readersDrained = null;
+                }
+
+                // Signalled outside the gate so that no continuation runs while it is held.
+                readersDrained?.TrySetResult(true);
+            }
+
+            return readerCount;
+        }
 
         public bool HasActiveReaders()
             => Interlocked.CompareExchange(ref this.readerCount, 0, 0) != 0;
 
         public void IncrementReaderCount()
             => Interlocked.Increment(ref this.readerCount);
+
+        /// <summary>
+        /// Gets a task which completes once this protocol has no active readers, or
+        /// <see langword="null"/> when it has none right now.
+        /// </summary>
+        /// <returns>
+        /// The task to wait on, or <see langword="null"/> when there is nothing to wait for.
+        /// </returns>
+        public Task<bool>? GetReadersDrainedTask()
+        {
+            lock (this.readersDrainedGate)
+            {
+                // The reader count is published before DecrementReaderCount takes the
+                // gate, so a reader which has already drained is seen here and reported
+                // as nothing to wait for. Anything still active is guaranteed to signal.
+                if (!this.HasActiveReaders())
+                {
+                    return null;
+                }
+
+                this.readersDrained ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                return this.readersDrained.Task;
+            }
+        }
 
         public bool TryExpandBuffer()
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs
@@ -15,7 +15,7 @@ internal sealed class PrometheusCollectionManager
 
     // Upper bound on how many times entering a collection will retry while
     // resolving races with concurrent scrapes (a collection completing, active
-    // readers draining, or a shared collection that did not serve this protocol).
+    // readers draining, or a collection this scrape could not register with).
     // In practice only a couple of iterations ever run; the cap exists purely so
     // a pathological interleaving of concurrent scrapes cannot starve one into
     // looping forever.
@@ -270,31 +270,36 @@ internal sealed class PrometheusCollectionManager
         {
             var collectionResult = await pendingCollectionTask.ConfigureAwait(false);
 
-            if (joinedActiveCollection &&
-                collectionResult.TryGetResponse(protocol, out var response))
+            if (joinedActiveCollection)
             {
+                // This scrape shared the collection, so the collection's outcome is
+                // this scrape's outcome. When it produced no response for this
+                // protocol it failed, and this scrape reports that failure rather
+                // than collecting again: a retry cannot reuse the collection it just
+                // shared, so it would have to start a new one, which cannot begin
+                // until every active reader of this protocol has drained. Under
+                // concurrent scrapes that wait can spin for an unbounded time while
+                // holding a thread, so retrying here risks starving the scrapes whose
+                // completion it is waiting on.
+                if (!collectionResult.TryGetResponse(protocol, out var response))
+                {
+                    PrometheusExporterEventSource.Log.CollectFailed();
+
+                    // The reader slot taken when joining is left outstanding for the
+                    // caller's ExitCollect to release.
+                    return default;
+                }
+
                 return response;
             }
 
-            if (joinedActiveCollection)
-            {
-                this.ExitCollect(protocol);
-            }
-
-            // Retire the collection that just completed. The thread which ran it
-            // publishes the result before clearing collectionContext, so without
-            // this a retry can observe - and re-join - the very same completed
-            // collection (TryRegisterProtocol accepts a protocol that is already
-            // registered, and a collection which failed before exporting never
-            // froze its protocol set) and spin without ever collecting again.
-            this.RetireCollection(pendingCollectionTask);
-
-            // The shared collection did not produce a response for this protocol,
-            // so make another attempt. Loop here (bounded by MaxCollectAttempts)
-            // rather than recursing back into EnterCollect: when the awaited
-            // collection completes synchronously the continuation runs inline,
-            // so a recursive retry would grow the stack on every iteration
-            // and eventually overflow under contention.
+            // This scrape never registered with the collection it observed, so that
+            // collection was never going to produce a response for it: make another
+            // attempt. Loop here (bounded by MaxCollectAttempts) rather than recursing
+            // back into EnterCollect: when the awaited collection completes
+            // synchronously the continuation runs inline, so a recursive retry would
+            // grow the stack on every iteration and eventually overflow under
+            // contention.
             var step = this.TryEnterCollect(protocol);
 
             if (step.PendingCollectionTask is null)
@@ -322,30 +327,6 @@ internal sealed class PrometheusCollectionManager
         }
 
         return default;
-    }
-
-    /// <summary>
-    /// Clears the active collection if it is still the one which produced
-    /// <paramref name="completedCollectionTask"/>, so that the next attempt to
-    /// enter a collection starts a new one instead of joining a finished one.
-    /// </summary>
-    /// <param name="completedCollectionTask">The task of the collection which has completed.</param>
-    private void RetireCollection(Task<CollectionResult> completedCollectionTask)
-    {
-        this.EnterGlobalLock();
-
-        try
-        {
-            if (this.collectionContext is { } currentCollectionContext &&
-                ReferenceEquals(currentCollectionContext.Task, completedCollectionTask))
-            {
-                this.collectionContext = null;
-            }
-        }
-        finally
-        {
-            this.ExitGlobalLock();
-        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -345,11 +345,33 @@ public sealed class PrometheusCollectionManagerTests
         Assert.Equal(1, collectCount);
 
         // The waiting is asynchronous: entering hands back an incomplete task rather
-        // than blocking this thread until the readers drain. Blocking here would never
-        // resolve, because the reader being waited on is held by this thread.
+        // than blocking the caller until the readers drain. Entering is done on a worker
+        // thread and time-boxed here, because if entering blocks (as it did before the fix)
+        // it never returns at all, as the reader being waited on is held by this thread.
+        // Doing it this way makes such a regression fail the test rather than hang CI.
+        var enteringScrape = new TaskCompletionSource<Task<PrometheusCollectionManager.CollectionResponse>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
 #pragma warning disable CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
-        var waitingScrape = EnterCollectAsync(exporter, protocol);
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                enteringScrape.SetResult(EnterCollectAsync(exporter, protocol));
+            }
+            catch (Exception ex)
+            {
+                enteringScrape.SetException(ex);
+            }
+        });
 #pragma warning restore CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
+
+        var entered = await Task.WhenAny(enteringScrape.Task, Task.Delay(testTimeout, cts.Token));
+
+        Assert.Same(enteringScrape.Task, entered);
+
+        // The reader held by this thread has not exited yet, so the scrape cannot have
+        // completed unless entering a collection stopped waiting for the active reader.
+        var waitingScrape = await enteringScrape.Task;
 
         Assert.False(waitingScrape.IsCompleted, "Entering a collection did not wait for the active reader.");
         Assert.Equal(1, collectCount);

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -301,6 +301,79 @@ public sealed class PrometheusCollectionManagerTests
         }
     }
 
+    [Fact]
+    public async Task EnterCollectDoesNotBlockWaitingForActiveReadersToExit()
+    {
+        var testTimeout = TimeSpan.FromSeconds(30);
+        using var cts = new CancellationTokenSource(testTimeout);
+
+        using var meter = CreateMeter();
+#if PROMETHEUS_HTTP_LISTENER
+        using var provider = CreateMeterProviderWithRandomPort(meter);
+#elif PROMETHEUS_ASPNETCORE
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 0)
+            .Build();
+#endif
+
+#pragma warning disable CA2000 // MeterProvider owns exporter lifecycle
+        if (!provider.TryFindExporter(out PrometheusExporter? exporter))
+#pragma warning restore CA2000 // MeterProvider owns exporter lifecycle
+        {
+            throw new InvalidOperationException("PrometheusExporter could not be found on MeterProvider.");
+        }
+
+        var collectCount = 0;
+        var originalCollect = exporter.Collect;
+
+        exporter.Collect = (timeout) =>
+        {
+            Interlocked.Increment(ref collectCount);
+            return originalCollect!(timeout);
+        };
+
+        meter.CreateCounter<int>("counter_int").Add(100);
+
+        var protocol = GetProtocol(openMetricsRequested: false);
+
+        // Hold a reader on this thread, so the next scrape cannot start
+        // a collection until it exits.
+        var firstResponse = await EnterCollectAsync(exporter, protocol);
+
+        Assert.True(firstResponse.Succeeded);
+        Assert.Equal(1, collectCount);
+
+        // The waiting is asynchronous: entering hands back an incomplete task rather
+        // than blocking this thread until the readers drain. Blocking here would never
+        // resolve, because the reader being waited on is held by this thread.
+#pragma warning disable CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
+        var waitingScrape = EnterCollectAsync(exporter, protocol);
+#pragma warning restore CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
+
+        Assert.False(waitingScrape.IsCompleted, "Entering a collection did not wait for the active reader.");
+        Assert.Equal(1, collectCount);
+
+        exporter.CollectionManager.ExitCollect(protocol);
+
+        var completion = await Task.WhenAny(waitingScrape, Task.Delay(testTimeout, cts.Token));
+
+        Assert.Same(waitingScrape, completion);
+
+        var secondResponse = await waitingScrape;
+
+        try
+        {
+            Assert.True(secondResponse.Succeeded, "The scrape which waited for the active reader did not succeed.");
+            Assert.True(secondResponse.View.Count > 0, "The view is empty.");
+            Assert.Equal(2, collectCount);
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect(protocol);
+        }
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -406,8 +406,11 @@ public sealed class PrometheusCollectionManagerTests
     }
 
     [Fact]
-    public async Task EnterCollectRetriesAfterFailedSharedCollection()
+    public async Task EnterCollectFailsScrapesWhichSharedAFailedCollection()
     {
+        var testTimeout = TimeSpan.FromSeconds(30);
+        using var cts = new CancellationTokenSource(testTimeout);
+
         using var meter = CreateMeter();
 #if PROMETHEUS_HTTP_LISTENER
         using var provider = CreateMeterProviderWithRandomPort(meter);
@@ -447,7 +450,7 @@ public sealed class PrometheusCollectionManagerTests
 
         var protocol = GetProtocol(openMetricsRequested: false);
 
-        var firstCollectTask = Task.Run(async () =>
+        var collectingScrape = Task.Run(async () =>
         {
             var response = await EnterCollectAsync(exporter, protocol);
             try
@@ -462,36 +465,42 @@ public sealed class PrometheusCollectionManagerTests
 
         await firstCollectStarted.Task;
 
-        var secondCollectTask = Task.Run(async () =>
-        {
-            var response = await EnterCollectAsync(exporter, protocol);
-            try
-            {
-                return response;
-            }
-            finally
-            {
-                exporter.CollectionManager.ExitCollect(protocol);
-            }
-        });
+        // Share the collection which is about to be failed. EnterCollect registers this
+        // scrape with the in-flight collection before it returns the task to wait on, so
+        // by the time this call returns the collection is being shared and releasing it
+        // below cannot race with joining it.
+#pragma warning disable CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
+        var sharingScrape = EnterCollectAsync(exporter, protocol);
+#pragma warning restore CA2025 // The test awaits the scheduled work before disposing the provider/exporter.
 
         allowFirstCollectToComplete.SetResult(true);
 
-        var timeout = TimeSpan.FromSeconds(5);
+        var all = Task.WhenAll(collectingScrape, sharingScrape);
+        var completion = await Task.WhenAny(all, Task.Delay(testTimeout, cts.Token));
 
-        using (var cts = new CancellationTokenSource(timeout))
+        Assert.Same(all, completion);
+
+        var collectingResponse = await collectingScrape;
+
+        PrometheusCollectionManager.CollectionResponse sharingResponse;
+        try
         {
-            var all = Task.WhenAll(firstCollectTask, secondCollectTask);
-            var completion = await Task.WhenAny(all, Task.Delay(timeout, cts.Token));
-            Assert.Same(all, completion);
+            sharingResponse = await sharingScrape;
+        }
+        finally
+        {
+            exporter.CollectionManager.ExitCollect(protocol);
         }
 
-        var firstResponse = await firstCollectTask;
-        var secondResponse = await secondCollectTask;
+        // A failed collection is reported to every scrape which shared it, and is not
+        // collected again on their behalf.
+        Assert.Equal(1, collectCount);
 
-        Assert.Equal(2, collectCount);
-        Assert.Equal(0, firstResponse.View.Count);
-        Assert.True(secondResponse.View.Count > 0);
+        Assert.False(collectingResponse.Succeeded, "The scrape which ran the failed collection did not report failure.");
+        Assert.Equal(0, collectingResponse.View.Count);
+
+        Assert.False(sharingResponse.Succeeded, "The scrape which shared the failed collection did not report failure.");
+        Assert.Equal(0, sharingResponse.View.Count);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -407,6 +407,8 @@ public class PrometheusHttpListenerTests
     [Fact]
     public async Task HttpListenerHandlesConcurrentScrapes()
     {
+        EnsureThreadPoolWorkerThreadsAvailable();
+
         var timeout = TimeSpan.FromSeconds(5);
 
         using var firstCollectStarted = new ManualResetEventSlim();


### PR DESCRIPTION
## Changes

Fix concurrency issue introduced by the fix in #7524. Now, instead of retrying under failed scrapes under contention, instead return an error.

A first attempt at fixing the issue made things work by introducing a deadlock, and the original fix that created this secondary issue was for a stack overflow, so at this point it's probably safer to fail faster _if_ under high contention (which realistically shouldn't happen to a scrape endpoint?) and let the client itself retry.

Detected by test flakiness in #6899. [This job](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/30451056694) took 6 attempts to pass - for some reason the bug is more apparent only when running under .NET 11.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
