### PR TITLE
[OTLP] Update HttpClientFactory documentation

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/IOtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/IOtlpExporterOptions.cs
@@ -94,11 +94,18 @@ internal interface IOtlpExporterOptions
     /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
     /// created through the factory with the name "OtlpMetricExporter" otherwise
     /// an <see cref="HttpClient"/> will be instantiated directly.</item>
-    /// <item>
-    /// The default behavior when using logging registration extensions is an
-    /// <see cref="HttpClient"/> will be instantiated directly. <a
+    /// <item>The default behavior when using logging registration extensions is
+    /// if an <a
     /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
-    /// is not currently supported for logging.
+    /// instance can be resolved through the application <see
+    /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
+    /// created through the factory with the name "OtlpLogExporter" otherwise
+    /// an <see cref="HttpClient"/> will be instantiated directly.</item>
+    /// <item>
+    /// Applications that use custom classes derived from <see cref="DelegatingHandler"/>
+    /// in .NET 5 or later must override both the asynchronous
+    /// <see cref="DelegatingHandler.SendAsync(HttpRequestMessage, CancellationToken)"/>
+    /// and synchronous <c>Send(HttpRequestMessage, CancellationToken)</c> methods.
     /// </item>
     /// </list>
     /// </remarks>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -619,7 +619,7 @@ services.AddOpenTelemetry()
 
 For users using
 [IHttpClientFactory](https://docs.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests)
-you may also customize the named "OtlpTraceExporter" and/or "OtlpMetricExporter"
+you may also customize the named "OtlpTraceExporter", "OtlpMetricExporter", and/or "OtlpLogExporter"
 `HttpClient` using the built-in `AddHttpClient` extension:
 
 ```csharp
@@ -629,8 +629,12 @@ services.AddHttpClient(
         client.DefaultRequestHeaders.Add("X-MyCustomHeader", "value"));
 ```
 
-> [!NOTE]
-> `IHttpClientFactory` is NOT currently supported by `OtlpLogExporter`.
+> [!IMPORTANT]
+> Applications that use custom [`DelegatingHandler`](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler)
+> implementations when targeting .NET 5 or later must override both the
+> [SendAsync()](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler.sendasync) and
+> [Send()](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler.send) methods to ensure
+> that their custom logic is executed for all HTTP requests made by the OTLP exporter.
 
 ## Experimental features
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -619,8 +619,9 @@ services.AddOpenTelemetry()
 
 For users using
 [IHttpClientFactory](https://docs.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests)
-you may also customize the named "OtlpTraceExporter", "OtlpMetricExporter", and/or "OtlpLogExporter"
-`HttpClient` using the built-in `AddHttpClient` extension:
+you may also customize the named "OtlpTraceExporter", "OtlpMetricExporter",
+and/or "OtlpLogExporter" `HttpClient` using the built-in `AddHttpClient`
+extension:
 
 ```csharp
 services.AddHttpClient(
@@ -632,9 +633,11 @@ services.AddHttpClient(
 > [!IMPORTANT]
 > Applications that use custom [`DelegatingHandler`](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler)
 > implementations when targeting .NET 5 or later must override both the
-> [SendAsync()](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler.sendasync) and
-> [Send()](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler.send) methods to ensure
-> that their custom logic is executed for all HTTP requests made by the OTLP exporter.
+> [SendAsync()](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler.sendasync)
+> and
+> [Send()](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler.send)
+> methods to ensure that their custom logic is executed for all HTTP requests
+> made by the OTLP exporter.
 
 ## Experimental features
 


### PR DESCRIPTION
Fixes #7575

## Changes

- Update out-of-date notes about the logging integration (see #7109 and #7298).
- Document that .NET 5+ must override `DelegatingHandler.Send()`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
