### PR TITLE
[Zipkin] Do not read HTTP response body

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,12 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed the exporter to read responses with
+  `HttpCompletionOption.ResponseHeadersRead` for the .NET Framework and
+  .NET Standard targets, matching the behavior on .NET to avoid buffering
+  the response body in memory when it is not actually used.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -10,7 +10,7 @@ Notes](../../RELEASENOTES.md).
   `HttpCompletionOption.ResponseHeadersRead` for the .NET Framework and
   .NET Standard targets, matching the behavior on .NET to avoid buffering
   the response body in memory when it is not actually used.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7582](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7582))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -84,7 +84,7 @@ public class ZipkinExporter : BaseExporter<Activity>
             ? this.httpClient.Send(request, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None)
             : this.httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None).GetAwaiter().GetResult();
 #else
-            using var response = this.httpClient.SendAsync(request, CancellationToken.None).GetAwaiter().GetResult();
+            using var response = this.httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None).GetAwaiter().GetResult();
 #endif
 #pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -309,6 +309,26 @@ public sealed class ZipkinExporterTests : IDisposable
         Assert.Equal("myservicename", zipkinExporter.LocalEndpoint!.ServiceName);
     }
 
+    [Fact]
+    public void ResponseBodyIsNeverReadRegardlessOfSize()
+    {
+        const long OversizedResponseBytes = 16 * 1024 * 1024;
+
+        using var testHandler = new OversizedResponseHandler(OversizedResponseBytes);
+        using var httpClient = new HttpClient(testHandler, disposeHandler: false);
+
+        using var exporter = new ZipkinExporter(
+            new ZipkinExporterOptions { Endpoint = new Uri("http://localhost:9411/api/v2/spans") },
+            httpClient);
+
+        using var activity = ZipkinActivitySource.CreateTestActivity();
+
+        var result = exporter.Export(new Batch<Activity>([activity], 1));
+
+        Assert.Equal(ExportResult.Success, result);
+        Assert.Equal(0, testHandler.BytesProduced);
+    }
+
     [Theory]
     [InlineData(true, false, false)]
     [InlineData(false, false, false)]
@@ -444,5 +464,82 @@ public sealed class ZipkinExporterTests : IDisposable
                 + @"""otel.library.name"":""ZipkinActivitySource"""
             + "}}]",
             Responses[requestId]);
+    }
+
+    private sealed class OversizedResponseHandler(long totalBytes) : HttpMessageHandler
+    {
+        private readonly GeneratedStream stream = new(totalBytes);
+
+        public long BytesProduced => this.stream.BytesProduced;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(this.CreateResponse(request));
+
+#if NET
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+            => this.CreateResponse(request);
+#endif
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.stream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private HttpResponseMessage CreateResponse(HttpRequestMessage request) =>
+            new(HttpStatusCode.OK)
+            {
+                RequestMessage = request,
+                Content = new StreamContent(this.stream),
+            };
+
+        private sealed class GeneratedStream(long totalBytes) : Stream
+        {
+            public long BytesProduced { get; private set; }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var remaining = totalBytes - this.BytesProduced;
+                if (remaining <= 0)
+                {
+                    return 0;
+                }
+
+                var read = (int)Math.Min(count, remaining);
+                Array.Clear(buffer, offset, read);
+                this.BytesProduced += read;
+
+                return read;
+            }
+
+            public override void Flush()
+            {
+                // No-op
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
## Changes

Do not read the HTTP response body when targeting .NET Framework and .NET Standard.

Found by a GitHub Copilot review of the codebase.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
