### PR TITLE
[OTLP] Fix retry-thread termination and missing catch-all in HTTP export client

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -20,6 +20,12 @@ Notes](../../RELEASENOTES.md).
   the serializer's per-thread state. For logs, this also leaked pooled instances.
   ([#7579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7579))
 
+* Fixed the persistent-storage retry thread terminating permanently on an
+  unexpected exception, which silently disabled `disk` retry for the remaining
+  process lifetime while stored telemetry continued to accumulate and then
+  expire.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -24,7 +24,7 @@ Notes](../../RELEASENOTES.md).
   unexpected exception, which silently disabled `disk` retry for the remaining
   process lifetime while stored telemetry continued to accumulate and then
   expire.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#7597](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7597))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
@@ -26,14 +26,6 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
     private static readonly ExportClientHttpResponse SuccessExportResponse = new(success: true, deadlineUtc: default, response: null, exception: null);
     private static readonly MediaTypeHeaderValue MediaHeaderValue = new("application/grpc");
 
-    private static readonly ExportClientGrpcResponse DefaultExceptionExportClientGrpcResponse
-        = new(
-            success: false,
-            deadlineUtc: default,
-            exception: null,
-            status: null,
-            grpcStatusDetailsHeader: null);
-
 #if !NET
     private static readonly byte[] GrpcFrameHeader = [0, 0, 0, 0, 0];
 #endif
@@ -164,7 +156,7 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
                 status: null,
                 grpcStatusDetailsHeader: null);
         }
-        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException && !cancellationToken.IsCancellationRequested)
         {
             // Handle TaskCanceledException caused by TimeoutException.
             OpenTelemetryProtocolExporterEventSource.Log.RequestTimedOut(this.Endpoint, ex);
@@ -186,10 +178,21 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
                 status: new Status(StatusCode.Cancelled, "Operation was canceled unexpectedly."),
                 grpcStatusDetailsHeader: null);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
+            // Return Unavailable so the response is classified as retryable,
+            // preserving any blob written to persistent storage.
             OpenTelemetryProtocolExporterEventSource.Log.FailedToReachCollector(this.Endpoint, ex);
-            return DefaultExceptionExportClientGrpcResponse;
+            return new ExportClientGrpcResponse(
+                success: false,
+                deadlineUtc: deadlineUtc,
+                exception: ex,
+                status: new Status(StatusCode.Unavailable, "Unexpected error - retryable"),
+                grpcStatusDetailsHeader: null);
         }
         finally
         {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpExportClient.cs
@@ -53,7 +53,7 @@ internal sealed class OtlpHttpExportClient : OtlpExportClient
             OpenTelemetryProtocolExporterEventSource.Log.FailedToReachCollector(this.Endpoint, ex);
             return new ExportClientHttpResponse(success: false, deadlineUtc: deadlineUtc, response: null, exception: ex);
         }
-        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException && !cancellationToken.IsCancellationRequested)
         {
             // Handle TaskCanceledException caused by TimeoutException.
             OpenTelemetryProtocolExporterEventSource.Log.RequestTimedOut(this.Endpoint, ex);
@@ -63,6 +63,17 @@ internal sealed class OtlpHttpExportClient : OtlpExportClient
         {
             // Handle unexpected cancellation.
             OpenTelemetryProtocolExporterEventSource.Log.OperationUnexpectedlyCanceled(this.Endpoint, ex);
+            return new ExportClientHttpResponse(success: false, deadlineUtc: deadlineUtc, response: null, exception: ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Return a response with no status code. OtlpRetry.IsRetryable treats a missing
+            // status code as retryable, preserving any blob written to persistent storage.
+            OpenTelemetryProtocolExporterEventSource.Log.FailedToReachCollector(this.Endpoint, ex);
             return new ExportClientHttpResponse(success: false, deadlineUtc: deadlineUtc, response: null, exception: ex);
         }
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -129,21 +129,31 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
                         break;
                     }
 
-                    if (blob.TryLease((int)this.TimeoutMilliseconds) && blob.TryRead(out var data))
+                    try
                     {
-                        var deadlineUtc = DateTime.UtcNow.AddMilliseconds(this.TimeoutMilliseconds);
-
-                        // Note: The deadline is intentionally ignored when deciding whether to keep
-                        // the blob. A retry attempt that exhausts the deadline should not cause the
-                        // stored data to be deleted if the failure is otherwise retryable; it should
-                        // remain on disk to be retried again later.
-                        if (this.TryRetryRequest(data, data.Length, deadlineUtc, out var response) ||
-                            !RetryHelper.ShouldRetryRequest(response))
+                        if (blob.TryLease((int)this.TimeoutMilliseconds) && blob.TryRead(out var data))
                         {
-                            blob.TryDelete();
-                        }
+                            var deadlineUtc = DateTime.UtcNow.AddMilliseconds(this.TimeoutMilliseconds);
 
-                        // TODO: extend the lease period based on the response from server on retryAfter.
+                            // Note: The deadline is intentionally ignored when deciding whether to keep
+                            // the blob. A retry attempt that exhausts the deadline should not cause the
+                            // stored data to be deleted if the failure is otherwise retryable; it should
+                            // remain on disk to be retried again later.
+                            if (this.TryRetryRequest(data, data.Length, deadlineUtc, out var response) ||
+                                !RetryHelper.ShouldRetryRequest(response))
+                            {
+                                blob.TryDelete();
+                            }
+
+                            // TODO: extend the lease period based on the response from server on retryAfter. See https://github.com/open-telemetry/opentelemetry-dotnet/issues/4115
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // An unexpected failure transmitting one blob must not terminate this
+                        // thread. Leave the blob on disk; its lease will expire and it will be
+                        // retried on a later pass.
+                        OpenTelemetryProtocolExporterEventSource.Log.RetryStoredRequestException(ex);
                     }
 
                     fileCount++;
@@ -156,6 +166,8 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
             }
             catch (Exception ex)
             {
+                // The wait handles are gone, most likely because Dispose was called without
+                // Shutdown. There is nothing left to wait on.
                 OpenTelemetryProtocolExporterEventSource.Log.RetryStoredRequestException(ex);
                 return;
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -42,6 +42,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
     // Used for test.
     internal bool InitiateAndWaitForRetryProcess(int timeOutMilliseconds)
     {
+        this.dataExportNotification.Reset();
         this.exportEvent.Set();
 
         return this.dataExportNotification.WaitOne(timeOutMilliseconds);
@@ -159,10 +160,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
                     fileCount++;
                 }
 
-                // Set and reset the handle to notify export and wait for next signal.
-                // This is used for InitiateAndWaitForRetryProcess.
                 this.dataExportNotification.Set();
-                this.dataExportNotification.Reset();
             }
             catch (Exception ex)
             {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandlerTests.cs
@@ -63,6 +63,50 @@ public class OtlpExporterPersistentStorageTransmissionHandlerTests
         Assert.Null(persistentBlobProvider.LastBuffer);
     }
 
+    [Fact]
+    public void RetryStoredRequests_ThreadSurvivesExportClientException()
+    {
+        // Pre-fix: the exception kills the thread and the second InitiateAndWaitForRetryProcess
+        // call times out. Use a real timeout so a dead thread does not hang the test.
+        // The RetainingBlobProvider re-exposes the same blob after SimulateLeaseExpiry, proving
+        // that the blob itself is eventually transmitted rather than silently abandoned.
+        var exportClient = new ThrowOnceThenSucceedExportClient();
+        var blobProvider = new RetainingBlobProvider();
+        var blob1 = new TrackingBlob([1, 2, 3]);
+        blobProvider.SetBlob(blob1);
+
+        using var handler = new OtlpExporterPersistentStorageTransmissionHandler(blobProvider, exportClient, timeoutMilliseconds: 10_000);
+
+        Assert.True(handler.InitiateAndWaitForRetryProcess(5_000), "thread must survive an export client exception");
+        Assert.False(blob1.WasDeleted, "blob must be retained when the export client throws");
+
+        // Simulate lease expiry so the same blob is re-exposed on the next pass.
+        blobProvider.SimulateLeaseExpiry();
+
+        Assert.True(handler.InitiateAndWaitForRetryProcess(5_000), "thread must still be alive on the second pass");
+        Assert.True(blob1.WasDeleted, "blob must be deleted after successful transmission on the second pass");
+    }
+
+    [Fact]
+    public void RetryStoredRequests_ContinuesProcessingRemainingBlobsAfterException()
+    {
+        // When one blob causes the export client to throw, the remaining blobs in the same
+        // pass must still be processed rather than the loop aborting.
+        var exportClient = new ThrowOnceThenSucceedExportClient();
+        var blobProvider = new QueueBlobProvider();
+
+        using var handler = new OtlpExporterPersistentStorageTransmissionHandler(blobProvider, exportClient, timeoutMilliseconds: 10_000);
+
+        var blob1 = new TrackingBlob([1, 2, 3]);
+        var blob2 = new TrackingBlob([4, 5, 6]);
+        blobProvider.Enqueue(blob1);
+        blobProvider.Enqueue(blob2);
+
+        Assert.True(handler.InitiateAndWaitForRetryProcess(5_000));
+        Assert.False(blob1.WasDeleted, "blob1 must be retained when the export client throws");
+        Assert.True(blob2.WasDeleted, "blob2 must be processed in the same pass after blob1 throws");
+    }
+
     private sealed class FailingExportClient : IExportClient
     {
         private readonly HttpStatusCode statusCode;
@@ -126,5 +170,127 @@ public class OtlpExporterPersistentStorageTransmissionHandlerTests
         protected override bool OnTryLease(int leasePeriodMilliseconds) => false;
 
         protected override bool OnTryDelete() => true;
+    }
+
+    private sealed class ThrowOnceThenSucceedExportClient : IExportClient
+    {
+        private int callCount;
+
+        public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref this.callCount) == 1)
+            {
+                throw new InvalidOperationException("Simulated export client failure.");
+            }
+
+            return new ExportClientHttpResponse(success: true, deadlineUtc: deadlineUtc, response: null, exception: null);
+        }
+
+        public bool Shutdown(int timeoutMilliseconds) => true;
+    }
+
+    private sealed class QueueBlobProvider : PersistentBlobProvider
+    {
+        private readonly Queue<PersistentBlob> queue = new();
+
+        public void Enqueue(PersistentBlob blob) => this.queue.Enqueue(blob);
+
+        protected override IEnumerable<PersistentBlob> OnGetBlobs() => this.queue;
+
+        protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out PersistentBlob blob)
+        {
+            blob = default!;
+            return false;
+        }
+
+        protected override bool OnTryCreateBlob(byte[] buffer, out PersistentBlob blob)
+        {
+            blob = default!;
+            return false;
+        }
+
+        protected override bool OnTryGetBlob(out PersistentBlob blob)
+        {
+            if (this.queue.Count > 0)
+            {
+                blob = this.queue.Dequeue();
+                return true;
+            }
+
+            blob = default!;
+            return false;
+        }
+    }
+
+    // Models a persistent blob whose lease expires and is re-discovered on a later pass.
+    // SetBlob makes the blob available once; SimulateLeaseExpiry makes it available again,
+    // matching what FileBlobProvider does when a lease period elapses.
+    private sealed class RetainingBlobProvider : PersistentBlobProvider
+    {
+        private TrackingBlob? blob;
+        private bool available;
+
+        public void SetBlob(TrackingBlob blob)
+        {
+            this.blob = blob;
+            this.available = true;
+        }
+
+        public void SimulateLeaseExpiry() => this.available = true;
+
+        protected override IEnumerable<PersistentBlob> OnGetBlobs() => [];
+
+        protected override bool OnTryCreateBlob(byte[] buffer, int leasePeriodMilliseconds, out PersistentBlob blob)
+        {
+            blob = default!;
+            return false;
+        }
+
+        protected override bool OnTryCreateBlob(byte[] buffer, out PersistentBlob blob)
+        {
+            blob = default!;
+            return false;
+        }
+
+        protected override bool OnTryGetBlob(out PersistentBlob blob)
+        {
+            if (this.available && this.blob != null && !this.blob.WasDeleted)
+            {
+                blob = this.blob;
+                this.available = false;
+                return true;
+            }
+
+            blob = default!;
+            return false;
+        }
+    }
+
+    private sealed class TrackingBlob : PersistentBlob
+    {
+        private readonly byte[] data;
+
+        public TrackingBlob(byte[] data)
+        {
+            this.data = data;
+        }
+
+        public bool WasDeleted { get; private set; }
+
+        protected override bool OnTryRead(out byte[] buffer)
+        {
+            buffer = this.data;
+            return true;
+        }
+
+        protected override bool OnTryWrite(byte[] buffer, int leasePeriodMilliseconds = 0) => true;
+
+        protected override bool OnTryLease(int leasePeriodMilliseconds) => true;
+
+        protected override bool OnTryDelete()
+        {
+            this.WasDeleted = true;
+            return true;
+        }
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpGrpcExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpGrpcExportClientTests.cs
@@ -182,7 +182,9 @@ public class OtlpGrpcExportClientTests
             httpClient,
             string.Empty);
 
-        Assert.Throws<OperationCanceledException>(() =>
+        // Use ThrowsAny to accept TaskCanceledException (a subtype of OperationCanceledException),
+        // which HttpClient may produce when wrapping a timeout that coincides with caller cancellation.
+        Assert.ThrowsAny<OperationCanceledException>(() =>
             exportClient.SendExportRequest(buffer, buffer.Length, DateTime.UtcNow.AddSeconds(10), cts.Token));
     }
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpGrpcExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpGrpcExportClientTests.cs
@@ -142,6 +142,76 @@ public class OtlpGrpcExportClientTests
         Assert.True(RetryHelper.ShouldRetryRequest(response), "An unexpected cancellation should be retryable.");
     }
 
+    [Fact]
+    public void SendExportRequest_UnexpectedException_ReturnsRetryableUnavailableResponse()
+    {
+        // A non-HTTP exception from a user-supplied DelegatingHandler (e.g. an auth handler
+        // that throws InvalidOperationException on a failed token refresh) must be returned as
+        // Unavailable so that any blob written to persistent storage is retained for retry.
+        var exception = new InvalidOperationException("Custom handler failure.");
+
+        var response = SendExportRequestThatThrows(exception);
+
+        Assert.False(response.Success);
+        Assert.NotNull(response.Status);
+        Assert.Equal(StatusCode.Unavailable, response.Status.Value.StatusCode);
+        Assert.True(OtlpRetry.IsRetryable(response), "An unexpected exception must produce a retryable failure response.");
+    }
+
+    [Fact]
+    public void SendExportRequest_TimeoutWithCallerCancellationRequested_Propagates()
+    {
+        // A TaskCanceledException with an inner TimeoutException must still propagate when
+        // the caller's token is also signaled. Without the cancellationToken guard in the
+        // when clause, the timeout catch fires first and swallows the caller cancellation.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var buffer = BuildGrpcFrame("grpc test payload"u8.ToArray());
+
+        using var testHandler = new ThrowingHttpMessageHandler(
+            new TaskCanceledException("The request timed out.", new TimeoutException()));
+        using var httpClient = new HttpClient(testHandler, disposeHandler: false);
+
+        var exportClient = new OtlpGrpcExportClient(
+            new OtlpExporterOptions
+            {
+                Endpoint = new Uri("http://localhost:4317"),
+                Compression = OtlpExportCompression.None,
+            },
+            httpClient,
+            string.Empty);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            exportClient.SendExportRequest(buffer, buffer.Length, DateTime.UtcNow.AddSeconds(10), cts.Token));
+    }
+
+    [Fact]
+    public void SendExportRequest_CallerCancellationRequested_Propagates()
+    {
+        // OperationCanceledException thrown when the caller's token is signaled must propagate
+        // rather than being swallowed and converted into an Unavailable response.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var buffer = BuildGrpcFrame("grpc test payload"u8.ToArray());
+
+        using var testHandler = new ThrowingHttpMessageHandler(new OperationCanceledException(cts.Token));
+        using var httpClient = new HttpClient(testHandler, disposeHandler: false);
+
+        var exportClient = new OtlpGrpcExportClient(
+            new OtlpExporterOptions
+            {
+                Endpoint = new Uri("http://localhost:4317"),
+                Compression = OtlpExportCompression.None,
+            },
+            httpClient,
+            string.Empty);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            exportClient.SendExportRequest(buffer, buffer.Length, DateTime.UtcNow.AddSeconds(10), cts.Token));
+    }
+
     private static ExportClientGrpcResponse SendExportRequestThatThrows(Exception exception)
     {
         var buffer = BuildGrpcFrame("grpc test payload"u8.ToArray());

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpGrpcExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpGrpcExportClientTests.cs
@@ -182,8 +182,6 @@ public class OtlpGrpcExportClientTests
             httpClient,
             string.Empty);
 
-        // Use ThrowsAny to accept TaskCanceledException (a subtype of OperationCanceledException),
-        // which HttpClient may produce when wrapping a timeout that coincides with caller cancellation.
         Assert.ThrowsAny<OperationCanceledException>(() =>
             exportClient.SendExportRequest(buffer, buffer.Length, DateTime.UtcNow.AddSeconds(10), cts.Token));
     }
@@ -191,8 +189,6 @@ public class OtlpGrpcExportClientTests
     [Fact]
     public void SendExportRequest_CallerCancellationRequested_Propagates()
     {
-        // OperationCanceledException thrown when the caller's token is signaled must propagate
-        // rather than being swallowed and converted into an Unavailable response.
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpHttpExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpHttpExportClientTests.cs
@@ -190,7 +190,9 @@ public class OtlpHttpExportClientTests
             httpClient,
             string.Empty);
 
-        Assert.Throws<OperationCanceledException>(() =>
+        // Use ThrowsAny to accept TaskCanceledException (a subtype of OperationCanceledException),
+        // which HttpClient may produce when wrapping a timeout that coincides with caller cancellation.
+        Assert.ThrowsAny<OperationCanceledException>(() =>
             exportClient.SendExportRequest(payload, payload.Length, DateTime.UtcNow.AddSeconds(10), cts.Token));
     }
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpHttpExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpHttpExportClientTests.cs
@@ -115,6 +115,24 @@ public class OtlpHttpExportClientTests
     }
 
     [Fact]
+    public void SendExportRequest_UnexpectedException_ReturnsRetryableFailureResponse()
+    {
+        // A non-HTTP exception from a user-supplied DelegatingHandler (e.g. an auth handler
+        // that throws InvalidOperationException on a failed token refresh) must be caught and
+        // returned as a retryable failure rather than propagating out of SendExportRequest,
+        // which would kill the persistent-storage retry thread.
+        var exception = new InvalidOperationException("Auth handler failure.");
+
+        var response = SendExportRequestThatThrows(exception);
+
+        Assert.NotNull(response);
+        Assert.False(response.Success);
+        Assert.NotNull(response.Exception);
+        var httpResponse = Assert.IsType<ExportClientHttpResponse>(response);
+        Assert.True(OtlpRetry.IsRetryable(httpResponse), "An unexpected exception must produce a retryable failure response.");
+    }
+
+    [Fact]
     public void SendExportRequest_Timeout_ReturnsRetryableFailureResponse()
     {
         // A TaskCanceledException whose InnerException is a TimeoutException is
@@ -145,6 +163,62 @@ public class OtlpHttpExportClientTests
         Assert.False(response.Success);
         Assert.NotNull(response.Exception);
         Assert.True(RetryHelper.ShouldRetryRequest(response), "An unexpected cancellation should be retryable.");
+    }
+
+    [Fact]
+    public void SendExportRequest_TimeoutWithCallerCancellationRequested_Propagates()
+    {
+        // A TaskCanceledException with an inner TimeoutException must still propagate when
+        // the caller's token is also signaled. Without the cancellationToken guard in the
+        // when clause, the timeout catch fires first and swallows the caller cancellation.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var payload = "hello world"u8.ToArray();
+
+        using var testHandler = new ThrowingHttpMessageHandler(
+            new TaskCanceledException("The request timed out.", new TimeoutException()));
+        using var httpClient = new HttpClient(testHandler, disposeHandler: false);
+
+        var exportClient = new OtlpHttpExportClient(
+            new OtlpExporterOptions
+            {
+                Endpoint = new Uri("http://localhost:4318"),
+                Protocol = OtlpExportProtocol.HttpProtobuf,
+                Compression = OtlpExportCompression.None,
+            },
+            httpClient,
+            string.Empty);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            exportClient.SendExportRequest(payload, payload.Length, DateTime.UtcNow.AddSeconds(10), cts.Token));
+    }
+
+    [Fact]
+    public void SendExportRequest_CallerCancellationRequested_Propagates()
+    {
+        // OperationCanceledException thrown when the caller's token is signaled must propagate
+        // rather than being swallowed and converted into a retryable response.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var payload = "hello world"u8.ToArray();
+
+        using var testHandler = new ThrowingHttpMessageHandler(new OperationCanceledException(cts.Token));
+        using var httpClient = new HttpClient(testHandler, disposeHandler: false);
+
+        var exportClient = new OtlpHttpExportClient(
+            new OtlpExporterOptions
+            {
+                Endpoint = new Uri("http://localhost:4318"),
+                Protocol = OtlpExportProtocol.HttpProtobuf,
+                Compression = OtlpExportCompression.None,
+            },
+            httpClient,
+            string.Empty);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            exportClient.SendExportRequest(payload, payload.Length, DateTime.UtcNow.AddSeconds(10), cts.Token));
     }
 
     private static ExportClientResponse SendExportRequestThatThrows(Exception exception)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpRetryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpRetryTests.cs
@@ -11,6 +11,22 @@ public class OtlpRetryTests
 
     public static TheoryData<HttpRetryTestCase> HttpRetryTestData => HttpRetryTestCase.GetHttpTestCases();
 
+    [Fact]
+    public void IsRetryable_GrpcUnexpectedExceptionResponse_ReturnsTrue()
+    {
+        // OtlpGrpcExportClient catches unexpected exceptions and returns a response with
+        // StatusCode.Unavailable so that any blob written to persistent storage is retained
+        // rather than deleted. Guard that the classification stays retryable.
+        var response = new ExportClientGrpcResponse(
+            success: false,
+            deadlineUtc: DateTime.UtcNow.AddSeconds(10),
+            exception: new InvalidOperationException("unexpected"),
+            status: new Status(StatusCode.Unavailable, "Unexpected error - retryable"),
+            grpcStatusDetailsHeader: null);
+
+        Assert.True(OtlpRetry.IsRetryable(response));
+    }
+
     [Theory]
     [MemberData(nameof(GrpcRetryTestData))]
     public void TryGetGrpcRetryResultTest(GrpcRetryTestCase testCase)


### PR DESCRIPTION
## Changes

This PR fixes two related bugs in the OTLP exporter's disk retry path that together cause silent, permanent data loss for the process lifetime.

Bug 1 - Retry thread terminates permanently on first unexpected exception

`RetryStoredRequests` had a single outer catch (Exception) that returned from the method, killing the singleton background thread on any unexpected exception thrown while processing a blob. After that point, `OnSubmitRequestFailure` continued writing blobs to disk, nothing ever re-read them, and the 2-day retention window silently expired them.

The fix wraps the per-blob work in its own try/catch that logs and continues to the next blob, leaving any failed blob on disk to be retried when its lease expires. The outer catch is kept for exceptions thrown by the wait handles themselves (e.g. `ObjectDisposedException` after `Dispose` without `Shutdown`), which is the only case where returning is correct.

Bug 2 - `OtlpHttpExportClient` lacked a catch-all, unlike the gRPC client

`OtlpGrpcExportClient` had a catch fallback, but `OtlpHttpExportClient` only caught `HttpRequestException`, `TaskCanceledException`, and `OperationCanceledException`. Exceptions such as `ObjectDisposedException` (from a disposed `HttpClient` during a shutdown race) or `InvalidOperationException`/`FormatException` from a restricted header escaped directly into the retry thread's outer catch, triggering Bug 1.

The fix adds a catch fallback to `OtlpHttpExportClient.SendExportRequest` that returns a failed `ExportClientHttpResponse` with no HTTP status code. `OtlpRetry.IsRetryable` treats a missing status code as retryable, so any blob written to persistent storage is preserved rather than deleted.

Related fix in gRPC client

The gRPC catch-all previously returned a static response with a null status, which `RetryHelper.ShouldRetryRequest` would classify as non-retryable (deleting the blob). It is now changed to return `StatusCode.Unavailable`, making the response retryable and consistent with the HTTP fix. The `TaskCanceledException` filter is also tightened on both clients to not swallow real cancellations when the token is already cancelled.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~