### PR TITLE
Add otel.sdk.processor.span.processed SDK self-observability metric

### DIFF
--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
-override OpenTelemetry.BatchLogRecordExportProcessor.OnShutdown(int timeoutMilliseconds) -> bool
+override OpenTelemetry.SimpleActivityExportProcessor.OnShutdown(int timeoutMilliseconds) -> bool
 override OpenTelemetry.SimpleLogRecordExportProcessor.OnEnd(OpenTelemetry.Logs.LogRecord! data) -> void
 override OpenTelemetry.SimpleLogRecordExportProcessor.OnShutdown(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -25,6 +25,12 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
 
     private readonly CircularBuffer<T> circularBuffer;
     private readonly BatchExportWorker<T> worker;
+
+    // Number of OnEnd calls currently in-flight (past the shutdown check).
+    // OnShutdown waits for this to reach zero so those items finish enqueueing
+    // before teardown, keeping the processed vs. already_shutdown counting race-free.
+    private int activeOnEndCount;
+    private int isShutdown;
     private bool disposed;
 
     /// <summary>
@@ -74,6 +80,47 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
     /// </summary>
     internal long ProcessedCount => this.circularBuffer.RemovedCount;
 
+    /// <summary>
+    /// Gets a value indicating whether <see cref="OnShutdown(int)"/> has been invoked.
+    /// </summary>
+    private bool IsShutdown => Volatile.Read(ref this.isShutdown) != 0;
+
+    /// <summary>
+    /// Marks the beginning of an <see cref="BaseProcessor{T}.OnEnd(T)"/> call which may enqueue data.
+    /// </summary>
+    /// <remarks>
+    /// When this returns <see langword="true"/> the caller MUST invoke <see
+    /// cref="ExitOnEnd"/> once it is done enqueueing. When it returns <see
+    /// langword="false"/> the processor has already been shut down and the
+    /// caller MUST NOT enqueue.
+    /// </remarks>
+    /// <returns><see langword="true"/> if the caller may proceed to enqueue data.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryEnterOnEnd()
+    {
+        if (this.IsShutdown)
+        {
+            return false;
+        }
+
+        Interlocked.Increment(ref this.activeOnEndCount);
+
+        if (this.IsShutdown)
+        {
+            Interlocked.Decrement(ref this.activeOnEndCount);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Marks the end of an <see cref="BaseProcessor{T}.OnEnd(T)"/> call started by <see cref="TryEnterOnEnd"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void ExitOnEnd()
+        => Interlocked.Decrement(ref this.activeOnEndCount);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool TryExport(T data)
     {
@@ -89,8 +136,16 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
 
         // either the queue is full or exceeded the spin limit, drop the item on the floor
         this.worker.IncrementDroppedCount();
+        this.OnItemDropped();
 
         return false;
+    }
+
+    /// <summary>
+    /// Invoked when an item could not be enqueued and was dropped.
+    /// </summary>
+    internal virtual void OnItemDropped()
+    {
     }
 
     /// <inheritdoc/>
@@ -104,6 +159,13 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
     /// <inheritdoc/>
     protected override bool OnShutdown(int timeoutMilliseconds)
     {
+        // Note: BaseProcessor.Shutdown guarantees OnShutdown is invoked at most once, so
+        // the previous value is discarded. Interlocked is used instead of Volatile.Write
+        // for the full fence it provides, which TryEnterOnEnd relies on.
+        _ = Interlocked.Exchange(ref this.isShutdown, 1);
+
+        timeoutMilliseconds = this.WaitForActiveOnEndCalls(timeoutMilliseconds);
+
         long? timestamp = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.GetTimestamp();
 
         var result = this.worker.Shutdown(timeoutMilliseconds);
@@ -172,4 +234,41 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
 
     private void OnExportStarted(long count)
         => this.ExportStarted?.Invoke(count);
+
+    /// <summary>
+    /// Waits for in-flight <see cref="BaseProcessor{T}.OnEnd(T)"/> calls to finish enqueueing so
+    /// teardown is consistent, without exceeding the caller's shutdown budget.
+    /// </summary>
+    /// <param name="timeoutMilliseconds">The shutdown timeout supplied by the caller.</param>
+    /// <returns>The remaining timeout available for the rest of the shutdown sequence.</returns>
+    private int WaitForActiveOnEndCalls(int timeoutMilliseconds)
+    {
+        if (Volatile.Read(ref this.activeOnEndCount) == 0)
+        {
+            return timeoutMilliseconds;
+        }
+
+        SpinWait spinner = default;
+
+        if (timeoutMilliseconds == Timeout.Infinite)
+        {
+            while (Volatile.Read(ref this.activeOnEndCount) != 0)
+            {
+                spinner.SpinOnce();
+            }
+
+            return Timeout.Infinite;
+        }
+
+        var startedAt = Stopwatch.GetTimestamp();
+        int remainingMilliseconds;
+
+        while ((remainingMilliseconds = Stopwatch.Remaining(timeoutMilliseconds, startedAt)) > 0
+            && Volatile.Read(ref this.activeOnEndCount) != 0)
+        {
+            spinner.SpinOnce();
+        }
+
+        return remainingMilliseconds;
+    }
 }

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -18,6 +18,15 @@ Notes](../../RELEASENOTES.md).
 * Added the `otel.sdk.processor.log.processed` SDK self-observability metric.
   ([#7486](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7486))
 
+* Added the `otel.sdk.processor.span.processed` SDK self-observability metric.
+  ([#7598](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7598))
+
+* `BatchActivityExportProcessor` and `SimpleActivityExportProcessor` no longer
+  forward spans to the exporter once `Shutdown` has been called, and
+  `BatchActivityExportProcessor.Shutdown` now waits for in-flight `OnEnd` calls
+  to finish enqueueing before flushing.
+  ([#7598](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7598))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry/Internal/SdkSelfObservability.cs
+++ b/src/OpenTelemetry/Internal/SdkSelfObservability.cs
@@ -11,11 +11,25 @@ namespace OpenTelemetry;
 /// </summary>
 internal static class SdkSelfObservability
 {
+    /// <summary>
+    /// The name of the <see cref="System.Diagnostics.Metrics.Meter"/> used for SDK self-observability metrics.
+    /// </summary>
+    /// <remarks>
+    /// This is a constant so that it can be referenced without triggering the static
+    /// initialization of this class, which would create the instruments.
+    /// </remarks>
+    internal const string MeterName = "otel.sdk.experimental";
+
     internal static readonly Meter Meter = MeterFactory.Create(
-        typeof(SdkSelfObservability), semanticConventionsVersion: null, name: "otel.sdk.experimental");
+        typeof(SdkSelfObservability), semanticConventionsVersion: null, name: MeterName);
 
     internal static readonly Counter<long> LogProcessedCounter = Meter.CreateCounter<long>(
         "otel.sdk.processor.log.processed",
         "{log_record}",
         "The number of log records for which the processing has finished, either successful or failed.");
+
+    internal static readonly Counter<long> SpanProcessedCounter = Meter.CreateCounter<long>(
+        "otel.sdk.processor.span.processed",
+        "{span}",
+        "The number of spans for which the processing has finished, either successful or failed.");
 }

--- a/src/OpenTelemetry/Logs/Processor/BatchLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/Processor/BatchLogRecordExportProcessor.cs
@@ -17,12 +17,6 @@ public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
     private readonly KeyValuePair<string, object?>[] queueFullTags;
     private readonly KeyValuePair<string, object?>[] alreadyShutdownTags;
 
-    // Number of OnEnd calls currently in-flight (past the shutdown check).
-    // OnShutdown waits for this to reach zero so those records finish enqueueing
-    // before teardown, keeping the processed vs. already_shutdown counting race-free.
-    private int activeOnEndCount;
-    private int isShutdown;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="BatchLogRecordExportProcessor"/> class.
     /// </summary>
@@ -60,23 +54,14 @@ public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
     /// <inheritdoc/>
     public override void OnEnd(LogRecord data)
     {
-        if (Volatile.Read(ref this.isShutdown) != 0)
+        if (!this.TryEnterOnEnd())
         {
             SdkSelfObservability.LogProcessedCounter.Add(1, this.alreadyShutdownTags);
             return;
         }
 
-        Interlocked.Increment(ref this.activeOnEndCount);
         try
         {
-            if (Volatile.Read(ref this.isShutdown) != 0)
-            {
-                SdkSelfObservability.LogProcessedCounter.Add(1, this.alreadyShutdownTags);
-                return;
-            }
-
-            bool enqueued;
-
             // Note: Intentionally not using Guard.ThrowIfNull to save prod cycles
 #pragma warning disable CA1062 // Validate arguments of public methods
             switch (data.Source)
@@ -85,8 +70,7 @@ public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
                 case LogRecord.LogRecordSource.FromSharedPool:
                     data.Buffer();
                     data.AddReference();
-                    enqueued = this.TryExport(data);
-                    if (!enqueued)
+                    if (!this.TryExport(data))
                     {
                         LogRecordSharedPool.Current.Return(data);
                     }
@@ -95,7 +79,7 @@ public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
 
                 case LogRecord.LogRecordSource.CreatedManually:
                     data.Buffer();
-                    enqueued = this.TryExport(data);
+                    this.TryExport(data);
                     break;
 
                 case LogRecord.LogRecordSource.FromThreadStaticPool:
@@ -103,48 +87,20 @@ public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
                     Debug.Assert(data.Source == LogRecord.LogRecordSource.FromThreadStaticPool, "LogRecord source was something unexpected");
 
                     // Note: If we are using ThreadStatic pool we make a copy of the record.
-                    enqueued = this.TryExport(data.Copy());
+                    this.TryExport(data.Copy());
                     break;
-            }
-
-            // TODO(#7586): Consider an ObservableCounter instead of per-item Counter.Add(). See #7486.
-            if (!enqueued)
-            {
-                SdkSelfObservability.LogProcessedCounter.Add(1, this.queueFullTags);
             }
         }
         finally
         {
-            Interlocked.Decrement(ref this.activeOnEndCount);
+            this.ExitOnEnd();
         }
     }
 
-    /// <inheritdoc/>
-    protected override bool OnShutdown(int timeoutMilliseconds)
-    {
-        Interlocked.Exchange(ref this.isShutdown, 1);
-
-        // Wait for in-flight OnEnd calls to finish so teardown is consistent,
-        // without exceeding the caller's shutdown budget.
-        var stopwatch = timeoutMilliseconds == Timeout.Infinite ? null : Stopwatch.StartNew();
-
-        SpinWait spinner = default;
-        while (Volatile.Read(ref this.activeOnEndCount) != 0)
-        {
-            if (stopwatch != null && stopwatch.ElapsedMilliseconds >= timeoutMilliseconds)
-            {
-                break;
-            }
-
-            spinner.SpinOnce();
-        }
-
-        var remainingTimeoutMilliseconds = stopwatch == null
-            ? Timeout.Infinite
-            : (int)Math.Max(0, timeoutMilliseconds - stopwatch.ElapsedMilliseconds);
-
-        return base.OnShutdown(remainingTimeoutMilliseconds);
-    }
+    // TODO: https://github.com/open-telemetry/opentelemetry-dotnet/issues/7586
+    // Consider an ObservableCounter instead of per-item Counter.Add().
+    internal override void OnItemDropped()
+        => SdkSelfObservability.LogProcessedCounter.Add(1, this.queueFullTags);
 
     private void RecordSuccessfulProcessing(long count)
         => SdkSelfObservability.LogProcessedCounter.Add(count, this.successTags);

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -239,11 +239,18 @@ internal sealed class MeterProviderSdk : MeterProvider
         }
         else if (!listenToInstrumentUsingSdkConfiguration && !listeningIsManagedExternally)
         {
-            OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
-                instrument.Name,
-                instrument.Meter.Name,
-                "Instrument belongs to a Meter not subscribed by this provider. If another MeterProvider is configured to listen to this Meter, this warning can be ignored.",
-                "Use AddMeter to add the Meter to the provider.");
+            // Note: The SDK always creates its self-observability instruments, but they are
+            // opt-in. Warning that they are ignored would be noise for users who never asked
+            // for them, so it is suppressed here.
+            if (!string.Equals(instrument.Meter.Name, SdkSelfObservability.MeterName, StringComparison.Ordinal))
+            {
+                OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
+                    instrument.Name,
+                    instrument.Meter.Name,
+                    "Instrument belongs to a Meter not subscribed by this provider. If another MeterProvider is configured to listen to this Meter, this warning can be ignored.",
+                    "Use AddMeter to add the Meter to the provider.");
+            }
+
             return null;
         }
 

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -49,8 +49,8 @@ SDK](../../docs/README.md#initialize-the-sdk).
 ## Self-Observability (Experimental)
 
 The SDK can emit metrics about its own internal operations, enabling operators to
-monitor the health of the telemetry pipeline itself (e.g., detecting dropped log
-records due to queue overflow).
+monitor the health of the telemetry pipeline itself (e.g., detecting dropped
+telemetry due to queue overflow).
 
 > [!NOTE]
 > Self-observability metrics are **experimental** and may change in future
@@ -77,22 +77,34 @@ Conventions](https://opentelemetry.io/docs/specs/semconv/otel/sdk-metrics/).
 | Metric Name | Instrument | Unit | Description |
 | --- | --- | --- | --- |
 | `otel.sdk.processor.log.processed` | Counter | `{log_record}` | Number of log records processed by the SDK, tagged with outcome. |
+| `otel.sdk.processor.span.processed` | Counter | `{span}` | Number of spans processed by the SDK, tagged with outcome. |
 
 ### Attributes
 
 | Attribute | Description | Example |
 | --- | --- | --- |
-| `otel.component.type` | The processor type. | `batching_log_processor`, `simple_log_processor` |
-| `otel.component.name` | Unique instance identifier. | `batching_log_processor/0` |
+| `otel.component.type` | The processor type. | `batching_log_processor`, `simple_log_processor`, `batching_span_processor`, `simple_span_processor` |
+| `otel.component.name` | Unique instance identifier. | `batching_log_processor/0`, `batching_span_processor/0` |
 | `error.type` | Present only on failure. | `queue_full`, `already_shutdown` |
 
-When `error.type` is absent, the log record was successfully accepted by the
-processor. When present:
+When `error.type` is absent, the item was successfully accepted by the
+processor. This means the processor completed its intended handling of the
+item; for the Simple and Batching processors it is recorded when the item is
+handed to the exporter, and it does **not** indicate that the export itself
+succeeded or that the item reached the backend. Export failures are not
+reflected in this metric. When present:
 
-* `queue_full` - The batch processor's internal queue was full; the log record
-  was dropped.
-* `already_shutdown` - The processor had already been shut down; the log record
-  was lost.
+* `queue_full` - The batch processor's internal queue was full; the item was
+  dropped.
+* `already_shutdown` - The processor had already been shut down; the item was
+  lost.
+
+> [!NOTE]
+> Sampling affects `otel.sdk.processor.span.processed` as follows. Spans dropped
+> by the sampler (`DROP`) are not counted, because span processors are not
+> invoked for them at all. Spans sampled as `RECORD_ONLY` are counted as
+> successfully processed because they do reach the processor and by design are
+> never handed to an exporter.
 
 ## Troubleshooting
 

--- a/src/OpenTelemetry/Trace/Processor/BatchActivityExportProcessor.cs
+++ b/src/OpenTelemetry/Trace/Processor/BatchActivityExportProcessor.cs
@@ -11,6 +11,12 @@ namespace OpenTelemetry;
 /// </summary>
 public class BatchActivityExportProcessor : BatchExportProcessor<Activity>
 {
+    private static long instanceCounter = -1;
+
+    private readonly KeyValuePair<string, object?>[] successTags;
+    private readonly KeyValuePair<string, object?>[] queueFullTags;
+    private readonly KeyValuePair<string, object?>[] alreadyShutdownTags;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BatchActivityExportProcessor"/> class.
     /// </summary>
@@ -32,6 +38,17 @@ public class BatchActivityExportProcessor : BatchExportProcessor<Activity>
             exporterTimeoutMilliseconds,
             maxExportBatchSize)
     {
+        var index = Interlocked.Increment(ref instanceCounter);
+        var componentName = "batching_span_processor/" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var baseTags = new KeyValuePair<string, object?>[]
+        {
+            new("otel.component.type", "batching_span_processor"),
+            new("otel.component.name", componentName),
+        };
+        this.successTags = baseTags;
+        this.queueFullTags = [.. baseTags, new("error.type", "queue_full")];
+        this.alreadyShutdownTags = [.. baseTags, new("error.type", "already_shutdown")];
+        this.ExportStarted = this.RecordSuccessfulProcessing;
     }
 
     /// <inheritdoc />
@@ -42,9 +59,40 @@ public class BatchActivityExportProcessor : BatchExportProcessor<Activity>
         if (!data.Recorded)
 #pragma warning restore CA1062 // Validate arguments of public methods - needed for netstandard2.1
         {
+            if (data.IsAllDataRequested)
+            {
+                // RECORD_ONLY: the span reaches the processor but by design is never
+                // handed to an exporter, so its processing is complete and successful.
+                SdkSelfObservability.SpanProcessedCounter.Add(1, this.successTags);
+            }
+
+            // Note: TracerProviderSdk does not invoke processors for activities with
+            // IsAllDataRequested set to false (spans the sampler dropped), so that case is
+            // only reachable when OnEnd is called directly. Such spans are not counted.
             return;
         }
 
-        this.OnExport(data);
+        if (!this.TryEnterOnEnd())
+        {
+            SdkSelfObservability.SpanProcessedCounter.Add(1, this.alreadyShutdownTags);
+            return;
+        }
+
+        try
+        {
+            this.OnExport(data);
+        }
+        finally
+        {
+            this.ExitOnEnd();
+        }
     }
+
+    // TODO: https://github.com/open-telemetry/opentelemetry-dotnet/issues/7586
+    // Consider an ObservableCounter instead of per-item Counter.Add().
+    internal override void OnItemDropped()
+        => SdkSelfObservability.SpanProcessedCounter.Add(1, this.queueFullTags);
+
+    private void RecordSuccessfulProcessing(long count)
+        => SdkSelfObservability.SpanProcessedCounter.Add(count, this.successTags);
 }

--- a/src/OpenTelemetry/Trace/Processor/SimpleActivityExportProcessor.cs
+++ b/src/OpenTelemetry/Trace/Processor/SimpleActivityExportProcessor.cs
@@ -11,6 +11,13 @@ namespace OpenTelemetry;
 /// </summary>
 public class SimpleActivityExportProcessor : SimpleExportProcessor<Activity>
 {
+    private static long instanceCounter = -1;
+
+    private readonly KeyValuePair<string, object?>[] successTags;
+    private readonly KeyValuePair<string, object?>[] alreadyShutdownTags;
+
+    private int isShutdown;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SimpleActivityExportProcessor"/> class.
     /// </summary>
@@ -18,6 +25,15 @@ public class SimpleActivityExportProcessor : SimpleExportProcessor<Activity>
     public SimpleActivityExportProcessor(BaseExporter<Activity> exporter)
         : base(exporter)
     {
+        var index = Interlocked.Increment(ref instanceCounter);
+        var componentName = "simple_span_processor/" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var baseTags = new KeyValuePair<string, object?>[]
+        {
+            new("otel.component.type", "simple_span_processor"),
+            new("otel.component.name", componentName),
+        };
+        this.successTags = baseTags;
+        this.alreadyShutdownTags = [.. baseTags, new("error.type", "already_shutdown")];
     }
 
     /// <inheritdoc />
@@ -28,9 +44,40 @@ public class SimpleActivityExportProcessor : SimpleExportProcessor<Activity>
         if (!data.Recorded)
 #pragma warning restore CA1062 // Validate arguments of public methods - needed for netstandard2.1
         {
+            if (data.IsAllDataRequested)
+            {
+                // RECORD_ONLY: the span reaches the processor but by design is never
+                // handed to an exporter, so its processing is complete and successful.
+                SdkSelfObservability.SpanProcessedCounter.Add(1, this.successTags);
+            }
+
+            // Note: TracerProviderSdk does not invoke processors for activities with
+            // IsAllDataRequested set to false (spans the sampler dropped), so that case is
+            // only reachable when OnEnd is called directly. Such spans are not counted.
             return;
         }
 
+        // SimpleActivityExportProcessor exports synchronously per span and is not
+        // intended for production use. We accept a benign shutdown race here: a span
+        // whose OnEnd runs concurrently with OnShutdown may be exported and counted
+        // as processed, or counted as already_shutdown, depending on timing.
+        // Exporters are required to be safe against concurrent and post-shutdown
+        // Export calls, so this is harmless; we keep the processor simple rather
+        // than add barrier synchronization.
+        if (Volatile.Read(ref this.isShutdown) != 0)
+        {
+            SdkSelfObservability.SpanProcessedCounter.Add(1, this.alreadyShutdownTags);
+            return;
+        }
+
+        SdkSelfObservability.SpanProcessedCounter.Add(1, this.successTags);
         this.OnExport(data);
+    }
+
+    /// <inheritdoc/>
+    protected override bool OnShutdown(int timeoutMilliseconds)
+    {
+        _ = Interlocked.Exchange(ref this.isShutdown, 1);
+        return base.OnShutdown(timeoutMilliseconds);
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/ActivityExportProcessorSelfObservabilityTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExportProcessorSelfObservabilityTests.cs
@@ -1,0 +1,600 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma warning disable CA2000 // Provider takes ownership of processor/exporter
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Tests.Trace;
+
+public class ActivityExportProcessorSelfObservabilityTests
+{
+    private const string MetricName = "otel.sdk.processor.span.processed";
+
+    [Fact]
+    public async Task BatchProcessor_CountsSuccessWhenSubmittedToExporter()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        using var exportStarted = new ManualResetEventSlim(false);
+        using var allowExport = new ManualResetEventSlim(false);
+        using var exporter = new DelegatingExporter<Activity>
+        {
+            OnExportFunc = batch =>
+            {
+                exportStarted.Set();
+                allowExport.Wait();
+                return ExportResult.Success;
+            },
+        };
+        using var processor = new BatchActivityExportProcessor(
+            exporter,
+            scheduledDelayMilliseconds: int.MaxValue);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(processor)
+            .Build();
+
+        StartAndStopActivities(source, 3);
+
+        meterProvider.ForceFlush();
+        Assert.DoesNotContain(exportedMetrics, m => m.Name == MetricName);
+
+        var flushTask = Task.Run(() => processor.ForceFlush());
+        try
+        {
+            Assert.True(exportStarted.Wait(TimeSpan.FromSeconds(5)));
+            meterProvider.ForceFlush();
+
+            var points = GetMetricPoints(exportedMetrics);
+            var successPoint = points.Single(p => !HasTag(p, "error.type"));
+
+            Assert.Equal(3, successPoint.GetSumLong());
+            AssertTag(successPoint, "otel.component.type", "batching_span_processor");
+            AssertTagStartsWith(successPoint, "otel.component.name", "batching_span_processor/");
+        }
+        finally
+        {
+            allowExport.Set();
+        }
+
+        Assert.True(await flushTask);
+    }
+
+    [Fact]
+    public void BatchProcessor_QueueFull()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        // Use a blocking exporter so the worker thread holds the queue slot
+        // while we overflow it, guaranteeing drops.
+        using var exportStarted = new ManualResetEventSlim(false);
+        using var allowExport = new ManualResetEventSlim(false);
+        using var exporter = new DelegatingExporter<Activity>
+        {
+            OnExportFunc = batch =>
+            {
+                exportStarted.Set();
+                allowExport.Wait();
+                return ExportResult.Success;
+            },
+        };
+        using var processor = new BatchActivityExportProcessor(
+            exporter,
+            maxQueueSize: 1,
+            scheduledDelayMilliseconds: 1,
+            maxExportBatchSize: 1);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(processor)
+            .Build();
+
+        // First span triggers the worker; wait for it to block in Export.
+        StartAndStopActivities(source, 1);
+        Assert.True(exportStarted.Wait(TimeSpan.FromSeconds(5)));
+
+        // Now the queue is being drained but the worker is blocked.
+        // Subsequent spans will overflow the queue (size=1).
+        StartAndStopActivities(source, 5);
+
+        // Release the exporter so the flush can complete.
+        allowExport.Set();
+        processor.ForceFlush();
+
+        meterProvider.ForceFlush();
+
+        var points = GetMetricPoints(exportedMetrics);
+        var queueFullPoint = points.Single(p => HasTagValue(p, "error.type", "queue_full"));
+
+        Assert.True(queueFullPoint.GetSumLong() > 0);
+        Assert.Equal(6, points.Sum(p => p.GetSumLong()));
+    }
+
+    [Fact]
+    public void BatchProcessor_AfterShutdown()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        var exportedActivities = new List<Activity>();
+        using var exporter = new InMemoryExporter<Activity>(exportedActivities);
+        var processor = new BatchActivityExportProcessor(exporter);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(processor)
+            .Build();
+
+        StartAndStopActivities(source, 2);
+
+        processor.Shutdown();
+
+        StartAndStopActivities(source, 1);
+
+        meterProvider.ForceFlush();
+
+        var points = GetMetricPoints(exportedMetrics);
+        var shutdownPoint = points.Single(p => HasTagValue(p, "error.type", "already_shutdown"));
+        var successPoint = points.Single(p => !HasTag(p, "error.type"));
+
+        Assert.Equal(1, shutdownPoint.GetSumLong());
+        Assert.Equal(2, successPoint.GetSumLong());
+        Assert.Equal(2, exportedActivities.Count);
+    }
+
+    [Fact]
+    public void SimpleProcessor_SuccessAndShutdown()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        var exportedActivities = new List<Activity>();
+        using var exporter = new InMemoryExporter<Activity>(exportedActivities);
+        var processor = new SimpleActivityExportProcessor(exporter);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(processor)
+            .Build();
+
+        StartAndStopActivities(source, 2);
+
+        processor.Shutdown();
+
+        StartAndStopActivities(source, 1);
+
+        meterProvider.ForceFlush();
+
+        var points = GetMetricPoints(exportedMetrics);
+
+        var successPoint = points.Single(p =>
+            HasTagValue(p, "otel.component.type", "simple_span_processor") && !HasTag(p, "error.type"));
+        var shutdownPoint = points.Single(p =>
+            HasTagValue(p, "otel.component.type", "simple_span_processor") && HasTagValue(p, "error.type", "already_shutdown"));
+
+        Assert.Equal(2, successPoint.GetSumLong());
+        Assert.Equal(1, shutdownPoint.GetSumLong());
+        Assert.Equal(2, exportedActivities.Count);
+        AssertTagStartsWith(successPoint, "otel.component.name", "simple_span_processor/");
+    }
+
+    [Fact]
+    public void MultipleProcessors_DistinctComponentNames()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        using var exporter1 = new InMemoryExporter<Activity>(new List<Activity>());
+        using var exporter2 = new InMemoryExporter<Activity>(new List<Activity>());
+        using var batch1 = new BatchActivityExportProcessor(exporter1);
+        using var batch2 = new BatchActivityExportProcessor(exporter2);
+        using var simple = new SimpleActivityExportProcessor(exporter1);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(batch1)
+            .AddProcessor(batch2)
+            .AddProcessor(simple)
+            .Build();
+
+        StartAndStopActivities(source, 2);
+
+        batch1.ForceFlush();
+        batch2.ForceFlush();
+        meterProvider.ForceFlush();
+
+        var points = GetMetricPoints(exportedMetrics);
+
+        // Each processor instance gets a unique otel.component.name, so we expect
+        // separate MetricPoints for each: 2 batch + 1 simple = 3 distinct streams.
+        var batchPoints = points.Where(p => HasTagValue(p, "otel.component.type", "batching_span_processor")).ToList();
+        var simplePoints = points.Where(p => HasTagValue(p, "otel.component.type", "simple_span_processor")).ToList();
+
+        Assert.Equal(2, batchPoints.Count);
+        Assert.Single(simplePoints);
+
+        // Each batch processor received the same 2 spans (composite processor fans out).
+        Assert.All(batchPoints, p => Assert.Equal(2, p.GetSumLong()));
+        Assert.Equal(2, simplePoints[0].GetSumLong());
+
+        // Verify component names are distinct across batch processors.
+        var batchNames = batchPoints
+            .Select(p => GetTagValue(p, "otel.component.name"))
+            .ToList();
+        Assert.Equal(2, batchNames.Distinct().Count());
+    }
+
+    [Fact]
+    public void DroppedSpansDoNotReachProcessorsAndAreNotCounted()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        using var batchExporter = new InMemoryExporter<Activity>(new List<Activity>());
+        using var simpleExporter = new InMemoryExporter<Activity>(new List<Activity>());
+        using var batch = new BatchActivityExportProcessor(batchExporter);
+        using var simple = new SimpleActivityExportProcessor(simpleExporter);
+        var onEndCalls = 0;
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOffSampler())
+            .AddProcessor(new TestActivityProcessor(_ => { }, _ => Interlocked.Increment(ref onEndCalls)))
+            .AddProcessor(batch)
+            .AddProcessor(simple)
+            .Build();
+
+        // Root spans dropped by the sampler are still created as PropagationData
+        // activities so that trace context propagates, but TracerProviderSdk filters
+        // them out (IsAllDataRequested is false) before invoking any processor.
+        var activities = StartAndStopActivities(source, 5);
+        Assert.Equal(5, activities.Count);
+        Assert.All(activities, a =>
+        {
+            Assert.False(a.Recorded);
+            Assert.False(a.IsAllDataRequested);
+        });
+
+        batch.ForceFlush();
+        meterProvider.ForceFlush();
+
+        Assert.Equal(0, onEndCalls);
+        Assert.DoesNotContain(exportedMetrics, m => m.Name == MetricName);
+    }
+
+    [Fact]
+    public void DroppedSpanPassedDirectlyToOnEndIsNotCounted()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        using var batchExporter = new InMemoryExporter<Activity>(new List<Activity>());
+        using var simpleExporter = new InMemoryExporter<Activity>(new List<Activity>());
+        using var batch = new BatchActivityExportProcessor(batchExporter);
+        using var simple = new SimpleActivityExportProcessor(simpleExporter);
+
+        // TracerProviderSdk never hands a dropped span to a processor, but the processors
+        // are public API and can be invoked directly, so guard that path explicitly.
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.PropagationData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = source.StartActivity("test");
+        Assert.NotNull(activity);
+        Assert.False(activity.Recorded);
+        Assert.False(activity.IsAllDataRequested);
+
+        batch.OnEnd(activity);
+        simple.OnEnd(activity);
+
+        batch.ForceFlush();
+        meterProvider.ForceFlush();
+
+        Assert.DoesNotContain(exportedMetrics, m => m.Name == MetricName);
+    }
+
+    // RECORD_ONLY spans are counted as successfully processed per the clarification
+    // proposed in https://github.com/open-telemetry/semantic-conventions/pull/3978.
+    [Fact]
+    public void RecordOnlySpansAreCountedAsSuccess()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        var batchExported = new List<Activity>();
+        var simpleExported = new List<Activity>();
+        using var batchExporter = new InMemoryExporter<Activity>(batchExported);
+        using var simpleExporter = new InMemoryExporter<Activity>(simpleExported);
+        using var batch = new BatchActivityExportProcessor(batchExporter);
+        using var simple = new SimpleActivityExportProcessor(simpleExporter);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new RecordOnlySampler())
+            .AddProcessor(batch)
+            .AddProcessor(simple)
+            .Build();
+
+        var activities = StartAndStopActivities(source, 3);
+        Assert.Equal(3, activities.Count);
+        Assert.All(activities, a =>
+        {
+            Assert.False(a.Recorded);
+            Assert.True(a.IsAllDataRequested);
+        });
+
+        batch.ForceFlush();
+        meterProvider.ForceFlush();
+
+        var points = GetMetricPoints(exportedMetrics);
+
+        var batchPoint = points.Single(p => HasTagValue(p, "otel.component.type", "batching_span_processor"));
+        var simplePoint = points.Single(p => HasTagValue(p, "otel.component.type", "simple_span_processor"));
+
+        Assert.Equal(3, batchPoint.GetSumLong());
+        Assert.Equal(3, simplePoint.GetSumLong());
+        Assert.False(HasTag(batchPoint, "error.type"));
+        Assert.False(HasTag(simplePoint, "error.type"));
+
+        // RECORD_ONLY spans are counted as processed but must never reach an exporter.
+        Assert.Empty(batchExported);
+        Assert.Empty(simpleExported);
+    }
+
+    [Fact]
+    public void RecordOnlySpansAreCountedAsSuccessAfterShutdown()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        using var exporter = new InMemoryExporter<Activity>(new List<Activity>());
+        var processor = new BatchActivityExportProcessor(exporter);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new RecordOnlySampler())
+            .AddProcessor(processor)
+            .Build();
+
+        processor.Shutdown();
+
+        StartAndStopActivities(source, 2);
+
+        meterProvider.ForceFlush();
+
+        // Shutdown does not change the outcome for a RECORD_ONLY span: it was never
+        // going to be exported, so nothing is lost and it is not "already_shutdown".
+        var points = GetMetricPoints(exportedMetrics);
+        var point = points.Single();
+
+        Assert.Equal(2, point.GetSumLong());
+        Assert.False(HasTag(point, "error.type"));
+    }
+
+    [Fact]
+    public void NoListener_NoException()
+    {
+        // No MeterProvider subscribing to "otel.sdk.experimental" - verifying no exceptions.
+        using var exporter = new InMemoryExporter<Activity>(new List<Activity>());
+        using var processor = new BatchActivityExportProcessor(exporter);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(processor)
+            .Build();
+
+        StartAndStopActivities(source, 100);
+    }
+
+    [Fact]
+    public void BatchProcessor_OnEndInvokesOnExportOverride()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        var exportedActivities = new List<Activity>();
+        using var exporter = new InMemoryExporter<Activity>(exportedActivities);
+        using var processor = new OnExportTrackingBatchActivityExportProcessor(exporter);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(processor)
+            .Build();
+
+        StartAndStopActivities(source, 3);
+        processor.ForceFlush();
+        meterProvider.ForceFlush();
+
+        Assert.Equal(3, processor.OnExportCalls);
+
+        var points = GetMetricPoints(exportedMetrics);
+        var success = points.Single(p => !HasTag(p, "error.type"));
+        Assert.Equal(3, success.GetSumLong());
+    }
+
+    [Fact]
+    public void SelfObservabilityInstrumentsDoNotProduceIgnoredInstrumentWarnings()
+    {
+        using var activitySource = new ActivitySource(new ActivitySourceOptions(Utils.GetCurrentMethodName()));
+        using var exporter = new InMemoryExporter<Activity>(new List<Activity>());
+        using var processor = new BatchActivityExportProcessor(exporter);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(activitySource.Name)
+            .AddProcessor(processor)
+            .Build();
+
+        using (activitySource.StartActivity("Test"))
+        {
+        }
+
+        // Forces the self-observability instruments to be created.
+        processor.ForceFlush();
+
+        using var eventListener = new TestEventListener(OpenTelemetrySdkEventSource.Log, EventLevel.Warning);
+
+        // A meter which is not subscribed to by the provider below. It guarantees at least one
+        // MetricInstrumentIgnored warning is emitted, so the assert below is not vacuous.
+        using var unsubscribedMeter = new Meter(new MeterOptions(Utils.GetCurrentMethodName() + ".Unsubscribed"));
+        unsubscribedMeter.CreateCounter<long>("test.counter");
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(Utils.GetCurrentMethodName())
+            .Build();
+
+        var warnings = eventListener.Messages
+            .Where(e => e.EventId == 33)
+            .Select(e => (string?)e.Payload?[0])
+            .ToList();
+
+        Assert.Contains("test.counter", warnings);
+        Assert.DoesNotContain(warnings, w => w?.StartsWith("otel.sdk.", StringComparison.Ordinal) == true);
+    }
+
+    private static MeterProvider CreateMeterProvider(List<Metric> exportedMetrics)
+        => Sdk.CreateMeterProviderBuilder()
+            .AddMeter("otel.sdk.experimental")
+            .AddInMemoryExporter(exportedMetrics)
+            .Build();
+
+    private static List<Activity> StartAndStopActivities(ActivitySource source, int count)
+    {
+        var activities = new List<Activity>(count);
+
+        for (var i = 0; i < count; i++)
+        {
+            using var activity = source.StartActivity("test");
+            if (activity != null)
+            {
+                activities.Add(activity);
+            }
+        }
+
+        return activities;
+    }
+
+    private static List<MetricPoint> GetMetricPoints(List<Metric> exportedMetrics)
+    {
+        var metric = exportedMetrics.Single(m => m.Name == MetricName);
+
+        var points = new List<MetricPoint>();
+        foreach (ref readonly var mp in metric.GetMetricPoints())
+        {
+            points.Add(mp);
+        }
+
+        return points;
+    }
+
+    private static bool HasTag(MetricPoint point, string key)
+    {
+        foreach (var tag in point.Tags)
+        {
+            if (tag.Key == key)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasTagValue(MetricPoint point, string key, string value)
+    {
+        foreach (var tag in point.Tags)
+        {
+            if (tag.Key == key && (string?)tag.Value == value)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? GetTagValue(MetricPoint point, string key)
+    {
+        foreach (var tag in point.Tags)
+        {
+            if (tag.Key == key)
+            {
+                return (string?)tag.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static void AssertTag(MetricPoint point, string key, string expected)
+    {
+        var value = GetTagValue(point, key);
+        Assert.NotNull(value);
+        Assert.Equal(expected, value);
+    }
+
+    private static void AssertTagStartsWith(MetricPoint point, string key, string prefix)
+    {
+        var value = GetTagValue(point, key);
+        Assert.NotNull(value);
+        Assert.StartsWith(prefix, value, StringComparison.Ordinal);
+    }
+
+    private sealed class OnExportTrackingBatchActivityExportProcessor : BatchActivityExportProcessor
+    {
+        private int onExportCalls;
+
+        public OnExportTrackingBatchActivityExportProcessor(BaseExporter<Activity> exporter)
+            : base(exporter)
+        {
+        }
+
+        public int OnExportCalls => Volatile.Read(ref this.onExportCalls);
+
+        protected override void OnExport(Activity data)
+        {
+            Interlocked.Increment(ref this.onExportCalls);
+            base.OnExport(data);
+        }
+    }
+}


### PR DESCRIPTION
Adds `otel.sdk.processor.span.processed` to the built-in Simple and Batching span processors, mirroring #7486 which did the same for logs. Same meter, tag set and `error.type` values — see #7486 for the design rationale.

Three things that aren't obvious from the diff:

* `RECORD_ONLY` spans are counted as successfully processed: they reach the processor and by design are never forwarded to an exporter. This follows the clarification proposed in open-telemetry/semantic-conventions#3978 — **if that proposal is not accepted, this will be revisited**. `DROP` spans are not counted, since the SDK never invokes processors for them.
* Enqueue failures are counted via a new `internal virtual OnItemDropped()` hook instead of `TryExport`'s return value, so `OnEnd` can keep calling the virtual `OnExport` and subclasses overriding it are still honored. `BatchLogRecordExportProcessor` moves onto the same hook, restoring its pre-#7486 `OnEnd` body.
* The shutdown barrier added to `BatchLogRecordExportProcessor` in #7486 is lifted into `BatchExportProcessor<T>` so both signals share it — the follow-up called out in that PR.

No public API change.
