### PR TITLE
[API] Guard calls to CreateFromString 

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -154,7 +154,15 @@ public sealed class B3Propagator : TextMapPropagator
                     traceIdStr = UpperTraceId + traceIdStr;
                 }
 
-                traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+                try
+                {
+                    traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Invalid format
+                    return context;
+                }
             }
             else
             {
@@ -165,7 +173,15 @@ public sealed class B3Propagator : TextMapPropagator
             var spanIdStr = getter(carrier, XB3SpanId)?.FirstOrDefault();
             if (spanIdStr != null)
             {
-                spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+                try
+                {
+                    spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Invalid format
+                    return context;
+                }
             }
             else
             {
@@ -256,8 +272,16 @@ public sealed class B3Propagator : TextMapPropagator
             }
         }
 
-        traceId = CreateTraceId(traceIdStr);
-        spanId = ActivitySpanId.CreateFromString(spanIdStr);
+        try
+        {
+            traceId = CreateTraceId(traceIdStr);
+            spanId = ActivitySpanId.CreateFromString(spanIdStr);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Invalid format
+            return false;
+        }
 
         if (IsSampledValue(traceFlagsStr) ||
             traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -146,7 +146,15 @@ public sealed class B3Propagator : TextMapPropagator
                     traceIdStr = UpperTraceId + traceIdStr;
                 }
 
-                traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+                try
+                {
+                    traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Invalid format
+                    return context;
+                }
             }
             else
             {
@@ -157,7 +165,15 @@ public sealed class B3Propagator : TextMapPropagator
             var spanIdStr = getter(carrier, XB3SpanId)?.FirstOrDefault();
             if (spanIdStr != null)
             {
-                spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+                try
+                {
+                    spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Invalid format
+                    return context;
+                }
             }
             else
             {
@@ -248,8 +264,16 @@ public sealed class B3Propagator : TextMapPropagator
             }
         }
 
-        traceId = CreateTraceId(traceIdStr);
-        spanId = ActivitySpanId.CreateFromString(spanIdStr);
+        try
+        {
+            traceId = CreateTraceId(traceIdStr);
+            spanId = ActivitySpanId.CreateFromString(spanIdStr);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Invalid format
+            return false;
+        }
 
         if (IsSampledValue(traceFlagsStr) ||
             traceFlagsStr.Equals(FlagsValue.AsSpan(), StringComparison.Ordinal))

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -166,14 +166,30 @@ public class JaegerPropagator : TextMapPropagator
             traceIdStr = traceIdStr.PadLeft(TraceId128BitLength, '0');
         }
 
-        traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+        try
+        {
+            traceId = ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Invalid format
+            return false;
+        }
 
         if (spanIdStr.Length < SpanIdLength)
         {
             spanIdStr = spanIdStr.PadLeft(SpanIdLength, '0');
         }
 
-        spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+        try
+        {
+            spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Invalid format
+            return false;
+        }
 
         if (string.Equals(SampledValue, traceFlagsStr, StringComparison.Ordinal))
         {

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/JaegerPropagatorTests.cs
@@ -20,6 +20,8 @@ public class JaegerPropagatorTests
     private const string ParentSpanId = "0";
     private const string FlagSampled = "1";
     private const string FlagNotSampled = "0";
+    private const string AllZeroesTraceId = "00000000000000000000000000000000";
+    private const string AllZeroesSpanId = "0000000000000000";
 
     private static readonly Func<IDictionary<string, string[]>, string, IEnumerable<string>> Getter =
         static (headers, name) => headers.TryGetValue(name, out var value) ? value : [];
@@ -102,6 +104,47 @@ public class JaegerPropagatorTests
 
         // assert
         Assert.Equal(propagationContext, result);
+    }
+
+    [Theory]
+    [InlineData("invalid trace id")]
+    [InlineData("zzz7651916cd43dd8448eb211c803177")] // Right length, but not hexadecimal
+    [InlineData("0007651916CD43DD8448EB211C803177")] // Right length, but upper case
+    [InlineData("0")] // Padded to all zeroes
+    [InlineData(AllZeroesTraceId)]
+    public void TryExtractTraceContextReturnsFalseIfTraceIdIsMalformed(string traceId)
+    {
+        // arrange
+        var formattedHeader = string.Join(JaegerDelimiter, traceId, SpanId, ParentSpanId, FlagSampled);
+
+        // act
+        var result = JaegerPropagator.TryExtractTraceContext(formattedHeader, out var extractedTraceId, out var extractedSpanId, out var traceOptions);
+
+        // assert
+        Assert.False(result);
+        Assert.Equal(default, extractedTraceId);
+        Assert.Equal(default, extractedSpanId);
+        Assert.Equal(ActivityTraceFlags.None, traceOptions);
+    }
+
+    [Theory]
+    [InlineData("invalid span id")]
+    [InlineData("zzzc989f9791877")] // Right length once padded, but not hexadecimal
+    [InlineData("0007C989F9791877")] // Right length, but upper case
+    [InlineData("0")] // Padded to all zeroes
+    [InlineData(AllZeroesSpanId)]
+    public void TryExtractTraceContextReturnsFalseIfSpanIdIsMalformed(string spanId)
+    {
+        // arrange
+        var formattedHeader = string.Join(JaegerDelimiter, TraceId, spanId, ParentSpanId, FlagSampled);
+
+        // act
+        var result = JaegerPropagator.TryExtractTraceContext(formattedHeader, out _, out var extractedSpanId, out var traceOptions);
+
+        // assert
+        Assert.False(result);
+        Assert.Equal(default, extractedSpanId);
+        Assert.Equal(ActivityTraceFlags.None, traceOptions);
     }
 
     [Theory]


### PR DESCRIPTION
## Changes

Wrap calls to `ActivityTraceId.CreateFromString()` and `ActivitySpanId.CreateFromString()` with a catch for `ArgumentOutOfRangeException` against malformed input.

The Jaeger propagator didn't catch malformed input at all, the others did, but at a higher-level rather than returning as invalid.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
