### PR TITLE
[OpenTelemetry] Use cheaper operation

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricPoint/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint/MetricPointOptionalComponents.cs
@@ -47,9 +47,7 @@ internal sealed class MetricPointOptionalComponents
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ReleaseLock()
-    {
-        Interlocked.Exchange(ref this.isCriticalSectionOccupied, 0);
-    }
+        => Volatile.Write(ref this.isCriticalSectionOccupied, 0);
 
     // Note: This method is marked as NoInlining because the whole point of it
     // is to avoid the initialization of SpinWait unless it is needed.


### PR DESCRIPTION
## Changes

Use `Volatile.Write()` instead of `Interlocked.Exchange()` for a cheaper operation as the original value of the field isn't actually used.

The optimisation was suggested from having Claude Code look at the codebase for small performance wins.

Running benchmarks locally gives the following improvement from the [`HistogramBenchmarks`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/test/Benchmarks/Metrics/HistogramBenchmarks.cs) compared to main:

| BoundCount | Method | main (ns) | HEAD (ns) | Δ |
|---|---|---|---|---|
| 10 | HistogramHotPath (no tags) | 29.63 | 29.04 | −2.0% |
| 49 | HistogramHotPath | 36.14 | 35.01 | −3.1% |
| 50 | HistogramHotPath | 34.23 | 33.63 | −1.8% |
| 1000 | HistogramHotPath | 60.05 | 56.68 | **−5.6%** |
| 10 | HistogramWith1LabelHotPath | 48.59 | 46.52 | −4.3% |
| 1000 | HistogramWith1LabelHotPath | 79.12 | 76.08 | −3.8% |
| 49/50 | HistogramWith3/5/7LabelsHotPath | ~100–280 | ~98–282 | within noise (±1–2%) |

Diff of the ASM from [sharplab.io](https://sharplab.io/):

```diff
OpenTelemetry.Metrics.MetricPointOptionalComponents.ReleaseLock()
-   L0000: add ecx, 4
-   L0003: xor eax, eax
-   L0005: xchg [ecx], eax
-   L0007: ret
+   L0000: xor eax, eax
+   L0002: mov [ecx+4], eax
+   L0005: ret
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
