### PR TITLE
[OTLP] Avoid redundant buffer scrubbing

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -358,10 +358,16 @@ internal static class ProtobufSerializer
     /// <param name="minimumSize">The minimum required buffer size in bytes.</param>
     /// <returns>A pooled buffer that must be handed back via <see cref="ReturnBuffer(byte[])"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static byte[] RentBuffer(int minimumSize) => ArrayPool<byte>.Shared.Rent(minimumSize);
+    internal static byte[] RentBuffer(int minimumSize) => RentBuffer(ArrayPool<byte>.Shared, minimumSize);
+
+    /// <inheritdoc cref="RentBuffer(int)"/>
+    /// <param name="pool">The pool to rent the buffer from.</param>
+    /// <param name="minimumSize">The minimum required buffer size in bytes.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static byte[] RentBuffer(ArrayPool<byte> pool, int minimumSize) => pool.Rent(minimumSize);
 
     /// <summary>
-    /// Returns a buffer previously obtained from <see cref="RentBuffer"/> or
+    /// Returns a buffer previously obtained from <see cref="RentBuffer(int)"/> or
     /// grown by <see cref="IncreaseBufferSize"/> back to the pool after clearing
     /// its contents.
     /// </summary>
@@ -371,7 +377,7 @@ internal static class ProtobufSerializer
     internal static void ReturnBuffer(ArrayPool<byte> pool, byte[] buffer) => pool.Return(buffer, clearArray: true);
 
     /// <summary>
-    /// Returns a buffer previously obtained from <see cref="RentBuffer"/> back to the
+    /// Returns a buffer previously obtained from <see cref="RentBuffer(int)"/> back to the
     /// pool, scrubbing only the leading <paramref name="writtenLength"/> bytes.
     /// </summary>
     /// <param name="buffer">The buffer to return.</param>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -370,6 +370,31 @@ internal static class ProtobufSerializer
 
     internal static void ReturnBuffer(ArrayPool<byte> pool, byte[] buffer) => pool.Return(buffer, clearArray: true);
 
+    /// <summary>
+    /// Returns a buffer previously obtained from <see cref="RentBuffer"/> back to the
+    /// pool, scrubbing only the leading <paramref name="writtenLength"/> bytes.
+    /// </summary>
+    /// <param name="buffer">The buffer to return.</param>
+    /// <param name="writtenLength">The number of leading bytes that may contain data.</param>
+    internal static void ReturnBuffer(byte[] buffer, int writtenLength)
+        => ReturnBuffer(ArrayPool<byte>.Shared, buffer, writtenLength);
+
+    /// <inheritdoc cref="ReturnBuffer(byte[], int)"/>
+    /// <param name="pool">The pool to return the buffer to.</param>
+    /// <param name="buffer">The buffer to return.</param>
+    /// <param name="writtenLength">The number of leading bytes that may contain data.</param>
+    internal static void ReturnBuffer(ArrayPool<byte> pool, byte[] buffer, int writtenLength)
+    {
+        Debug.Assert((uint)writtenLength <= (uint)buffer.Length, "writtenLength was out of range");
+
+        if (writtenLength > 0)
+        {
+            buffer.AsSpan(0, writtenLength).Clear();
+        }
+
+        pool.Return(buffer, clearArray: false);
+    }
+
     internal static bool IncreaseBufferSize(ref byte[] buffer, OtlpSignalType otlpSignalType)
     {
         if (buffer.Length >= MaxBufferSize)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/SerializationBuffer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/SerializationBuffer.cs
@@ -1,13 +1,15 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Buffers;
+
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 
 /// <summary>
 /// Manages the buffer used to serialize a single OTLP export request. The buffer
 /// is sized from the previous export's serialized length (to avoid resizing without
-/// preserving excess capacity) and is sourced from the shared array pool via
-/// <see cref="ProtobufSerializer"/>.
+/// preserving excess capacity) and is sourced via <see cref="ProtobufSerializer"/>
+/// from an array pool, the shared pool unless one is supplied.
 /// </summary>
 /// <remarks>
 /// On .NET Framework and .NET Standard builds the shared array pool may not pool
@@ -20,7 +22,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer
 /// and trims them under memory pressure, so each export simply rents and returns
 /// without retaining anything.
 /// </remarks>
-internal sealed class SerializationBuffer(int initialSize)
+internal sealed class SerializationBuffer(int initialSize, ArrayPool<byte>? pool = null)
 {
 #if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER
     // The largest array guaranteed to be pooled by the legacy shared array pool.
@@ -29,6 +31,7 @@ internal sealed class SerializationBuffer(int initialSize)
     private const int MaxPooledArrayLength = 1024 * 1024;
 #endif
 
+    private readonly ArrayPool<byte> pool = pool ?? ArrayPool<byte>.Shared;
     private readonly int initialSize = initialSize;
     private int nextSize = initialSize;
 
@@ -61,10 +64,10 @@ internal sealed class SerializationBuffer(int initialSize)
         }
 
         this.dirtyLength = 0;
-        return ProtobufSerializer.RentBuffer(this.nextSize);
+        return ProtobufSerializer.RentBuffer(this.pool, this.nextSize);
 #else
         this.dirtyLength = 0;
-        return ProtobufSerializer.RentBuffer(this.nextSize);
+        return ProtobufSerializer.RentBuffer(this.pool, this.nextSize);
 #endif
     }
 
@@ -102,7 +105,7 @@ internal sealed class SerializationBuffer(int initialSize)
         // Return pool-reusable buffers and buffers whose excess capacity should
         // not be retained by this exporter.
         this.dirtyLength = 0;
-        ProtobufSerializer.ReturnBuffer(buffer, dirtyLength);
+        ProtobufSerializer.ReturnBuffer(this.pool, buffer, dirtyLength);
     }
 
     /// <summary>
@@ -119,7 +122,7 @@ internal sealed class SerializationBuffer(int initialSize)
             this.retained = null;
             var dirtyLength = this.dirtyLength;
             this.dirtyLength = 0;
-            ProtobufSerializer.ReturnBuffer(buffer, dirtyLength);
+            ProtobufSerializer.ReturnBuffer(this.pool, buffer, dirtyLength);
         }
 #endif
     }
@@ -136,6 +139,6 @@ internal sealed class SerializationBuffer(int initialSize)
 
         // Serialization failed, so how far into the buffer the writer got is unknown.
         // Fall back to clearing the whole array.
-        ProtobufSerializer.ReturnBuffer(buffer);
+        ProtobufSerializer.ReturnBuffer(this.pool, buffer);
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/SerializationBuffer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/SerializationBuffer.cs
@@ -31,6 +31,14 @@ internal sealed class SerializationBuffer(int initialSize)
 
     private readonly int initialSize = initialSize;
     private int nextSize = initialSize;
+
+    // High-water mark of the number of leading bytes of the buffer currently held by
+    // the caller that may contain serialized telemetry. Only this prefix has to be
+    // scrubbed before the buffer goes back to the shared pool; the bytes beyond it
+    // were never written by this instance. A retained buffer (legacy target
+    // frameworks only) keeps its contents across exports, so the mark has to persist
+    // rather than being derived from a single export's serialized length.
+    private int dirtyLength;
 #if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER
     private byte[]? retained;
 #endif
@@ -44,9 +52,18 @@ internal sealed class SerializationBuffer(int initialSize)
     {
 #if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER
         var buffer = this.retained;
-        this.retained = null;
-        return buffer ?? ProtobufSerializer.RentBuffer(this.nextSize);
+        if (buffer != null)
+        {
+            // The retained buffer still holds the previous export's payload, so its
+            // existing dirty prefix carries over.
+            this.retained = null;
+            return buffer;
+        }
+
+        this.dirtyLength = 0;
+        return ProtobufSerializer.RentBuffer(this.nextSize);
 #else
+        this.dirtyLength = 0;
         return ProtobufSerializer.RentBuffer(this.nextSize);
 #endif
     }
@@ -64,6 +81,9 @@ internal sealed class SerializationBuffer(int initialSize)
         // Use the actual payload length rather than the rented capacity so a single
         // large export does not force every subsequent export to rent the same size.
         this.nextSize = Math.Max(this.initialSize, serializedLength);
+
+        var dirtyLength = Math.Max(this.dirtyLength, serializedLength);
+
 #if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER
         if (buffer.Length > MaxPooledArrayLength &&
             serializedLength > MaxPooledArrayLength &&
@@ -71,17 +91,18 @@ internal sealed class SerializationBuffer(int initialSize)
         {
             // The pool may not reuse a buffer this large. Keep it only while it is
             // well utilized so a transient spike does not remain the steady size.
+            // The payload is left in place for the next export to overwrite, so the
+            // dirty prefix has to be carried over.
             this.retained = buffer;
+            this.dirtyLength = dirtyLength;
+            return;
         }
-        else
-        {
-            // Return pool-reusable buffers and buffers whose excess capacity should
-            // not be retained by this exporter.
-            ProtobufSerializer.ReturnBuffer(buffer);
-        }
-#else
-        ProtobufSerializer.ReturnBuffer(buffer);
 #endif
+
+        // Return pool-reusable buffers and buffers whose excess capacity should
+        // not be retained by this exporter.
+        this.dirtyLength = 0;
+        ProtobufSerializer.ReturnBuffer(buffer, dirtyLength);
     }
 
     /// <summary>
@@ -96,7 +117,9 @@ internal sealed class SerializationBuffer(int initialSize)
         if (buffer != null)
         {
             this.retained = null;
-            ProtobufSerializer.ReturnBuffer(buffer);
+            var dirtyLength = this.dirtyLength;
+            this.dirtyLength = 0;
+            ProtobufSerializer.ReturnBuffer(buffer, dirtyLength);
         }
 #endif
     }
@@ -109,6 +132,10 @@ internal sealed class SerializationBuffer(int initialSize)
     public void Discard(byte[] buffer)
     {
         this.nextSize = this.initialSize;
+        this.dirtyLength = 0;
+
+        // Serialization failed, so how far into the buffer the writer got is unknown.
+        // Fall back to clearing the whole array.
         ProtobufSerializer.ReturnBuffer(buffer);
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/SerializationBufferTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/SerializationBufferTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Buffers;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.Implementation.Serializer;
@@ -13,16 +14,15 @@ public class SerializationBufferTests
         const int InitialSize = 1024;
         const int SerializedLength = 2048;
 
-        var serializationBuffer = new SerializationBuffer(InitialSize);
-        var oversizedBuffer = ProtobufSerializer.RentBuffer(8 * 1024 * 1024);
+        var pool = new TrackingArrayPool();
+        var serializationBuffer = new SerializationBuffer(InitialSize, pool);
+        var oversizedBuffer = pool.Rent(8 * 1024 * 1024);
+
         serializationBuffer.Return(oversizedBuffer, SerializedLength);
 
         var nextBuffer = serializationBuffer.Rent();
 
         Assert.Equal(SerializedLength, nextBuffer.Length);
-
-        serializationBuffer.Return(nextBuffer, 0);
-        serializationBuffer.Release();
     }
 
     [Fact]
@@ -30,16 +30,15 @@ public class SerializationBufferTests
     {
         const int InitialSize = 1024;
 
-        var serializationBuffer = new SerializationBuffer(InitialSize);
-        var oversizedBuffer = ProtobufSerializer.RentBuffer(8 * 1024 * 1024);
+        var pool = new TrackingArrayPool();
+        var serializationBuffer = new SerializationBuffer(InitialSize, pool);
+        var oversizedBuffer = pool.Rent(8 * 1024 * 1024);
+
         serializationBuffer.Discard(oversizedBuffer);
 
         var nextBuffer = serializationBuffer.Rent();
 
         Assert.Equal(InitialSize, nextBuffer.Length);
-
-        serializationBuffer.Return(nextBuffer, 0);
-        serializationBuffer.Release();
     }
 
     [Fact]
@@ -47,37 +46,41 @@ public class SerializationBufferTests
     {
         const int SerializedLength = 128;
 
-        var serializationBuffer = new SerializationBuffer(1024);
-        var buffer = ProtobufSerializer.RentBuffer(4096);
+        var pool = new TrackingArrayPool();
+        var serializationBuffer = new SerializationBuffer(1024, pool);
+        var buffer = pool.Rent(4096);
         buffer.AsSpan().Fill(0xAB);
 
         serializationBuffer.Return(buffer, SerializedLength);
 
+        // The buffer belongs to the pool once it has been handed back, so it is
+        // inspected as the pool saw it rather than through the rental.
+        var returned = Assert.Single(pool.Returned);
+
         // The serialized payload must never be handed to another consumer of the pool.
         Assert.All(
-            buffer.AsSpan(0, SerializedLength).ToArray(),
+            returned.AsSpan(0, SerializedLength).ToArray(),
             static value => Assert.Equal(0, value));
 
         // The bytes past the payload were never written, so clearing them would be wasted work.
-        Assert.Equal(0xAB, buffer[SerializedLength]);
-        Assert.Equal(0xAB, buffer[buffer.Length - 1]);
-
-        serializationBuffer.Release();
+        Assert.Equal(0xAB, returned[SerializedLength]);
+        Assert.Equal(0xAB, returned[returned.Length - 1]);
     }
 
     [Fact]
     public void DiscardScrubsWholeBuffer()
     {
-        var serializationBuffer = new SerializationBuffer(1024);
-        var buffer = ProtobufSerializer.RentBuffer(4096);
+        var pool = new TrackingArrayPool();
+        var serializationBuffer = new SerializationBuffer(1024, pool);
+        var buffer = pool.Rent(4096);
         buffer.AsSpan().Fill(0xAB);
 
         // How far the writer got is unknown after a failure, so everything is scrubbed.
         serializationBuffer.Discard(buffer);
 
-        Assert.All(buffer, static value => Assert.Equal(0, value));
+        var returned = Assert.Single(pool.Returned);
 
-        serializationBuffer.Release();
+        Assert.All(returned, static value => Assert.Equal(0, value));
     }
 
 #if NETFRAMEWORK
@@ -87,16 +90,18 @@ public class SerializationBufferTests
         const int BufferSize = 2 * 1024 * 1024;
         const int SerializedLength = 3 * 1024 * 1024 / 2;
 
-        var serializationBuffer = new SerializationBuffer(1024);
-        var oversizedBuffer = ProtobufSerializer.RentBuffer(BufferSize);
+        var pool = new TrackingArrayPool();
+        var serializationBuffer = new SerializationBuffer(1024, pool);
+        var oversizedBuffer = pool.Rent(BufferSize);
+
         serializationBuffer.Return(oversizedBuffer, SerializedLength);
+
+        // The buffer is retained rather than handed back to a pool that may not reuse it.
+        Assert.Empty(pool.Returned);
 
         var nextBuffer = serializationBuffer.Rent();
 
         Assert.Same(oversizedBuffer, nextBuffer);
-
-        serializationBuffer.Return(nextBuffer, 0);
-        serializationBuffer.Release();
     }
 
     [Fact]
@@ -106,8 +111,9 @@ public class SerializationBufferTests
         const int LargeSerializedLength = 3 * 1024 * 1024 / 2;
         const int SmallSerializedLength = 128;
 
-        var serializationBuffer = new SerializationBuffer(1024);
-        var oversizedBuffer = ProtobufSerializer.RentBuffer(BufferSize);
+        var pool = new TrackingArrayPool();
+        var serializationBuffer = new SerializationBuffer(1024, pool);
+        var oversizedBuffer = pool.Rent(BufferSize);
         oversizedBuffer.AsSpan(0, LargeSerializedLength).Fill(0xAB);
 
         // A large export retains the buffer, leaving its payload in place.
@@ -118,11 +124,11 @@ public class SerializationBufferTests
         // earlier, larger payload must be scrubbed too, not just the new one.
         serializationBuffer.Return(oversizedBuffer, SmallSerializedLength);
 
-        Assert.All(
-            oversizedBuffer.AsSpan(0, LargeSerializedLength).ToArray(),
-            static value => Assert.Equal(0, value));
+        var returned = Assert.Single(pool.Returned);
 
-        serializationBuffer.Release();
+        Assert.All(
+            returned.AsSpan(0, LargeSerializedLength).ToArray(),
+            static value => Assert.Equal(0, value));
     }
 
     [Fact]
@@ -131,16 +137,36 @@ public class SerializationBufferTests
         const int BufferSize = 2 * 1024 * 1024;
         const int SerializedLength = 3 * 1024 * 1024 / 2;
 
-        var serializationBuffer = new SerializationBuffer(1024);
-        var oversizedBuffer = ProtobufSerializer.RentBuffer(BufferSize);
+        var pool = new TrackingArrayPool();
+        var serializationBuffer = new SerializationBuffer(1024, pool);
+        var oversizedBuffer = pool.Rent(BufferSize);
         oversizedBuffer.AsSpan(0, SerializedLength).Fill(0xAB);
 
         serializationBuffer.Return(oversizedBuffer, SerializedLength);
         serializationBuffer.Release();
 
+        var returned = Assert.Single(pool.Returned);
+
         Assert.All(
-            oversizedBuffer.AsSpan(0, SerializedLength).ToArray(),
+            returned.AsSpan(0, SerializedLength).ToArray(),
             static value => Assert.Equal(0, value));
     }
 #endif
+
+    private sealed class TrackingArrayPool : ArrayPool<byte>
+    {
+        public List<byte[]> Returned { get; } = [];
+
+        public override byte[] Rent(int minimumLength) => new byte[minimumLength];
+
+        public override void Return(byte[] array, bool clearArray = false)
+        {
+            if (clearArray)
+            {
+                array.AsSpan().Clear();
+            }
+
+            this.Returned.Add(array);
+        }
+    }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/SerializationBufferTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/SerializationBufferTests.cs
@@ -42,6 +42,44 @@ public class SerializationBufferTests
         serializationBuffer.Release();
     }
 
+    [Fact]
+    public void ReturnScrubsSerializedPayloadAndLeavesRemainderUntouched()
+    {
+        const int SerializedLength = 128;
+
+        var serializationBuffer = new SerializationBuffer(1024);
+        var buffer = ProtobufSerializer.RentBuffer(4096);
+        buffer.AsSpan().Fill(0xAB);
+
+        serializationBuffer.Return(buffer, SerializedLength);
+
+        // The serialized payload must never be handed to another consumer of the pool.
+        Assert.All(
+            buffer.AsSpan(0, SerializedLength).ToArray(),
+            static value => Assert.Equal(0, value));
+
+        // The bytes past the payload were never written, so clearing them would be wasted work.
+        Assert.Equal(0xAB, buffer[SerializedLength]);
+        Assert.Equal(0xAB, buffer[buffer.Length - 1]);
+
+        serializationBuffer.Release();
+    }
+
+    [Fact]
+    public void DiscardScrubsWholeBuffer()
+    {
+        var serializationBuffer = new SerializationBuffer(1024);
+        var buffer = ProtobufSerializer.RentBuffer(4096);
+        buffer.AsSpan().Fill(0xAB);
+
+        // How far the writer got is unknown after a failure, so everything is scrubbed.
+        serializationBuffer.Discard(buffer);
+
+        Assert.All(buffer, static value => Assert.Equal(0, value));
+
+        serializationBuffer.Release();
+    }
+
 #if NETFRAMEWORK
     [Fact]
     public void ReturnRetainsWellUtilizedOversizedBuffer()
@@ -59,6 +97,50 @@ public class SerializationBufferTests
 
         serializationBuffer.Return(nextBuffer, 0);
         serializationBuffer.Release();
+    }
+
+    [Fact]
+    public void ReturnScrubsPayloadCarriedOverByRetainedBuffer()
+    {
+        const int BufferSize = 2 * 1024 * 1024;
+        const int LargeSerializedLength = 3 * 1024 * 1024 / 2;
+        const int SmallSerializedLength = 128;
+
+        var serializationBuffer = new SerializationBuffer(1024);
+        var oversizedBuffer = ProtobufSerializer.RentBuffer(BufferSize);
+        oversizedBuffer.AsSpan(0, LargeSerializedLength).Fill(0xAB);
+
+        // A large export retains the buffer, leaving its payload in place.
+        serializationBuffer.Return(oversizedBuffer, LargeSerializedLength);
+        Assert.Same(oversizedBuffer, serializationBuffer.Rent());
+
+        // A much smaller export then hands the same buffer back to the pool. The
+        // earlier, larger payload must be scrubbed too, not just the new one.
+        serializationBuffer.Return(oversizedBuffer, SmallSerializedLength);
+
+        Assert.All(
+            oversizedBuffer.AsSpan(0, LargeSerializedLength).ToArray(),
+            static value => Assert.Equal(0, value));
+
+        serializationBuffer.Release();
+    }
+
+    [Fact]
+    public void ReleaseScrubsRetainedPayload()
+    {
+        const int BufferSize = 2 * 1024 * 1024;
+        const int SerializedLength = 3 * 1024 * 1024 / 2;
+
+        var serializationBuffer = new SerializationBuffer(1024);
+        var oversizedBuffer = ProtobufSerializer.RentBuffer(BufferSize);
+        oversizedBuffer.AsSpan(0, SerializedLength).Fill(0xAB);
+
+        serializationBuffer.Return(oversizedBuffer, SerializedLength);
+        serializationBuffer.Release();
+
+        Assert.All(
+            oversizedBuffer.AsSpan(0, SerializedLength).ToArray(),
+            static value => Assert.Equal(0, value));
     }
 #endif
 }


### PR DESCRIPTION
## Changes

Only scrub as much of pooled buffers as were written to to avoid redundant work.

Throwaway rent + write payload + return benchmark, before -> after:

```text
  10 KB payload    15,748 ns -> 172 ns   (-98.9%)
  100 KB payload   17,643 ns -> 4,855 ns (-72.5%)
  700 KB payload   30,658 ns -> 32,313 ns (unchanged, within error)
```

The gain compared to main is proportional to how close to the buffer bucket length the written payload is.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
