### PR TITLE
[OTLP] Avoid counting UTF-8 string byte count

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -21,6 +21,12 @@ internal static class ProtobufSerializer
     private const int Fixed64Size = 8;
     private const int MaskBitsLow = 0b_0111_1111;
     private const int MaskBitHigh = 0b_1000_0000;
+
+    // A UTF-16 character encodes to at most 3 UTF-8 bytes (a surrogate pair encodes to 4
+    // bytes across 2 characters, so 3 is the per-character worst case), so any string of
+    // this length or shorter encodes to at most MaskBitsLow bytes and its protobuf length
+    // prefix therefore always fits in a single varint byte.
+    private const int MaxCharsWithSingleByteUtf8Length = MaskBitsLow / 3;
 #if NETFRAMEWORK || NETSTANDARD2_0
     private const int MaxThreadStaticCharBufferSize = 1024;
 #endif
@@ -258,6 +264,34 @@ internal static class ProtobufSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int WriteStringWithTag(byte[] buffer, int writePosition, int fieldNumber, string value)
     {
+        // A string this short cannot encode to more than MaskBitsLow bytes, so its length
+        // prefix is always a single varint byte. Reserving that byte and filling it in once
+        // the characters have been encoded removes the separate GetByteCount pass, roughly
+        // halving the cost of writing a short string. Attribute keys and span names go
+        // through here, so this runs many times per exported item.
+        if (value.Length <= MaxCharsWithSingleByteUtf8Length)
+        {
+            writePosition = WriteTag(buffer, writePosition, fieldNumber, ProtobufWireType.LEN);
+
+            var lengthPosition = writePosition++;
+
+            // Claim the reserved byte before encoding. It keeps the out-of-space
+            // failure as IndexOutOfRangeException the same as the slower path.
+            buffer[lengthPosition] = 0;
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+            var bytesWritten = Utf8Encoding.GetBytes(value, 0, value.Length, buffer, writePosition);
+#else
+            var bytesWritten = Utf8Encoding.GetBytes(value.AsSpan(), buffer.AsSpan(writePosition));
+#endif
+
+            Debug.Assert(bytesWritten <= MaskBitsLow, "bytesWritten did not fit in a single byte varint");
+
+            buffer[lengthPosition] = (byte)bytesWritten;
+
+            return writePosition + bytesWritten;
+        }
+
         var numberOfUtf8CharsInString = GetNumberOfUtf8CharsInString(value);
         return WriteStringWithTag(buffer, writePosition, fieldNumber, numberOfUtf8CharsInString, value);
     }


### PR DESCRIPTION
## Changes

Avoid counting the number of UTF-8 bytes a string would encode into if the length would fit into a `varint` byte.

This optimisation was found by a scan of the codebase with Claude Code.

Using [`ProtobufOtlpTraceSerializationBenchmarks`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/59e5e882592412fabdc9acd7d42f8485bc14c141/test/Benchmarks/Exporter/ProtobufOtlpTraceSerializationBenchmarks.cs) we get the following improvement:

| Method | SpanCount | main (baseline) | HEAD (change) | Improvement |
|---|---|---|---|---|
| SteadyState | 1 | 334.3 ns | 274.9 ns | ~18% faster |
| ResizeWithWarmPool | 1 | 13,782.9 ns | 13,647.6 ns | ~1% faster |
| PooledExport | 1 | 13,783.8 ns | 13,606.3 ns | ~1.3% faster |
| SteadyState | 5000 | 1,756,235.9 ns | 1,514,709.7 ns | ~13.8% faster |
| ResizeWithWarmPool | 5000 | 2,862,590.4 ns | 2,566,629.4 ns | ~10.3% faster |
| PooledExport | 5000 | 1,807,913.5 ns | 1,618,727.8 ns | ~10.5% faster |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
