### PR TITLE
[Infra] Reorder switch cases

### DIFF
--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -39,9 +39,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
 
         switch (value)
         {
-            case char c:
-                this.WriteCharTag(ref state, key, c);
-                break;
+            // Ordered by how often each type is likely to appear for performance
             case string s:
                 if (tagValueMaxLength is { } length && s.Length > length)
                 {
@@ -56,8 +54,20 @@ internal abstract class TagWriter<TTagState, TArrayState>
                 }
 
                 break;
+            case int i:
+                this.WriteIntegralTag(ref state, key, i);
+                break;
+            case long l:
+                this.WriteIntegralTag(ref state, key, l);
+                break;
             case bool b:
                 this.WriteBooleanTag(ref state, key, b);
+                break;
+            case double d:
+                this.WriteFloatingPointTag(ref state, key, d);
+                break;
+            case char c:
+                this.WriteCharTag(ref state, key, c);
                 break;
             case byte b:
                 this.WriteIntegralTag(ref state, key, b);
@@ -71,20 +81,11 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case ushort us:
                 this.WriteIntegralTag(ref state, key, us);
                 break;
-            case int i:
-                this.WriteIntegralTag(ref state, key, i);
-                break;
             case uint ui:
                 this.WriteIntegralTag(ref state, key, ui);
                 break;
-            case long l:
-                this.WriteIntegralTag(ref state, key, l);
-                break;
             case float f:
                 this.WriteFloatingPointTag(ref state, key, f);
-                break;
-            case double d:
-                this.WriteFloatingPointTag(ref state, key, d);
                 break;
             case Array array:
                 if (value.GetType() == typeof(byte[]) && this.TryWriteByteArrayTag(ref state, key, ((byte[])value).AsSpan()))
@@ -304,19 +305,29 @@ internal abstract class TagWriter<TTagState, TArrayState>
                 continue;
             }
 
+            // Ordered by how often each type is likely to appear for performance
             switch (item)
             {
-                case char c:
-                    this.WriteCharValue(ref arrayState, c);
-                    break;
                 case string s:
                     this.WriteStringValue(
                         ref arrayState,
                         s,
                         tagValueMaxLength);
                     break;
+                case int intValue:
+                    this.arrayWriter.WriteIntegralValue(ref arrayState, intValue);
+                    break;
+                case long l:
+                    this.arrayWriter.WriteIntegralValue(ref arrayState, l);
+                    break;
                 case bool b:
                     this.arrayWriter.WriteBooleanValue(ref arrayState, b);
+                    break;
+                case double d:
+                    this.arrayWriter.WriteFloatingPointValue(ref arrayState, d);
+                    break;
+                case char c:
+                    this.WriteCharValue(ref arrayState, c);
                     break;
                 case byte b:
                     this.arrayWriter.WriteIntegralValue(ref arrayState, b);
@@ -330,20 +341,11 @@ internal abstract class TagWriter<TTagState, TArrayState>
                 case ushort us:
                     this.arrayWriter.WriteIntegralValue(ref arrayState, us);
                     break;
-                case int intValue:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, intValue);
-                    break;
                 case uint ui:
                     this.arrayWriter.WriteIntegralValue(ref arrayState, ui);
                     break;
-                case long l:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, l);
-                    break;
                 case float f:
                     this.arrayWriter.WriteFloatingPointValue(ref arrayState, f);
-                    break;
-                case double d:
-                    this.arrayWriter.WriteFloatingPointValue(ref arrayState, d);
                     break;
 
                 // All other types are converted to strings including the following


### PR DESCRIPTION
## Changes

Reorder switch cases to by likely probability to improve performance.

Minor performance optimisation suggested by Claude Code.

Using [`ProtobufOtlpTraceSerializationBenchmarks.SteadyState()`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/59e5e882592412fabdc9acd7d42f8485bc14c141/test/Benchmarks/Exporter/ProtobufOtlpTraceSerializationBenchmarks.cs#L65) we get the following modest improvement:

| SpanCount | main (Mean) | HEAD (Mean) | Improvement |
|---|---|---|---|
| 1 | 327.4 ns ± 4.78 ns | 322.5 ns ± 5.32 ns | ~1.5% faster |
| 5000 | 1,703.1 μs ± 42.1 μs | 1,660.9 μs ± 37.1 μs | ~2.5% faster |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
