### PR TITLE
[Infra] Fix flaky test

### DIFF
--- a/test/OpenTelemetry.Apple.TestApp/AppleEndToEndTests.cs
+++ b/test/OpenTelemetry.Apple.TestApp/AppleEndToEndTests.cs
@@ -184,7 +184,7 @@ public sealed class AppleEndToEndTests
         options.Endpoint = new(OtlpBaseAddress, signalPath);
 
         // Export over the connection the entry point has already opened to the
-        // host rather than over one of this exporter's own
+        // host rather than over one of this exporter's own HttpClient.
         options.HttpClientFactory = static () => TestRunner.OtlpHttpClient;
         options.TimeoutMilliseconds = (int)TestRunner.ExportTimeout.TotalMilliseconds;
     }

--- a/test/OpenTelemetry.Apple.TestApp/AppleEndToEndTests.cs
+++ b/test/OpenTelemetry.Apple.TestApp/AppleEndToEndTests.cs
@@ -16,10 +16,11 @@ namespace OpenTelemetry.Apple.TestApp;
 [TestClass]
 public sealed class AppleEndToEndTests
 {
+    private const int FlushAttempts = 3;
+
     private static readonly Uri OtlpBaseAddress = new(InstrumentationSource.OtlpEndpoint);
 
     private static readonly TimeSpan FlushTimeout = TimeSpan.FromSeconds(60);
-    private static readonly TimeSpan ExportTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(30);
 
     [TestMethod]
@@ -48,12 +49,16 @@ public sealed class AppleEndToEndTests
 
         Assert.IsTrue(logger.IsEnabled(LogLevel.Information), "Information logs are not enabled.");
 
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            logger.LogInformation("{Message}", InstrumentationSource.LogBody);
-        }
-
-        FlushAndShutdown("Logs", loggerProvider.ForceFlush, loggerProvider.Shutdown);
+        RecordAndShutdown(
+            () =>
+            {
+                if (logger.IsEnabled(LogLevel.Information))
+                {
+                    logger.LogInformation("{Message}", InstrumentationSource.LogBody);
+                }
+            },
+            loggerProvider.ForceFlush,
+            loggerProvider.Shutdown);
     }
 
     [TestMethod]
@@ -93,17 +98,45 @@ public sealed class AppleEndToEndTests
 
         Assert.IsNotNull(tracerProvider, "TracerProvider failed to build on iOS.");
 
-        using (var activity = instrumentation.ActivitySource.StartActivity(InstrumentationSource.ActivityName))
-        {
-            Assert.IsNotNull(activity, "ActivitySource produced no Activity - the SDK did not subscribe on iOS.");
-            activity.SetTag(InstrumentationSource.ActivityTagKey, InstrumentationSource.ActivityTagValue);
-        }
+        RecordAndShutdown(
+            () =>
+            {
+                using var activity = instrumentation.ActivitySource.StartActivity(InstrumentationSource.ActivityName);
 
-        FlushAndShutdown("Traces", tracerProvider.ForceFlush, tracerProvider.Shutdown);
+                Assert.IsNotNull(activity, "ActivitySource produced no Activity - the SDK did not subscribe on iOS.");
+                activity.SetTag(InstrumentationSource.ActivityTagKey, InstrumentationSource.ActivityTagValue);
+            },
+            tracerProvider.ForceFlush,
+            tracerProvider.Shutdown);
     }
 
     private static ResourceBuilder CreateResourceBuilder()
         => ResourceBuilder.CreateDefault().AddService(InstrumentationSource.ServiceName);
+
+    private static void RecordAndShutdown(Action record, Func<int, bool> forceFlush, Func<int, bool> shutdown)
+    {
+        var flushed = false;
+        var deadline = DateTime.UtcNow + FlushTimeout;
+
+        for (var attempt = 0; attempt < FlushAttempts; attempt++)
+        {
+            var remaining = deadline - DateTime.UtcNow;
+
+            if (remaining <= TimeSpan.Zero)
+            {
+                break;
+            }
+
+            record();
+
+            // One attempt reaching the exporter is sufficient for the test to pass
+            flushed |= forceFlush((int)remaining.TotalMilliseconds);
+        }
+
+        Assert.IsTrue(flushed, $"The telemetry was not flushed within {FlushTimeout}.");
+
+        _ = shutdown((int)ShutdownTimeout.TotalMilliseconds);
+    }
 
     /// <summary>
     /// Flushes the telemetry recorded by a test and then shuts its provider down.
@@ -125,7 +158,6 @@ public sealed class AppleEndToEndTests
     /// <returns><see langword="true"/> if the telemetry was flushed; otherwise <see langword="false"/>.</returns>
     private static bool TryFlush(Func<int, bool> forceFlush)
     {
-        const int FlushAttempts = 3;
         var deadline = DateTime.UtcNow + FlushTimeout;
 
         for (var attempt = 0; attempt < FlushAttempts; attempt++)
@@ -150,6 +182,10 @@ public sealed class AppleEndToEndTests
     {
         options.Protocol = OtlpExportProtocol.HttpProtobuf;
         options.Endpoint = new(OtlpBaseAddress, signalPath);
-        options.TimeoutMilliseconds = (int)ExportTimeout.TotalMilliseconds;
+
+        // Export over the connection the entry point has already opened to the
+        // host rather than over one of this exporter's own
+        options.HttpClientFactory = static () => TestRunner.OtlpHttpClient;
+        options.TimeoutMilliseconds = (int)TestRunner.ExportTimeout.TotalMilliseconds;
     }
 }

--- a/test/OpenTelemetry.Apple.TestApp/Info.plist
+++ b/test/OpenTelemetry.Apple.TestApp/Info.plist
@@ -38,9 +38,10 @@
     </array>
     <!--
         NSAllowsLocalNetworking is required because the OTLP export targets plain
-        HTTP on the host loopback (http://localhost:<port>); App Transport
+        HTTP on the host loopback (http://127.0.0.1:<port>); App Transport
         Security blocks cleartext HTTP by default, which would otherwise silently
-        fail the export.
+        fail the export. The exemption covers the loopback and link-local address
+        ranges as well as unqualified host names.
     -->
     <key>NSAppTransportSecurity</key>
     <dict>

--- a/test/OpenTelemetry.Apple.TestApp/InstrumentationSource.cs
+++ b/test/OpenTelemetry.Apple.TestApp/InstrumentationSource.cs
@@ -14,7 +14,7 @@ namespace OpenTelemetry.Apple.TestApp;
 /// </summary>
 public sealed class InstrumentationSource : IDisposable
 {
-    public const string OtlpEndpoint = "http://localhost:4318";
+    public const string OtlpEndpoint = "http://127.0.0.1:4318";
 
     public const string ServiceName = "otel-apple-testapp";
 

--- a/test/OpenTelemetry.Apple.TestApp/TestRunner.cs
+++ b/test/OpenTelemetry.Apple.TestApp/TestRunner.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using Microsoft.Testing.Extensions;
@@ -22,6 +23,10 @@ internal static class TestRunner
     internal const string SummaryFileName = "summary.txt";
     internal const string ErrorFileName = "error.txt";
 
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ProbeInterval = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan ProbeDeadline = TimeSpan.FromSeconds(60);
+
     private static async Task Main(string[] args)
     {
         var resultsDirectory = Path.Combine(DocumentsDirectory(), ResultsDirectoryName);
@@ -39,6 +44,8 @@ internal static class TestRunner
         using var diagnostics = new SelfDiagnosticsListener(Console.Out);
 
         await Console.Out.WriteLineAsync("Exporting OTLP to " + InstrumentationSource.OtlpEndpoint).ConfigureAwait(false);
+
+        await WaitForCollectorAsync().ConfigureAwait(false);
 
         var consumer = new ResultConsumer();
         var exitCode = -1;
@@ -99,6 +106,60 @@ internal static class TestRunner
         // returns as soon as the run finishes instead of waiting on any threads
         // the test platform left running.
         Environment.Exit(failed == 0 && consumer.Passed > 0 ? 0 : 1);
+    }
+
+    /// <summary>
+    /// Waits until the collector on the host answers a request from the simulator.
+    /// </summary>
+    /// <remarks>
+    /// The first requests made after the app starts have been seen hanging until
+    /// they time out, only for the endpoint to become reachable a few seconds
+    /// later. An export lost that way cannot be recovered - the batch processors
+    /// drop a batch whose export failed - so the wait happens here, before any
+    /// test runs, rather than costing a test its telemetry. Nothing is asserted:
+    /// if the collector never answers the tests report that far better than a
+    /// failure from the entry point would.
+    /// </remarks>
+    private static async Task WaitForCollectorAsync()
+    {
+        // Any path the collector does not map answers 404, which proves it is
+        // reachable without adding to the requests the host asserts against.
+        var probe = new Uri(new Uri(InstrumentationSource.OtlpEndpoint), "ready");
+
+        using var client = new HttpClient { Timeout = ProbeTimeout };
+
+        var startedAt = Stopwatch.GetTimestamp();
+        var deadline = DateTime.UtcNow + ProbeDeadline;
+
+        for (var attempt = 1; DateTime.UtcNow < deadline; attempt++)
+        {
+            try
+            {
+                using var response = await client.GetAsync(probe).ConfigureAwait(false);
+
+                await Console.Out.WriteLineAsync(
+                    FormattableString.Invariant(
+                        $"Collector answered on attempt {attempt} after {Stopwatch.GetElapsedTime(startedAt).TotalSeconds:N1}s."))
+                    .ConfigureAwait(false);
+
+                return;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+            {
+                await Console.Out.WriteLineAsync(
+                    FormattableString.Invariant(
+                        $"Collector did not answer on attempt {attempt} after {Stopwatch.GetElapsedTime(startedAt).TotalSeconds:N1}s: {ex.Message}"))
+                    .ConfigureAwait(false);
+
+                // A connection that is refused rather than left hanging comes back
+                // immediately, so pause before trying again.
+                await Task.Delay(ProbeInterval).ConfigureAwait(false);
+            }
+        }
+
+        await Console.Out.WriteLineAsync(
+            FormattableString.Invariant($"Collector was still unreachable after {ProbeDeadline}; running the tests anyway."))
+            .ConfigureAwait(false);
     }
 
     private static string DocumentsDirectory()

--- a/test/OpenTelemetry.Apple.TestApp/TestRunner.cs
+++ b/test/OpenTelemetry.Apple.TestApp/TestRunner.cs
@@ -23,9 +23,19 @@ internal static class TestRunner
     internal const string SummaryFileName = "summary.txt";
     internal const string ErrorFileName = "error.txt";
 
+    internal static readonly TimeSpan ExportTimeout = TimeSpan.FromSeconds(10);
+
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan ProbeInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan ProbeDeadline = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Gets the <see cref="HttpClient"/> used to reach the collector on the host.
+    /// </summary>
+    /// <remarks>
+    /// Shared client used to avoid timeouts while establishing connections in the emulator.
+    /// </remarks>
+    internal static HttpClient OtlpHttpClient { get; } = new() { Timeout = ExportTimeout };
 
     private static async Task Main(string[] args)
     {
@@ -126,8 +136,6 @@ internal static class TestRunner
         // reachable without adding to the requests the host asserts against.
         var probe = new Uri(new Uri(InstrumentationSource.OtlpEndpoint), "ready");
 
-        using var client = new HttpClient { Timeout = ProbeTimeout };
-
         var startedAt = Stopwatch.GetTimestamp();
         var deadline = DateTime.UtcNow + ProbeDeadline;
 
@@ -135,7 +143,8 @@ internal static class TestRunner
         {
             try
             {
-                using var response = await client.GetAsync(probe).ConfigureAwait(false);
+                using var timeout = new CancellationTokenSource(ProbeTimeout);
+                using var response = await OtlpHttpClient.GetAsync(probe, timeout.Token).ConfigureAwait(false);
 
                 await Console.Out.WriteLineAsync(
                     FormattableString.Invariant(

--- a/test/OpenTelemetry.Apple.TestApp/TestRunner.cs
+++ b/test/OpenTelemetry.Apple.TestApp/TestRunner.cs
@@ -33,7 +33,7 @@ internal static class TestRunner
     /// Gets the <see cref="HttpClient"/> used to reach the collector on the host.
     /// </summary>
     /// <remarks>
-    /// Shared client used to avoid timeouts while establishing connections in the emulator.
+    /// Shared client used to avoid timeouts while establishing connections in the simulator.
     /// </remarks>
     internal static HttpClient OtlpHttpClient { get; } = new() { Timeout = ExportTimeout };
 

--- a/test/OpenTelemetry.Apple.Tests/AppleAppFixture.cs
+++ b/test/OpenTelemetry.Apple.Tests/AppleAppFixture.cs
@@ -61,11 +61,13 @@ public sealed class AppleAppFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        // Binding to 'localhost' (rather than a specific address) makes Kestrel
-        // listen on both loopback addresses, and matches the unqualified host
-        // name the app is allowed to reach over cleartext HTTP by the App
-        // Transport Security policy declared in the app's Info.plist.
-        this.Collector = await OtlpHttpCollector.StartAsync("http://localhost:4318");
+        // Bound to the IPv4 loopback address rather than to 'localhost', which
+        // would make Kestrel listen on both loopback addresses. The app addresses
+        // the collector by literal IP so that NSUrlSession is not left to choose
+        // between the two, and this must be the address it chose. Cleartext HTTP
+        // to the loopback range is allowed by the App Transport Security policy
+        // declared in the app's Info.plist.
+        this.Collector = await OtlpHttpCollector.StartAsync("http://127.0.0.1:4318");
 
         try
         {


### PR DESCRIPTION
## Changes

Further attempt to fix [flakiness](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/31492399395/job/93782045663) after changes in #7612 suggested by Claude Code.

- Use `127.0.0.1` to remove IPv4 vs. IPv6 ambiguity possibility.
- Wait for the collector to be healthy.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
