### PR TITLE
[OpenTelemetry] Remove redundant code

### DIFF
--- a/src/OpenTelemetry/Metrics/HistogramExplicitBounds.cs
+++ b/src/OpenTelemetry/Metrics/HistogramExplicitBounds.cs
@@ -218,13 +218,10 @@ internal sealed class HistogramExplicitBounds
     private int FindBucketIndexLinear(double value, int start, int end)
     {
 #if NET
-        if (!double.IsNaN(value))
+        var index = FindBucketIndexLinearSimd(this.Bounds.AsSpan(start, end - start), value);
+        if (index >= 0)
         {
-            var index = FindBucketIndexLinearSimd(this.Bounds.AsSpan(start, end - start), value);
-            if (index >= 0)
-            {
-                return start + index;
-            }
+            return start + index;
         }
 #endif
 
@@ -289,12 +286,6 @@ internal sealed class HistogramExplicitBounds
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public (int Start, int End) GetBucketSearchRange(double value)
         {
-            if (double.IsNaN(value))
-            {
-                var end = this.bucketSearchStarts[this.bucketSearchStarts.Length - 1];
-                return (end, end);
-            }
-
             var key = this.GetKey(ToSortableBits(value));
             return (this.bucketSearchStarts[key], this.bucketSearchStarts[key + 1]);
         }


### PR DESCRIPTION
## Changes

Remove redundant code to handle `double.IsNaN()` as the caller has already checked for that:

https://github.com/open-telemetry/opentelemetry-dotnet/blob/a9d56bfe96a57c5e4bab7e1826eea1168dc826d4/src/OpenTelemetry/Metrics/HistogramExplicitBounds.cs#L46

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
