### PR TITLE
[OpenTelemetry] Reduce binary search threshold to 32

### DIFF
--- a/src/OpenTelemetry/Metrics/HistogramExplicitBounds.cs
+++ b/src/OpenTelemetry/Metrics/HistogramExplicitBounds.cs
@@ -12,7 +12,7 @@ namespace OpenTelemetry.Metrics;
 
 internal sealed class HistogramExplicitBounds
 {
-    internal const int DefaultBoundaryCountForBinarySearch = 50;
+    internal const int DefaultBoundaryCountForBinarySearch = 32;
 
     private const int RadixLookupBitCount = 12;
     private const int RadixLinearSearchThreshold = 32;


### PR DESCRIPTION
## Changes

Reduce `DefaultBoundaryCountForBinarySearch` to 32 as from this value the SIMD-accelerated radix search performance outperforms the binary search by ~2x based on a performance investigation cmparing different values.

| Benchmark | Layout | main (ns) | HEAD (ns) | Ratio (HEAD/main) |
|---|---|---|---|---|
| LookupExactBoundary | MixedSigned | 5.32 | 3.23 | 0.61 |
| LookupInRangeValue | MixedSigned | 5.42 | 1.95 | 0.36 |
| LookupWithInfiniteBounds | MixedSigned | 5.46 | 1.82 | 0.33 |
| LookupExactBoundary | PositiveOnly | 5.59 | 3.07 | 0.55 |
| LookupInRangeValue | PositiveOnly | 5.96 | 3.03 | 0.51 |
| LookupWithInfiniteBounds | PositiveOnly | 6.01 | 3.07 | 0.51 |

<details>

<summary>Comparison</summary>

| Method          | BoundCount | Mean     | Error     | StdDev    | Median   | Ratio | RatioSD |
|---------------- |----------- |---------:|----------:|----------:|---------:|------:|--------:|
| PlainLinearScan | 8          | 1.876 ns | 0.1644 ns | 0.4742 ns | 1.796 ns |  1.06 |    0.37 |
| RadixLookup     | 8          | 1.781 ns | 0.1609 ns | 0.4669 ns | 1.606 ns |  1.01 |    0.36 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 12         | 1.729 ns | 0.1240 ns | 0.3556 ns | 1.572 ns |  1.03 |    0.28 |
| RadixLookup     | 12         | 2.839 ns | 0.2804 ns | 0.8223 ns | 2.560 ns |  1.70 |    0.57 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 16         | 3.125 ns | 0.3534 ns | 1.0082 ns | 2.995 ns |  1.11 |    0.51 |
| RadixLookup     | 16         | 2.888 ns | 0.2005 ns | 0.5752 ns | 2.932 ns |  1.02 |    0.39 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 20         | 2.419 ns | 0.1896 ns | 0.5469 ns | 2.264 ns |  1.05 |    0.32 |
| RadixLookup     | 20         | 1.915 ns | 0.0757 ns | 0.1494 ns | 1.891 ns |  0.83 |    0.18 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 24         | 2.551 ns | 0.0867 ns | 0.1992 ns | 2.502 ns |  1.01 |    0.11 |
| RadixLookup     | 24         | 1.918 ns | 0.1628 ns | 0.4750 ns | 1.715 ns |  0.76 |    0.19 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 28         | 3.337 ns | 0.1902 ns | 0.5547 ns | 3.149 ns |  1.03 |    0.23 |
| RadixLookup     | 28         | 2.858 ns | 0.2183 ns | 0.6437 ns | 2.662 ns |  0.88 |    0.24 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 32         | 5.053 ns | 0.2868 ns | 0.8319 ns | 4.769 ns |  1.02 |    0.22 |
| RadixLookup     | 32         | 2.583 ns | 0.1949 ns | 0.5656 ns | 2.338 ns |  0.52 |    0.14 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 36         | 4.496 ns | 0.3373 ns | 0.9839 ns | 4.494 ns |  1.04 |    0.31 |
| RadixLookup     | 36         | 2.074 ns | 0.0751 ns | 0.0976 ns | 2.058 ns |  0.48 |    0.10 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 40         | 3.452 ns | 0.1233 ns | 0.3478 ns | 3.359 ns |  1.01 |    0.14 |
| RadixLookup     | 40         | 2.044 ns | 0.1103 ns | 0.3216 ns | 2.070 ns |  0.60 |    0.11 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 44         | 3.336 ns | 0.4769 ns | 1.3987 ns | 3.334 ns |  1.31 |    1.06 |
| RadixLookup     | 44         | 1.897 ns | 0.0826 ns | 0.2397 ns | 1.827 ns |  0.74 |    0.49 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 48         | 5.606 ns | 0.3824 ns | 1.0847 ns | 5.217 ns |  1.03 |    0.27 |
| RadixLookup     | 48         | 6.951 ns | 0.8068 ns | 2.3789 ns | 7.008 ns |  1.28 |    0.50 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 56         | 8.762 ns | 0.5744 ns | 1.6936 ns | 8.620 ns |  1.04 |    0.28 |
| RadixLookup     | 56         | 4.425 ns | 0.3672 ns | 1.0596 ns | 4.406 ns |  0.52 |    0.16 |
|                 |            |          |           |           |          |       |         |
| PlainLinearScan | 64         | 7.954 ns | 0.5403 ns | 1.5590 ns | 7.700 ns |  1.04 |    0.28 |
| RadixLookup     | 64         | 3.397 ns | 0.2532 ns | 0.7305 ns | 3.100 ns |  0.44 |    0.13 |

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
