### PR TITLE
[OTLP] Serialize logger version

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -48,7 +48,6 @@ Notes](../../RELEASENOTES.md).
 * Improved OTLP log attribute serialization performance by avoiding unnecessary
   boxing.
   ([#7645](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7645))
-  
 * The OTLP exporter will now export logger version if it was specified. Log
   records are grouped into `ScopeLogs` by logger name and version, so loggers
   sharing a name but reporting different versions are exported as separate

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -45,7 +45,6 @@ Notes](../../RELEASENOTES.md).
   limit is discarded and treated as a non-retryable failure.
   ([#7583](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7583))
 
-* The OTLP exporter will now export logger version if it was specified.
 * The OTLP exporter will now export logger version if it was specified. Log
   records are grouped into `ScopeLogs` by logger name and version, so loggers
   sharing a name but reporting different versions are exported as separate

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -46,6 +46,10 @@ Notes](../../RELEASENOTES.md).
   ([#7583](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7583))
 
 * The OTLP exporter will now export logger version if it was specified.
+* The OTLP exporter will now export logger version if it was specified. Log
+  records are grouped into `ScopeLogs` by logger name and version, so loggers
+  sharing a name but reporting different versions are exported as separate
+  scopes.
   ([#7636](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7636))
 
 ## 1.17.0

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -45,6 +45,9 @@ Notes](../../RELEASENOTES.md).
   limit is discarded and treated as a non-retryable failure.
   ([#7583](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7583))
 
+* The OTLP exporter will now export logger version if it was specified.
+  ([#7636](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7636))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -48,6 +48,7 @@ Notes](../../RELEASENOTES.md).
 * Improved OTLP log attribute serialization performance by avoiding unnecessary
   boxing.
   ([#7645](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7645))
+
 * The OTLP exporter will now export logger version if it was specified. Log
   records are grouped into `ScopeLogs` by logger name and version, so loggers
   sharing a name but reporting different versions are exported as separate

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -17,7 +17,7 @@ internal static class ProtobufOtlpLogSerializer
     [ThreadStatic]
     private static Stack<List<LogRecord>>? logsListPool;
     [ThreadStatic]
-    private static Dictionary<string, List<LogRecord>>? scopeLogsList;
+    private static Dictionary<InstrumentationScope, List<LogRecord>>? scopeLogsList;
 
     [ThreadStatic]
     private static SerializationState? threadSerializationState;
@@ -36,11 +36,12 @@ internal static class ProtobufOtlpLogSerializer
         {
             foreach (var logRecord in logRecordBatch)
             {
-                var scopeName = logRecord.Logger.Name;
-                if (!scopeLogsList.TryGetValue(scopeName, out var logRecords))
+                var logger = logRecord.Logger;
+                var scope = new InstrumentationScope(logger.Name, logger.Version);
+                if (!scopeLogsList.TryGetValue(scope, out var logRecords))
                 {
                     logRecords = logsListPool.Count > 0 ? logsListPool.Pop() : [];
-                    scopeLogsList[scopeName] = logRecords;
+                    scopeLogsList[scope] = logRecords;
                 }
 
                 if (logRecord.Source == LogRecord.LogRecordSource.FromSharedPool)
@@ -69,7 +70,7 @@ internal static class ProtobufOtlpLogSerializer
         return writePosition;
     }
 
-    internal static int TryWriteResourceLogs(ref byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Resources.Resource? resource, Dictionary<string, List<LogRecord>> scopeLogs)
+    internal static int TryWriteResourceLogs(ref byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Resources.Resource? resource, Dictionary<InstrumentationScope, List<LogRecord>> scopeLogs)
     {
         while (true)
         {
@@ -131,7 +132,7 @@ internal static class ProtobufOtlpLogSerializer
         }
     }
 
-    internal static int WriteResourceLogs(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Resources.Resource? resource, Dictionary<string, List<LogRecord>> scopeLogs)
+    internal static int WriteResourceLogs(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Resources.Resource? resource, Dictionary<InstrumentationScope, List<LogRecord>> scopeLogs)
     {
         writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, writePosition, resource);
         writePosition = WriteScopeLogs(buffer, writePosition, sdkLimitOptions, experimentalOptions, scopeLogs);
@@ -144,7 +145,7 @@ internal static class ProtobufOtlpLogSerializer
         return writePosition;
     }
 
-    internal static int WriteScopeLogs(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Dictionary<string, List<LogRecord>> scopeLogs)
+    internal static int WriteScopeLogs(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Dictionary<InstrumentationScope, List<LogRecord>> scopeLogs)
     {
         if (scopeLogs != null)
         {
@@ -154,7 +155,7 @@ internal static class ProtobufOtlpLogSerializer
                 var resourceLogsScopeLogsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
-                writePosition = WriteScopeLog(buffer, writePosition, sdkLimitOptions, experimentalOptions, entry.Value[0].Logger, entry.Value);
+                writePosition = WriteScopeLog(buffer, writePosition, sdkLimitOptions, experimentalOptions, entry.Key, entry.Value);
                 ProtobufSerializer.WriteReservedLength(buffer, resourceLogsScopeLogsLengthPosition, writePosition - (resourceLogsScopeLogsLengthPosition + ReserveSizeForLength));
             }
         }
@@ -162,18 +163,18 @@ internal static class ProtobufOtlpLogSerializer
         return writePosition;
     }
 
-    internal static int WriteScopeLog(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Logger logger, List<LogRecord> logRecords)
+    internal static int WriteScopeLog(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, in InstrumentationScope scope, List<LogRecord> logRecords)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
 
         var scopeLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, logger.Name);
+        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, scope.Name);
 
-        if (logger.Version != null)
+        if (scope.Version != null)
         {
-            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, logger.Version);
+            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, scope.Version);
         }
 
         ProtobufSerializer.WriteReservedLength(buffer, scopeLengthPosition, writePosition - (scopeLengthPosition + ReserveSizeForLength));
@@ -378,6 +379,44 @@ internal static class ProtobufOtlpLogSerializer
                 state.AttributeValueLengthLimit);
 
             state.TagWriterState.TagCount++;
+        }
+    }
+
+    /// <summary>
+    /// Identifies the instrumentation scope log records are grouped by. Loggers
+    /// sharing a name but reporting different versions are distinct scopes and
+    /// must be emitted as separate ScopeLogs entries.
+    /// </summary>
+    internal readonly struct InstrumentationScope : IEquatable<InstrumentationScope>
+    {
+        public InstrumentationScope(string name, string? version)
+        {
+            this.Name = name;
+            this.Version = version;
+        }
+
+        public string Name { get; }
+
+        public string? Version { get; }
+
+        public bool Equals(InstrumentationScope other)
+            => string.Equals(this.Name, other.Name, StringComparison.Ordinal)
+            && string.Equals(this.Version, other.Version, StringComparison.Ordinal);
+
+        public override bool Equals(object? obj)
+            => obj is InstrumentationScope other && this.Equals(other);
+
+        public override int GetHashCode()
+        {
+            // Note: HashCode is not available on all the target frameworks, so
+            // the hash is combined manually here.
+            unchecked
+            {
+                var hash = 17;
+                hash = (hash * 31) + (this.Version is null ? 0 : StringComparer.Ordinal.GetHashCode(this.Name));
+                hash = (hash * 31) + (this.Version is null ? 0 : StringComparer.Ordinal.GetHashCode(this.Version));
+                return hash;
+            }
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -164,7 +164,19 @@ internal static class ProtobufOtlpLogSerializer
 
     internal static int WriteScopeLog(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Logger logger, List<LogRecord> logRecords)
     {
-        writePosition = WriteInstrumentationScope(buffer, writePosition, logger);
+        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
+
+        var scopeLengthPosition = writePosition;
+        writePosition += ReserveSizeForLength;
+
+        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, logger.Name);
+
+        if (logger.Version != null)
+        {
+            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, logger.Version);
+        }
+
+        ProtobufSerializer.WriteReservedLength(buffer, scopeLengthPosition, writePosition - (scopeLengthPosition + ReserveSizeForLength));
 
         for (var i = 0; i < logRecords.Count; i++)
         {
@@ -334,25 +346,6 @@ internal static class ProtobufOtlpLogSerializer
                 }
             }
         }
-    }
-
-    private static int WriteInstrumentationScope(byte[] buffer, int writePosition, Logger logger)
-    {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
-
-        var scopeLengthPosition = writePosition;
-        writePosition += ReserveSizeForLength;
-
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, logger.Name);
-
-        if (logger.Version != null)
-        {
-            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, logger.Version);
-        }
-
-        ProtobufSerializer.WriteReservedLength(buffer, scopeLengthPosition, writePosition - (scopeLengthPosition + ReserveSizeForLength));
-
-        return writePosition;
     }
 
     private static int WriteLogRecordBody(byte[] buffer, int writePosition, string value)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -154,7 +154,7 @@ internal static class ProtobufOtlpLogSerializer
                 var resourceLogsScopeLogsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
-                writePosition = WriteScopeLog(buffer, writePosition, sdkLimitOptions, experimentalOptions, entry.Value[0].Logger.Name, entry.Value);
+                writePosition = WriteScopeLog(buffer, writePosition, sdkLimitOptions, experimentalOptions, entry.Value[0].Logger, entry.Value);
                 ProtobufSerializer.WriteReservedLength(buffer, resourceLogsScopeLogsLengthPosition, writePosition - (resourceLogsScopeLogsLengthPosition + ReserveSizeForLength));
             }
         }
@@ -162,14 +162,9 @@ internal static class ProtobufOtlpLogSerializer
         return writePosition;
     }
 
-    internal static int WriteScopeLog(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, string loggerName, List<LogRecord> logRecords)
+    internal static int WriteScopeLog(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ExperimentalOptions experimentalOptions, Logger logger, List<LogRecord> logRecords)
     {
-        var numberOfUtf8CharsInString = ProtobufSerializer.GetNumberOfUtf8CharsInString(loggerName);
-        var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
-
-        // numberOfUtf8CharsInString + tagSize + length field size.
-        writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, numberOfUtf8CharsInString, loggerName);
+        writePosition = WriteInstrumentationScope(buffer, writePosition, logger);
 
         for (var i = 0; i < logRecords.Count; i++)
         {
@@ -339,6 +334,25 @@ internal static class ProtobufOtlpLogSerializer
                 }
             }
         }
+    }
+
+    private static int WriteInstrumentationScope(byte[] buffer, int writePosition, Logger logger)
+    {
+        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
+
+        var scopeLengthPosition = writePosition;
+        writePosition += ReserveSizeForLength;
+
+        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, logger.Name);
+
+        if (logger.Version != null)
+        {
+            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, logger.Version);
+        }
+
+        ProtobufSerializer.WriteReservedLength(buffer, scopeLengthPosition, writePosition - (scopeLengthPosition + ReserveSizeForLength));
+
+        return writePosition;
     }
 
     private static int WriteLogRecordBody(byte[] buffer, int writePosition, string value)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -387,36 +387,43 @@ internal static class ProtobufOtlpLogSerializer
     /// sharing a name but reporting different versions are distinct scopes and
     /// must be emitted as separate ScopeLogs entries.
     /// </summary>
-    internal readonly struct InstrumentationScope : IEquatable<InstrumentationScope>
+    internal readonly record struct InstrumentationScope
     {
+        public readonly string Name;
+        public readonly string? Version;
+
         public InstrumentationScope(string name, string? version)
         {
             this.Name = name;
             this.Version = version;
         }
 
-        public string Name { get; }
-
-        public string? Version { get; }
-
         public bool Equals(InstrumentationScope other)
             => string.Equals(this.Name, other.Name, StringComparison.Ordinal)
             && string.Equals(this.Version, other.Version, StringComparison.Ordinal);
 
-        public override bool Equals(object? obj)
-            => obj is InstrumentationScope other && this.Equals(other);
-
         public override int GetHashCode()
         {
-            // Note: HashCode is not available on all the target frameworks, so
-            // the hash is combined manually here.
+#if NET || NETSTANDARD2_1_OR_GREATER
+            HashCode hashCode = default;
+            hashCode.Add(this.Name, StringComparer.Ordinal);
+            hashCode.Add(this.Version, StringComparer.Ordinal);
+            return hashCode.ToHashCode();
+#else
+            // Note: HashCode is not available on netstandard2.0 or .NET
+            // Framework, so the hash is combined manually there. Both members
+            // are null-checked because StringComparer.Ordinal.GetHashCode
+            // throws on null, whereas HashCode.Add above does not. Name is
+            // non-null for any scope built from a Logger, but this is a struct
+            // so a default instance carries a null Name.
             unchecked
             {
                 var hash = 17;
-                hash = (hash * 31) + (this.Version is null ? 0 : StringComparer.Ordinal.GetHashCode(this.Name));
+                hash = (hash * 31) + (this.Name is null ? 0 : StringComparer.Ordinal.GetHashCode(this.Name));
                 hash = (hash * 31) + (this.Version is null ? 0 : StringComparer.Ordinal.GetHashCode(this.Version));
                 return hash;
             }
+#endif
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -410,12 +410,6 @@ internal static class ProtobufOtlpLogSerializer
             hashCode.Add(this.Version, StringComparer.Ordinal);
             return hashCode.ToHashCode();
 #else
-            // Note: HashCode is not available on netstandard2.0 or .NET
-            // Framework, so the hash is combined manually there. Both members
-            // are null-checked because StringComparer.Ordinal.GetHashCode
-            // throws on null, whereas HashCode.Add above does not. Name is
-            // non-null for any scope built from a Logger, but this is a struct
-            // so a default instance carries a null Name.
             unchecked
             {
                 var hash = 17;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -1868,6 +1868,43 @@ public class OtlpLogExporterTests
         Assert.Equal(expectedVersion, request.ResourceLogs[0].ScopeLogs[0].Scope?.Version);
     }
 
+    [Fact]
+    public void LogRecordsFromLoggersWithSameNameAndDifferentVersionsAreExportedAsSeparateScopes()
+    {
+        var logRecords = new List<LogRecord>();
+
+        using (var loggerProvider = Sdk.CreateLoggerProviderBuilder()
+                   .AddInMemoryExporter(logRecords)
+                   .Build())
+        {
+            loggerProvider.GetLogger("MyLogger", "1.0.0").EmitLog(new LogRecordData());
+            loggerProvider.GetLogger("MyLogger", "2.0.0").EmitLog(new LogRecordData());
+            loggerProvider.GetLogger("MyLogger", "1.0.0").EmitLog(new LogRecordData());
+            loggerProvider.GetLogger("MyLogger", version: null).EmitLog(new LogRecordData());
+        }
+
+        Assert.Equal(4, logRecords.Count);
+
+        var batch = new Batch<LogRecord>([.. logRecords], logRecords.Count);
+        var request = CreateLogsExportRequest(DefaultSdkLimitOptions, new ExperimentalOptions(), batch, ResourceBuilder.CreateEmpty().Build());
+
+        Assert.NotNull(request);
+        Assert.Single(request.ResourceLogs);
+
+        var scopeLogs = request.ResourceLogs[0].ScopeLogs;
+        Assert.Equal(3, scopeLogs.Count);
+        Assert.All(scopeLogs, scopeLog => Assert.Equal("MyLogger", scopeLog.Scope?.Name));
+
+        var v1 = Assert.Single(scopeLogs, scopeLog => scopeLog.Scope?.Version == "1.0.0");
+        Assert.Equal(2, v1.LogRecords.Count);
+
+        var v2 = Assert.Single(scopeLogs, scopeLog => scopeLog.Scope?.Version == "2.0.0");
+        Assert.Single(v2.LogRecords);
+
+        var unversioned = Assert.Single(scopeLogs, scopeLog => scopeLog.Scope?.Version.Length == 0);
+        Assert.Single(unversioned.LogRecords);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -1815,11 +1815,6 @@ public class OtlpLogExporterTests
     [InlineData(null, "")]
     public void LogRecordLoggerNameIsExportedWhenUsingBridgeApi(string? loggerName, string expectedScopeName)
     {
-        LogRecordAttributeList attributes = default;
-        attributes.Add("name", "tomato");
-        attributes.Add("price", 2.99);
-        attributes.Add("{OriginalFormat}", "Hello from {name} {price}.");
-
         var logRecords = new List<LogRecord>();
 
         using (var loggerProvider = Sdk.CreateLoggerProviderBuilder()
@@ -1841,6 +1836,36 @@ public class OtlpLogExporterTests
         Assert.Single(request.ResourceLogs[0].ScopeLogs);
 
         Assert.Equal(expectedScopeName, request.ResourceLogs[0].ScopeLogs[0].Scope?.Name);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "1.0.0")]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "   ")]
+    public void LogRecordLoggerVersionIsExportedWhenUsingBridgeApi(string? version, string expectedVersion)
+    {
+        var logRecords = new List<LogRecord>();
+
+        using (var loggerProvider = Sdk.CreateLoggerProviderBuilder()
+                   .AddInMemoryExporter(logRecords)
+                   .Build())
+        {
+            var logger = loggerProvider.GetLogger("MyLogger", version);
+
+            logger.EmitLog(new LogRecordData());
+        }
+
+        Assert.Single(logRecords);
+
+        var batch = new Batch<LogRecord>([logRecords[0]], 1);
+        var request = CreateLogsExportRequest(DefaultSdkLimitOptions, new ExperimentalOptions(), batch, ResourceBuilder.CreateEmpty().Build());
+
+        Assert.NotNull(request);
+        Assert.Single(request.ResourceLogs);
+        Assert.Single(request.ResourceLogs[0].ScopeLogs);
+
+        Assert.Equal(expectedVersion, request.ResourceLogs[0].ScopeLogs[0].Scope?.Version);
     }
 
     [Theory]


### PR DESCRIPTION
Currently the logs bridge API allows users to specify the version of the logger, but the version isn't exported using the OTLP exporter.

## Changes

This PR modifies the OTLP exporter to make it export logger version.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
