### PR TITLE
[Propagators] Improve B3 extract performance

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -143,12 +143,33 @@ public sealed class B3Propagator : TextMapPropagator
         }
     }
 
+    private static string? GetFirstOrDefault(IEnumerable<string>? values)
+    {
+        if (values == null)
+        {
+            return null;
+        }
+
+        if (values is IList<string> list)
+        {
+            return list.Count > 0 ? list[0] : null;
+        }
+
+        if (values is IReadOnlyList<string> readOnlyList)
+        {
+            return readOnlyList.Count > 0 ? readOnlyList[0] : null;
+        }
+
+        using var enumerator = values.GetEnumerator();
+        return enumerator.MoveNext() ? enumerator.Current : null;
+    }
+
     private static PropagationContext ExtractFromMultipleHeaders<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>?> getter)
     {
         try
         {
             ActivityTraceId traceId;
-            var traceIdStr = getter(carrier, XB3TraceId)?.FirstOrDefault();
+            var traceIdStr = GetFirstOrDefault(getter(carrier, XB3TraceId));
             if (traceIdStr != null)
             {
                 if (traceIdStr.Length == 16)
@@ -173,7 +194,7 @@ public sealed class B3Propagator : TextMapPropagator
             }
 
             ActivitySpanId spanId;
-            var spanIdStr = getter(carrier, XB3SpanId)?.FirstOrDefault();
+            var spanIdStr = GetFirstOrDefault(getter(carrier, XB3SpanId));
             if (spanIdStr != null)
             {
                 try
@@ -192,9 +213,9 @@ public sealed class B3Propagator : TextMapPropagator
             }
 
             var traceOptions = ActivityTraceFlags.None;
-            var xb3Sampled = getter(carrier, XB3Sampled)?.FirstOrDefault();
+            var xb3Sampled = GetFirstOrDefault(getter(carrier, XB3Sampled));
             if ((xb3Sampled != null && SampledValues.Contains(xb3Sampled))
-                || string.Equals(FlagsValue, getter(carrier, XB3Flags)?.FirstOrDefault(), StringComparison.Ordinal))
+                || string.Equals(FlagsValue, GetFirstOrDefault(getter(carrier, XB3Flags)), StringComparison.Ordinal))
             {
                 traceOptions |= ActivityTraceFlags.Recorded;
             }
@@ -220,9 +241,9 @@ public sealed class B3Propagator : TextMapPropagator
                 return context;
             }
 
-            var header = headers.FirstOrDefault();
+            var header = GetFirstOrDefault(headers);
 
-            return string.IsNullOrWhiteSpace(header)
+            return header is not { Length: > 0 } || string.IsNullOrWhiteSpace(header)
                 ? context
                 : !TryExtractSingleHeaderContext(header, out var traceId, out var spanId, out var traceOptions)
                 ? context

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -135,12 +135,33 @@ public sealed class B3Propagator : TextMapPropagator
         }
     }
 
+    private static string? GetFirstOrDefault(IEnumerable<string>? values)
+    {
+        if (values == null)
+        {
+            return null;
+        }
+
+        if (values is IList<string> list)
+        {
+            return list.Count > 0 ? list[0] : null;
+        }
+
+        if (values is IReadOnlyList<string> readOnlyList)
+        {
+            return readOnlyList.Count > 0 ? readOnlyList[0] : null;
+        }
+
+        using var enumerator = values.GetEnumerator();
+        return enumerator.MoveNext() ? enumerator.Current : null;
+    }
+
     private static PropagationContext ExtractFromMultipleHeaders<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>?> getter)
     {
         try
         {
             ActivityTraceId traceId;
-            var traceIdStr = getter(carrier, XB3TraceId)?.FirstOrDefault();
+            var traceIdStr = GetFirstOrDefault(getter(carrier, XB3TraceId));
             if (traceIdStr != null)
             {
                 if (traceIdStr.Length == 16)
@@ -165,7 +186,7 @@ public sealed class B3Propagator : TextMapPropagator
             }
 
             ActivitySpanId spanId;
-            var spanIdStr = getter(carrier, XB3SpanId)?.FirstOrDefault();
+            var spanIdStr = GetFirstOrDefault(getter(carrier, XB3SpanId));
             if (spanIdStr != null)
             {
                 try
@@ -184,9 +205,9 @@ public sealed class B3Propagator : TextMapPropagator
             }
 
             var traceOptions = ActivityTraceFlags.None;
-            var xb3Sampled = getter(carrier, XB3Sampled)?.FirstOrDefault();
+            var xb3Sampled = GetFirstOrDefault(getter(carrier, XB3Sampled));
             if ((xb3Sampled != null && SampledValues.Contains(xb3Sampled))
-                || string.Equals(FlagsValue, getter(carrier, XB3Flags)?.FirstOrDefault(), StringComparison.Ordinal))
+                || string.Equals(FlagsValue, GetFirstOrDefault(getter(carrier, XB3Flags)), StringComparison.Ordinal))
             {
                 traceOptions |= ActivityTraceFlags.Recorded;
             }
@@ -212,9 +233,9 @@ public sealed class B3Propagator : TextMapPropagator
                 return context;
             }
 
-            var header = headers.FirstOrDefault();
+            var header = GetFirstOrDefault(headers);
 
-            return string.IsNullOrWhiteSpace(header)
+            return header is not { Length: > 0 } || string.IsNullOrWhiteSpace(header)
                 ? context
                 : !TryExtractSingleHeaderContext(header, out var traceId, out var spanId, out var traceOptions)
                 ? context

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/B3PropagatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections;
 using System.Diagnostics;
 
 namespace OpenTelemetry.Context.Propagation.Tests;
@@ -190,6 +191,49 @@ public class B3PropagatorTests
     }
 
     [Fact]
+    public void ParseNullHeaderValuesReturnsDefault()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3TraceId, TraceIdBase16 }, { B3Propagator.XB3SpanId, SpanIdBase16 },
+        };
+
+        Func<IDictionary<string, string>, string, IEnumerable<string>?> nullGetter = (_, _) => null;
+
+        Assert.Equal(default, this.b3propagator.Extract(default, headers, nullGetter));
+    }
+
+    [Fact]
+    public void ParseHeaderValuesFromReadOnlyListReturnsContext()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3TraceId, TraceIdBase16 }, { B3Propagator.XB3SpanId, SpanIdBase16 },
+        };
+
+        Func<IDictionary<string, string>, string, IEnumerable<string>?> readOnlyListGetter =
+            (d, k) => d.TryGetValue(k, out var v) ? new ReadOnlyListOnly<string>(v) : new ReadOnlyListOnly<string>();
+
+        var spanContext = new ActivityContext(TraceId, SpanId, ActivityTraceFlags.None, isRemote: true);
+        Assert.Equal(new PropagationContext(spanContext, default), this.b3propagator.Extract(default, headers, readOnlyListGetter));
+    }
+
+    [Fact]
+    public void ParseHeaderValuesFromPlainEnumerableReturnsContext()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3TraceId, TraceIdBase16 }, { B3Propagator.XB3SpanId, SpanIdBase16 },
+        };
+
+        Func<IDictionary<string, string>, string, IEnumerable<string>?> plainEnumerableGetter =
+            (d, k) => d.TryGetValue(k, out var v) ? AsPlainEnumerable(v) : AsPlainEnumerable(null);
+
+        var spanContext = new ActivityContext(TraceId, SpanId, ActivityTraceFlags.None, isRemote: true);
+        Assert.Equal(new PropagationContext(spanContext, default), this.b3propagator.Extract(default, headers, plainEnumerableGetter));
+    }
+
+    [Fact]
     public void Serialize_SampledContext_SingleHeader()
     {
         var carrier = new Dictionary<string, string>();
@@ -364,6 +408,14 @@ public class B3PropagatorTests
         Assert.Equal(default, result);
     }
 
+    private static IEnumerable<string> AsPlainEnumerable(string? value)
+    {
+        if (value != null)
+        {
+            yield return value;
+        }
+    }
+
     private static void ContainsExactly(ISet<string> list, List<string> items)
     {
         Assert.Equal(items.Count, list.Count);
@@ -385,5 +437,16 @@ public class B3PropagatorTests
         {
             Assert.Contains(item, dict);
         }
+    }
+
+    private sealed class ReadOnlyListOnly<T>(params T[] items) : IReadOnlyList<T>
+    {
+        public int Count => items.Length;
+
+        public T this[int index] => items[index];
+
+        public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)items).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/B3PropagatorTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections;
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 
@@ -188,6 +189,49 @@ public class B3PropagatorTests
     {
         var invalidHeaders = new Dictionary<string, string> { { B3Propagator.XB3TraceId, TraceIdBase16 } };
         Assert.Equal(default, this.b3propagator.Extract(default, invalidHeaders, Getter));
+    }
+
+    [Fact]
+    public void ParseNullHeaderValuesReturnsDefault()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3TraceId, TraceIdBase16 }, { B3Propagator.XB3SpanId, SpanIdBase16 },
+        };
+
+        Func<IDictionary<string, string>, string, IEnumerable<string>?> nullGetter = (_, _) => null;
+
+        Assert.Equal(default, this.b3propagator.Extract(default, headers, nullGetter));
+    }
+
+    [Fact]
+    public void ParseHeaderValuesFromReadOnlyListReturnsContext()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3TraceId, TraceIdBase16 }, { B3Propagator.XB3SpanId, SpanIdBase16 },
+        };
+
+        Func<IDictionary<string, string>, string, IEnumerable<string>?> readOnlyListGetter =
+            (d, k) => d.TryGetValue(k, out var v) ? new ReadOnlyListOnly<string>(v) : new ReadOnlyListOnly<string>();
+
+        var spanContext = new ActivityContext(TraceId, SpanId, ActivityTraceFlags.None, isRemote: true);
+        Assert.Equal(new PropagationContext(spanContext, default), this.b3propagator.Extract(default, headers, readOnlyListGetter));
+    }
+
+    [Fact]
+    public void ParseHeaderValuesFromPlainEnumerableReturnsContext()
+    {
+        var headers = new Dictionary<string, string>
+        {
+            { B3Propagator.XB3TraceId, TraceIdBase16 }, { B3Propagator.XB3SpanId, SpanIdBase16 },
+        };
+
+        Func<IDictionary<string, string>, string, IEnumerable<string>?> plainEnumerableGetter =
+            (d, k) => d.TryGetValue(k, out var v) ? AsPlainEnumerable(v) : AsPlainEnumerable(null);
+
+        var spanContext = new ActivityContext(TraceId, SpanId, ActivityTraceFlags.None, isRemote: true);
+        Assert.Equal(new PropagationContext(spanContext, default), this.b3propagator.Extract(default, headers, plainEnumerableGetter));
     }
 
     [Fact]
@@ -416,6 +460,14 @@ public class B3PropagatorTests
         Assert.Equal(default, result);
     }
 
+    private static IEnumerable<string> AsPlainEnumerable(string? value)
+    {
+        if (value != null)
+        {
+            yield return value;
+        }
+    }
+
     private static void ContainsExactly(ISet<string> list, List<string> items)
     {
         Assert.Equal(items.Count, list.Count);
@@ -437,5 +489,16 @@ public class B3PropagatorTests
         {
             Assert.Contains(item, dict);
         }
+    }
+
+    private sealed class ReadOnlyListOnly<T>(params T[] items) : IReadOnlyList<T>
+    {
+        public int Count => items.Length;
+
+        public T this[int index] => items[index];
+
+        public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)items).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }


### PR DESCRIPTION
## Changes

Avoid LINQ when extracting in the B3 propagators for ~20% performance gain identified by Claude Code.

| SingleHeader | Sampled | Main (ns) | Candidate (ns) | Ratio (candidate/main) | Change | Allocated (both) |
|---|---|---:|---:|---:|---:|---:|
| False | False | 120.13 | 95.26 | 0.79 | 21% faster | 192 B |
| False | True | 107.09 | 86.36 | 0.81 | 19% faster | 216 B |
| True | False | 85.38 | 80.05 | 0.94 | 6% faster | 168 B |
| True | True | 100.06 | 76.31 | 0.76 | 24% faster | 168 B |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
