### PR TITLE
[API] Improve TraceContextPropagator perf

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -716,7 +716,7 @@ public class TraceContextPropagator : TextMapPropagator
             }
         }
 
-        var result = new StringBuilder();
+        var result = new StringBuilder(TraceStateMaxCombinedLength);
 
         foreach (var member in members)
         {

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -24,6 +24,9 @@ public class TraceContextPropagator : TextMapPropagator
     private const int TraceStateKeyMaxLength = 256;
     private const int TraceStateValueMaxLength = 256;
 
+    private const int TraceStateMaxCombinedLength = 512;
+    private const int TraceStateLargeEntryLength = 128;
+
 #if NET
     private const int TraceIdSizeInBytes = 16;
     private const int SpanIdSizeInBytes = 8;
@@ -140,16 +143,18 @@ public class TraceContextPropagator : TextMapPropagator
         setter(carrier, TraceParent, traceparent);
 
         var tracestateStr = context.ActivityContext.TraceState;
-        if (tracestateStr?.Length > 0)
+        if (tracestateStr?.Length > 0 &&
+            TryExtractSingleTracestate(tracestateStr, out var normalizedTraceState) &&
+            normalizedTraceState.Length > 0)
         {
-            var tracestateEntries = new List<KeyValuePair<string, string>>();
-            if (TraceStateUtils.AppendTraceState(tracestateStr, tracestateEntries))
+            if (normalizedTraceState.Length > TraceStateMaxCombinedLength)
             {
-                var normalizedTraceState = TraceStateUtils.GetString(tracestateEntries);
-                if (normalizedTraceState.Length > 0)
-                {
-                    setter(carrier, TraceState, normalizedTraceState);
-                }
+                normalizedTraceState = TruncateOversizedTracestate(normalizedTraceState);
+            }
+
+            if (normalizedTraceState.Length > 0)
+            {
+                setter(carrier, TraceState, normalizedTraceState);
             }
         }
 
@@ -683,6 +688,52 @@ public class TraceContextPropagator : TextMapPropagator
 
         tracestateResult = result.ToString();
         return true;
+    }
+
+    private static string TruncateOversizedTracestate(string tracestate)
+    {
+        // Rare, cold path: only reached when a validated/deduplicated tracestate still exceeds
+        // the combined length limit. Drop large (>128 char) members first, scanning from the end,
+        // then drop remaining members from the end until under the limit.
+        string?[] members = tracestate.Split(',');
+        var combinedLength = tracestate.Length;
+
+        for (var i = members.Length - 1; i >= 0 && combinedLength > TraceStateMaxCombinedLength; i--)
+        {
+            if (members[i] is { Length: > TraceStateLargeEntryLength } member)
+            {
+                combinedLength -= member.Length + 1;
+                members[i] = null;
+            }
+        }
+
+        for (var i = members.Length - 1; i >= 0 && combinedLength > TraceStateMaxCombinedLength; i--)
+        {
+            if (members[i] is { } member)
+            {
+                combinedLength -= member.Length + 1;
+                members[i] = null;
+            }
+        }
+
+        var result = new StringBuilder();
+
+        foreach (var member in members)
+        {
+            if (member == null)
+            {
+                continue;
+            }
+
+            if (result.Length > 0)
+            {
+                result.Append(',');
+            }
+
+            result.Append(member);
+        }
+
+        return result.ToString();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/Benchmarks/Context/Propagation/TraceContextPropagatorBenchmarks.cs
+++ b/test/Benchmarks/Context/Propagation/TraceContextPropagatorBenchmarks.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry.Context.Propagation;
 
@@ -19,6 +20,9 @@ public class TraceContextPropagatorBenchmarks
     private static readonly Func<IReadOnlyDictionary<string, string>, string, IEnumerable<string>> Getter =
         static (headers, name) => headers.TryGetValue(name, out var value) ? [value] : [];
 
+    private static readonly Action<Dictionary<string, string>, string, string> Setter =
+        static (carrier, name, value) => carrier[name] = value;
+
     [Params(true, false)]
     public bool LongListMember { get; set; }
 
@@ -26,6 +30,10 @@ public class TraceContextPropagatorBenchmarks
     public int MembersCount { get; set; }
 
     public Dictionary<string, string>? Headers { get; private set; }
+
+    public PropagationContext InjectContext { get; private set; }
+
+    public Dictionary<string, string> InjectCarrier { get; private set; } = [];
 
     [GlobalSetup]
     public void Setup()
@@ -58,8 +66,24 @@ public class TraceContextPropagatorBenchmarks
             { TraceParent, $"00-{TraceId}-{SpanId}-01" },
             { TraceState, traceState },
         };
+
+        var activityContext = new ActivityContext(
+            ActivityTraceId.CreateFromString(TraceId.AsSpan()),
+            ActivitySpanId.CreateFromString(SpanId.AsSpan()),
+            ActivityTraceFlags.Recorded,
+            traceState: traceState.Length > 0 ? traceState : null);
+
+        this.InjectContext = new PropagationContext(activityContext, default);
+        this.InjectCarrier = [];
     }
 
     [Benchmark(Baseline = true)]
     public void Extract() => _ = TraceContextPropagator.Extract(default, this.Headers!, Getter);
+
+    [Benchmark]
+    public void Inject()
+    {
+        this.InjectCarrier.Clear();
+        TraceContextPropagator.Inject(this.InjectContext, this.InjectCarrier, Setter);
+    }
 }

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTests.cs
@@ -651,6 +651,27 @@ public class TraceContextPropagatorTests
     }
 
     [Fact]
+    public void Inject_TruncatesOversizedTracestateWithoutLargeEntries()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+
+        var allEntries = Enumerable.Range(0, 30).Select(i => $"k{i:00}={new string('a', 15)}").ToList();
+        var oversizedTraceState = string.Join(",", allEntries);
+        var expectedTraceState = string.Join(",", allEntries.Take(25));
+
+        var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded, oversizedTraceState);
+        var propagationContext = new PropagationContext(activityContext, default);
+        var carrier = new Dictionary<string, string>();
+        var propagator = new TraceContextPropagator();
+        propagator.Inject(propagationContext, carrier, Setter);
+
+        Assert.Equal($"00-{traceId}-{spanId}-01", carrier[TraceParent]);
+        Assert.Equal(expectedTraceState, carrier[TraceState]);
+        Assert.True(carrier[TraceState].Length <= 512);
+    }
+
+    [Fact]
     public void DuplicateKeys()
     {
         // test_tracestate_duplicated_keys


### PR DESCRIPTION
## Changes

Improve the performance of `TraceContextPropagator.Inject()` by leveraging  optimisations from #7613.

| LongListMember | MembersCount | Before (ns) | After (ns) | Ratio | Before (B) | After (B) | Alloc Ratio |
|-----------------|--------------|------------:|-----------:|------:|-----------:|----------:|------------:|
| False           | 0            |       52.12 |      35.86 |  0.69 |        136 |       136 |        1.00 |
| False           | 4            |      672.74 |     247.77 |  0.37 |       2000 |       136 |        0.07 |
| False           | 32           |     3948.44 |    2482.93 |  0.63 |      11776 |      6536 |        0.56 |
| True            | 0            |       63.53 |      37.79 |  0.59 |        136 |       136 |        1.00 |
| True            | 4            |     2460.63 |    1284.58 |  0.52 |       9192 |      4488 |        0.49 |
| True            | 32           |    18294.59 |   10722.04 |  0.59 |      71160 |     34056 |        0.48 |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
