### PR TITLE
[Hosting] Add ITelemetryHostInitializer

### DIFF
--- a/src/OpenTelemetry.Extensions.Hosting/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Hosting/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.ITelemetryHostInitializer
+OpenTelemetry.ITelemetryHostInitializer.Initialize() -> void

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -9,7 +9,7 @@ Notes](../../RELEASENOTES.md).
 * Add new `ITelemetryHostInitializer` interface for applications that do not
   support hosted services, such as Blazor, to use to manually initialize the
   OpenTelemetry SDK as part of application startup.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7641](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7641))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -6,6 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Add new `ITelemetryHostInitializer` interface for applications that do not
+  support hosted services, such as Blazor, to use to manually initialize the
+  OpenTelemetry SDK as part of application startup.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry.Extensions.Hosting/ITelemetryHostInitializer.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/ITelemetryHostInitializer.cs
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry;
+
+/// <summary>
+/// Defines a method that initializes telemetry for a host.
+/// </summary>
+public interface ITelemetryHostInitializer
+{
+    /// <summary>
+    /// Initializes telemetry for a host.
+    /// </summary>
+    void Initialize();
+}

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostInitializer.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostInitializer.cs
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Extensions.Hosting.Implementation;
+
+internal sealed class TelemetryHostInitializer(IServiceProvider serviceProvider) : ITelemetryHostInitializer
+{
+    public void Initialize()
+    {
+        if (serviceProvider.GetService<MeterProvider>() is null)
+        {
+            HostingExtensionsEventSource.Log.MeterProviderNotRegistered();
+        }
+
+        if (serviceProvider.GetService<TracerProvider>() is null)
+        {
+            HostingExtensionsEventSource.Log.TracerProviderNotRegistered();
+        }
+
+        if (serviceProvider.GetService<LoggerProvider>() is null)
+        {
+            HostingExtensionsEventSource.Log.LoggerProviderNotRegistered();
+        }
+    }
+}

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
@@ -1,11 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using OpenTelemetry.Logs;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
 
 // Warning: Do not change the namespace or class name in this file! Azure
 // Functions has taken a dependency on the specific details:
@@ -13,45 +9,16 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Extensions.Hosting.Implementation;
 
-internal sealed class TelemetryHostedService : IHostedService
+internal sealed class TelemetryHostedService(ITelemetryHostInitializer initializer) : IHostedService
 {
-    private readonly IServiceProvider serviceProvider;
-
-    public TelemetryHostedService(IServiceProvider serviceProvider)
-    {
-        this.serviceProvider = serviceProvider;
-    }
-
     public Task StartAsync(CancellationToken cancellationToken)
     {
         // The sole purpose of this HostedService is to ensure all
         // instrumentations, exporters, etc., are created and started.
-        Initialize(this.serviceProvider);
-
+        initializer.Initialize();
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
         => Task.CompletedTask;
-
-    internal static void Initialize(IServiceProvider serviceProvider)
-    {
-        var meterProvider = serviceProvider.GetService<MeterProvider>();
-        if (meterProvider == null)
-        {
-            HostingExtensionsEventSource.Log.MeterProviderNotRegistered();
-        }
-
-        var tracerProvider = serviceProvider.GetService<TracerProvider>();
-        if (tracerProvider == null)
-        {
-            HostingExtensionsEventSource.Log.TracerProviderNotRegistered();
-        }
-
-        var loggerProvider = serviceProvider.GetService<LoggerProvider>();
-        if (loggerProvider == null)
-        {
-            HostingExtensionsEventSource.Log.LoggerProviderNotRegistered();
-        }
-    }
 }

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry;
 using OpenTelemetry.Extensions.Hosting.Implementation;
@@ -42,6 +43,9 @@ public static class OpenTelemetryServicesExtensions
 
         if (!services.Any(d => d.ServiceType == typeof(IHostedService) && d.ImplementationType == typeof(TelemetryHostedService)))
         {
+            // TryAdd is used to allow any consuming application's customization not be overridden
+            services.TryAddSingleton<ITelemetryHostInitializer, TelemetryHostInitializer>();
+
             services.Insert(0, ServiceDescriptor.Singleton<IHostedService, TelemetryHostedService>());
         }
 

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -83,6 +83,17 @@ app.Run();
 A fully functional example can be found
 [here](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/examples/AspNetCore).
 
+> [!IMPORTANT]
+> Applications that do not support hosted services, such as Blazor, should
+> resolve the `ITelemetryHostInitializer` service from the service collection
+> to manually initialize the OpenTelemetry SDK as part of application startup.
+>
+> For example:
+>
+> ```csharp
+> app.Services.GetRequiredService<ITelemetryHostInitializer>().Initialize();
+> ```
+
 ### Resources
 
 To dynamically add resources at startup from the dependency injection you can

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -85,7 +85,7 @@ A fully functional example can be found
 
 > [!IMPORTANT]
 > Applications that do not support hosted services, such as Blazor, should
-> resolve the `ITelemetryHostInitializer` service from the service collection
+> resolve the `ITelemetryHostInitializer` service from the service provider
 > to manually initialize the OpenTelemetry SDK as part of application startup.
 >
 > For example:

--- a/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
@@ -10,13 +10,13 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
-var builder = WebAssemblyHostBuilder.CreateDefault(args);
-
-builder.RootComponents.Add<App>("#app");
-
 Environment.SetEnvironmentVariable("OTEL_BSP_SCHEDULE_DELAY", "1000");
 Environment.SetEnvironmentVariable("OTEL_BLRP_SCHEDULE_DELAY", "1000");
 Environment.SetEnvironmentVariable("OTEL_METRIC_EXPORT_INTERVAL", "1000");
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.RootComponents.Add<App>("#app");
 
 // The OTLP receiver is served from the same origin as the application, so the
 // export endpoints are resolved relative to the host base address. This keeps

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
@@ -23,44 +23,33 @@ Environment.SetEnvironmentVariable("OTEL_METRIC_EXPORT_INTERVAL", "1000");
 // the export a genuine cross-process HTTP/protobuf call while avoiding CORS.
 var baseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 
-var resourceBuilder = ResourceBuilder.CreateDefault()
-    .AddService(InstrumentationSource.ServiceName);
-
 using var instrumentation = new InstrumentationSource();
 builder.Services.AddSingleton(instrumentation);
 
 builder.Services.AddScoped(_ => new HttpClient { BaseAddress = baseAddress });
 
-var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .SetResourceBuilder(resourceBuilder)
-    .AddSource(InstrumentationSource.ActivitySourceName)
-    .AddSource("System.Net.Http")
-    .SetSampler(new AlwaysOnSampler())
-    .AddOtlpExporter((options) =>
-    {
-        options.Protocol = OtlpExportProtocol.HttpProtobuf;
-        options.Endpoint = new Uri(baseAddress, "v1/traces");
-    })
-    .Build();
-
-builder.Services.AddSingleton(tracerProvider);
-
-var meterProvider = Sdk.CreateMeterProviderBuilder()
-    .SetResourceBuilder(resourceBuilder)
-    .AddMeter(InstrumentationSource.MeterName)
-    .AddMeter("System.Net.Http")
-    .AddOtlpExporter((options) =>
-    {
-        options.Protocol = OtlpExportProtocol.HttpProtobuf;
-        options.Endpoint = new Uri(baseAddress, "v1/metrics");
-    })
-    .Build();
-
-builder.Services.AddSingleton(meterProvider);
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService(InstrumentationSource.ServiceName))
+    .WithTracing(tracing => tracing
+        .AddSource(InstrumentationSource.ActivitySourceName)
+        .AddSource("System.Net.Http")
+        .SetSampler(new AlwaysOnSampler())
+        .AddOtlpExporter(options =>
+        {
+            options.Protocol = OtlpExportProtocol.HttpProtobuf;
+            options.Endpoint = new Uri(baseAddress, "v1/traces");
+        }))
+    .WithMetrics(metrics => metrics
+        .AddMeter(InstrumentationSource.MeterName)
+        .AddMeter("System.Net.Http")
+        .AddOtlpExporter(options =>
+        {
+            options.Protocol = OtlpExportProtocol.HttpProtobuf;
+            options.Endpoint = new Uri(baseAddress, "v1/metrics");
+        }));
 
 builder.Logging.AddOpenTelemetry((options) =>
 {
-    options.SetResourceBuilder(resourceBuilder);
     options.IncludeFormattedMessage = true;
 
     options.AddOtlpExporter((exporterOptions) =>
@@ -71,5 +60,7 @@ builder.Logging.AddOpenTelemetry((options) =>
 });
 
 var app = builder.Build();
+
+app.Services.GetRequiredService<ITelemetryHostInitializer>().Initialize();
 
 await app.RunAsync().ConfigureAwait(false);

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -6,8 +6,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Extensions.Hosting.Implementation;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Extensions.Hosting.Tests;
@@ -473,6 +475,68 @@ public class OpenTelemetryServicesExtensionsTests
         Assert.Equal("test", activity.DisplayName);
     }
 
+    [Fact]
+    public void AddOpenTelemetry_TelemetryHostInitializer_ResolvesConfiguredProviders()
+    {
+        var services = new ServiceCollection();
+
+        services.AddOpenTelemetry()
+            .WithTracing(builder => { })
+            .WithMetrics(builder => { })
+            .WithLogging(builder => { });
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var initializer = serviceProvider.GetRequiredService<ITelemetryHostInitializer>();
+        initializer.Initialize();
+
+        Assert.NotNull(serviceProvider.GetService<TracerProvider>());
+        Assert.NotNull(serviceProvider.GetService<MeterProvider>());
+        Assert.NotNull(serviceProvider.GetService<LoggerProvider>());
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_TelemetryHostInitializer_WarnsWhenProvidersNotRegistered()
+    {
+        using var eventListener = new TestEventListener(HostingExtensionsEventSource.Log);
+
+        var services = new ServiceCollection();
+
+        services.AddOpenTelemetry();
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var initializer = serviceProvider.GetRequiredService<ITelemetryHostInitializer>();
+        initializer.Initialize();
+
+        Assert.Single(eventListener.Messages, e => e.EventId == 1);
+        Assert.Single(eventListener.Messages, e => e.EventId == 2);
+        Assert.Single(eventListener.Messages, e => e.EventId == 3);
+    }
+
+    [Fact]
+    public async Task AddOpenTelemetry_CustomTelemetryHostInitializer_InvokedByHostedServiceOnStart()
+    {
+        var customInitializer = new CustomTelemetryHostInitializer();
+
+        var builder = new HostBuilder().ConfigureServices(services =>
+        {
+            services.AddSingleton<ITelemetryHostInitializer>(customInitializer);
+            services.AddOpenTelemetry();
+        });
+
+        using var host = builder.Build();
+
+        Assert.Same(customInitializer, host.Services.GetRequiredService<ITelemetryHostInitializer>());
+        Assert.False(customInitializer.Initialized, "Custom initializer was invoked.");
+
+        await host.StartAsync();
+
+        Assert.True(customInitializer.Initialized, "Custom initializer was not invoked.");
+
+        await host.StopAsync();
+    }
+
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes
     private sealed class MySampler : Sampler
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
@@ -501,5 +565,12 @@ public class OpenTelemetryServicesExtensionsTests
 
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class CustomTelemetryHostInitializer : ITelemetryHostInitializer
+    {
+        public bool Initialized { get; private set; }
+
+        public void Initialize() => this.Initialized = true;
     }
 }


### PR DESCRIPTION
Fixes #7523

## Changes

Add `ITelemetryHostInitializer` for use with applications, such as Blazor, that cannot benefit from `IHostedService` to initialize the SDK.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
