### PR TITLE
Add processor queue self-observability metrics

### DIFF
--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -25,6 +25,7 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
 
     private readonly CircularBuffer<T> circularBuffer;
     private readonly BatchExportWorker<T> worker;
+    private IDisposable? queueMetricRegistration;
 
     // Number of OnEnd calls currently in-flight (past the shutdown check).
     // OnShutdown waits for this to reach zero so those items finish enqueueing
@@ -84,6 +85,17 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
     /// Gets a value indicating whether <see cref="OnShutdown(int)"/> has been invoked.
     /// </summary>
     private bool IsShutdown => Volatile.Read(ref this.isShutdown) != 0;
+
+    internal void RegisterQueueMetrics(
+        bool isLogProcessor,
+        KeyValuePair<string, object?>[] tags)
+    {
+        this.queueMetricRegistration = SdkSelfObservability.RegisterProcessorQueue(
+            isLogProcessor,
+            () => this.circularBuffer.Count,
+            this.circularBuffer.Capacity,
+            tags);
+    }
 
     /// <summary>
     /// Marks the beginning of an <see cref="BaseProcessor{T}.OnEnd(T)"/> call which may enqueue data.
@@ -197,6 +209,7 @@ public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
         {
             if (disposing)
             {
+                this.queueMetricRegistration?.Dispose();
                 this.worker?.Dispose();
             }
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -21,6 +21,10 @@ Notes](../../RELEASENOTES.md).
 * Added the `otel.sdk.processor.span.processed` SDK self-observability metric.
   ([#7598](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7598))
 
+* Added SDK self-observability metrics for the current size and configured
+  capacity of the batching span and log processor queues.
+  ([#7642](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7642))
+
 * `BatchActivityExportProcessor` and `SimpleActivityExportProcessor` no longer
   forward spans to the exporter once `Shutdown` has been called, and
   `BatchActivityExportProcessor.Shutdown` now waits for in-flight `OnEnd` calls
@@ -30,10 +34,6 @@ Notes](../../RELEASENOTES.md).
 * Fix logger, meter and tracer providers leaking background threads if an
   exception is thrown by their constructor after resource creation.
   ([#7615](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7615))
-
-* Added SDK self-observability metrics for the current size and configured
-  capacity of the batching span and log processor queues.
-  ([#7642](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7642))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -31,6 +31,10 @@ Notes](../../RELEASENOTES.md).
   exception is thrown by their constructor after resource creation.
   ([#7615](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7615))
 
+* Added SDK self-observability metrics for the current size and configured
+  capacity of the batching span and log processor queues.
+  ([#7642](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7642))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry/Internal/SdkSelfObservability.cs
+++ b/src/OpenTelemetry/Internal/SdkSelfObservability.cs
@@ -32,4 +32,107 @@ internal static class SdkSelfObservability
         "otel.sdk.processor.span.processed",
         "{span}",
         "The number of spans for which the processing has finished, either successful or failed.");
+
+    internal static readonly object ProcessorQueueRegistrationsLock = new();
+    internal static readonly List<ProcessorQueueRegistration> LogProcessorQueueRegistrations = [];
+    internal static readonly List<ProcessorQueueRegistration> SpanProcessorQueueRegistrations = [];
+
+    internal static readonly ObservableUpDownCounter<long> LogQueueSize = Meter.CreateObservableUpDownCounter(
+        "otel.sdk.processor.log.queue.size",
+        () => ObserveProcessorQueues(LogProcessorQueueRegistrations, observeCapacity: false),
+        "{log_record}",
+        "The number of log records in the queue of a given instance of an SDK log processor.");
+
+    internal static readonly ObservableUpDownCounter<long> LogQueueCapacity = Meter.CreateObservableUpDownCounter(
+        "otel.sdk.processor.log.queue.capacity",
+        () => ObserveProcessorQueues(LogProcessorQueueRegistrations, observeCapacity: true),
+        "{log_record}",
+        "The maximum number of log records the queue of a given instance of an SDK log processor can hold.");
+
+    internal static readonly ObservableUpDownCounter<long> SpanQueueSize = Meter.CreateObservableUpDownCounter(
+        "otel.sdk.processor.span.queue.size",
+        () => ObserveProcessorQueues(SpanProcessorQueueRegistrations, observeCapacity: false),
+        "{span}",
+        "The number of spans in the queue of a given instance of an SDK span processor.");
+
+    internal static readonly ObservableUpDownCounter<long> SpanQueueCapacity = Meter.CreateObservableUpDownCounter(
+        "otel.sdk.processor.span.queue.capacity",
+        () => ObserveProcessorQueues(SpanProcessorQueueRegistrations, observeCapacity: true),
+        "{span}",
+        "The maximum number of spans the queue of a given instance of an SDK span processor can hold.");
+
+    internal static IDisposable RegisterProcessorQueue(
+        bool isLogProcessor,
+        Func<long> observeSize,
+        long capacity,
+        KeyValuePair<string, object?>[] tags)
+    {
+        var registrations = isLogProcessor
+            ? LogProcessorQueueRegistrations
+            : SpanProcessorQueueRegistrations;
+        var registration = new ProcessorQueueRegistration(registrations, observeSize, capacity, tags);
+
+        lock (ProcessorQueueRegistrationsLock)
+        {
+            registrations.Add(registration);
+        }
+
+        return registration;
+    }
+
+    internal static Measurement<long>[] ObserveProcessorQueues(
+        List<ProcessorQueueRegistration> registrations,
+        bool observeCapacity)
+    {
+        lock (ProcessorQueueRegistrationsLock)
+        {
+            var measurements = new Measurement<long>[registrations.Count];
+
+            for (var i = 0; i < registrations.Count; i++)
+            {
+                var registration = registrations[i];
+                var value = observeCapacity ? registration.Capacity : registration.ObserveSize();
+                measurements[i] = new(value, registration.Tags);
+            }
+
+            return measurements;
+        }
+    }
+
+    internal sealed class ProcessorQueueRegistration : IDisposable
+    {
+        private readonly List<ProcessorQueueRegistration> registrations;
+        private int disposed;
+
+        public ProcessorQueueRegistration(
+            List<ProcessorQueueRegistration> registrations,
+            Func<long> observeSize,
+            long capacity,
+            KeyValuePair<string, object?>[] tags)
+        {
+            this.registrations = registrations;
+            this.ObserveSize = observeSize;
+            this.Capacity = capacity;
+            this.Tags = tags;
+        }
+
+        public Func<long> ObserveSize { get; }
+
+        public long Capacity { get; }
+
+        public KeyValuePair<string, object?>[] Tags { get; }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref this.disposed, 1) != 0)
+            {
+                return;
+            }
+
+            lock (ProcessorQueueRegistrationsLock)
+            {
+                this.registrations.Remove(this);
+            }
+        }
+    }
 }

--- a/src/OpenTelemetry/Logs/Processor/BatchLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/Processor/BatchLogRecordExportProcessor.cs
@@ -49,6 +49,7 @@ public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
         this.queueFullTags = [.. baseTags, new("error.type", "queue_full")];
         this.alreadyShutdownTags = [.. baseTags, new("error.type", "already_shutdown")];
         this.ExportStarted = this.RecordSuccessfulProcessing;
+        this.RegisterQueueMetrics(isLogProcessor: true, baseTags);
     }
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -76,7 +76,11 @@ Conventions](https://opentelemetry.io/docs/specs/semconv/otel/sdk-metrics/).
 
 | Metric Name | Instrument | Unit | Description |
 | --- | --- | --- | --- |
+| `otel.sdk.processor.log.queue.size` | ObservableUpDownCounter | `{log_record}` | Current number of log records queued by a batching processor. |
+| `otel.sdk.processor.log.queue.capacity` | ObservableUpDownCounter | `{log_record}` | Maximum number of log records that can be queued by a batching processor. |
 | `otel.sdk.processor.log.processed` | Counter | `{log_record}` | Number of log records processed by the SDK, tagged with outcome. |
+| `otel.sdk.processor.span.queue.size` | ObservableUpDownCounter | `{span}` | Current number of spans queued by a batching processor. |
+| `otel.sdk.processor.span.queue.capacity` | ObservableUpDownCounter | `{span}` | Maximum number of spans that can be queued by a batching processor. |
 | `otel.sdk.processor.span.processed` | Counter | `{span}` | Number of spans processed by the SDK, tagged with outcome. |
 
 ### Attributes

--- a/src/OpenTelemetry/Trace/Processor/BatchActivityExportProcessor.cs
+++ b/src/OpenTelemetry/Trace/Processor/BatchActivityExportProcessor.cs
@@ -49,6 +49,7 @@ public class BatchActivityExportProcessor : BatchExportProcessor<Activity>
         this.queueFullTags = [.. baseTags, new("error.type", "queue_full")];
         this.alreadyShutdownTags = [.. baseTags, new("error.type", "already_shutdown")];
         this.ExportStarted = this.RecordSuccessfulProcessing;
+        this.RegisterQueueMetrics(isLogProcessor: false, baseTags);
     }
 
     /// <inheritdoc />

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorSelfObservabilityTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorSelfObservabilityTests.cs
@@ -12,6 +12,50 @@ namespace OpenTelemetry.Tests.Logs;
 public class BatchLogRecordExportProcessorSelfObservabilityTests
 {
     [Fact]
+    public void BatchProcessor_ReportsQueueSizeAndCapacity()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter("otel.sdk.experimental")
+            .AddInMemoryExporter(exportedMetrics)
+            .Build();
+
+        using var exporter = new InMemoryExporter<LogRecord>(new List<LogRecord>());
+        using var processor = new BatchLogRecordExportProcessor(
+            exporter,
+            maxQueueSize: 5,
+            scheduledDelayMilliseconds: int.MaxValue,
+            maxExportBatchSize: 5);
+        using var loggerProvider = Sdk.CreateLoggerProviderBuilder()
+            .AddProcessor(processor)
+            .Build();
+
+        var logger = loggerProvider.GetLogger("test");
+        logger.EmitLog(new LogRecordData());
+        logger.EmitLog(new LogRecordData());
+
+        meterProvider.ForceFlush();
+
+        var sizePoint = GetMetricPoints(exportedMetrics.Single(
+            m => m.Name == "otel.sdk.processor.log.queue.size")).Single();
+        var capacityPoint = GetMetricPoints(exportedMetrics.Single(
+            m => m.Name == "otel.sdk.processor.log.queue.capacity")).Single();
+
+        Assert.Equal(2, sizePoint.GetSumLong());
+        Assert.Equal(5, capacityPoint.GetSumLong());
+        AssertTag(sizePoint, "otel.component.type", "batching_log_processor");
+        AssertTagStartsWith(sizePoint, "otel.component.name", "batching_log_processor/");
+
+        Assert.True(processor.ForceFlush());
+        exportedMetrics.Clear();
+        meterProvider.ForceFlush();
+
+        sizePoint = GetMetricPoints(exportedMetrics.Single(
+            m => m.Name == "otel.sdk.processor.log.queue.size")).Single();
+        Assert.Equal(0, sizePoint.GetSumLong());
+    }
+
+    [Fact]
     public async Task BatchProcessor_CountsSuccessWhenSubmittedToExporter()
     {
         var exportedMetrics = new List<Metric>();

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorSelfObservabilityTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorSelfObservabilityTests.cs
@@ -56,6 +56,37 @@ public class BatchLogRecordExportProcessorSelfObservabilityTests
     }
 
     [Fact]
+    public void DisposedBatchProcessor_StopsReportingQueueMetrics()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter("otel.sdk.experimental")
+            .AddInMemoryExporter(exportedMetrics)
+            .Build();
+
+        using var exporter1 = new InMemoryExporter<LogRecord>(new List<LogRecord>());
+        using var exporter2 = new InMemoryExporter<LogRecord>(new List<LogRecord>());
+        var disposedProcessor = new BatchLogRecordExportProcessor(
+            exporter1,
+            maxQueueSize: 3,
+            maxExportBatchSize: 3);
+        using var activeProcessor = new BatchLogRecordExportProcessor(
+            exporter2,
+            maxQueueSize: 7,
+            maxExportBatchSize: 7);
+
+        disposedProcessor.Dispose();
+        meterProvider.ForceFlush();
+
+        var capacityPoints = GetMetricPoints(exportedMetrics.Single(
+            m => m.Name == "otel.sdk.processor.log.queue.capacity"));
+
+        var capacityPoint = Assert.Single(capacityPoints);
+        Assert.Equal(7, capacityPoint.GetSumLong());
+        AssertTagStartsWith(capacityPoint, "otel.component.name", "batching_log_processor/");
+    }
+
+    [Fact]
     public async Task BatchProcessor_CountsSuccessWhenSubmittedToExporter()
     {
         var exportedMetrics = new List<Metric>();

--- a/test/OpenTelemetry.Tests/Trace/ActivityExportProcessorSelfObservabilityTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExportProcessorSelfObservabilityTests.cs
@@ -18,6 +18,46 @@ public class ActivityExportProcessorSelfObservabilityTests
     private const string MetricName = "otel.sdk.processor.span.processed";
 
     [Fact]
+    public void BatchProcessor_ReportsQueueSizeAndCapacity()
+    {
+        var exportedMetrics = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedMetrics);
+
+        using var exporter = new InMemoryExporter<Activity>(new List<Activity>());
+        using var processor = new BatchActivityExportProcessor(
+            exporter,
+            maxQueueSize: 5,
+            scheduledDelayMilliseconds: int.MaxValue,
+            maxExportBatchSize: 5);
+
+        var sourceName = Utils.GetCurrentMethodName();
+        using var source = new ActivitySource(sourceName);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(sourceName)
+            .SetSampler(new AlwaysOnSampler())
+            .AddProcessor(processor)
+            .Build();
+
+        StartAndStopActivities(source, 2);
+        meterProvider.ForceFlush();
+
+        var sizePoint = GetMetricPoints(exportedMetrics, "otel.sdk.processor.span.queue.size").Single();
+        var capacityPoint = GetMetricPoints(exportedMetrics, "otel.sdk.processor.span.queue.capacity").Single();
+
+        Assert.Equal(2, sizePoint.GetSumLong());
+        Assert.Equal(5, capacityPoint.GetSumLong());
+        AssertTag(sizePoint, "otel.component.type", "batching_span_processor");
+        AssertTagStartsWith(sizePoint, "otel.component.name", "batching_span_processor/");
+
+        Assert.True(processor.ForceFlush());
+        exportedMetrics.Clear();
+        meterProvider.ForceFlush();
+
+        sizePoint = GetMetricPoints(exportedMetrics, "otel.sdk.processor.span.queue.size").Single();
+        Assert.Equal(0, sizePoint.GetSumLong());
+    }
+
+    [Fact]
     public async Task BatchProcessor_CountsSuccessWhenSubmittedToExporter()
     {
         var exportedMetrics = new List<Metric>();
@@ -515,8 +555,11 @@ public class ActivityExportProcessorSelfObservabilityTests
     }
 
     private static List<MetricPoint> GetMetricPoints(List<Metric> exportedMetrics)
+        => GetMetricPoints(exportedMetrics, MetricName);
+
+    private static List<MetricPoint> GetMetricPoints(List<Metric> exportedMetrics, string metricName)
     {
-        var metric = exportedMetrics.Single(m => m.Name == MetricName);
+        var metric = exportedMetrics.Single(m => m.Name == metricName);
 
         var points = new List<MetricPoint>();
         foreach (ref readonly var mp in metric.GetMetricPoints())


### PR DESCRIPTION
Adds the four remaining processor queue SDK self-observability metrics:

- `otel.sdk.processor.log.queue.size`
- `otel.sdk.processor.log.queue.capacity`
- `otel.sdk.processor.span.queue.size`
- `otel.sdk.processor.span.queue.capacity`

The metrics are `ObservableUpDownCounter<long>` instruments registered on `otel.sdk.experimental`. A shared registry reports all active batching processor instances with `otel.component.type` and `otel.component.name`, and unregisters processors when they are disposed so observable callbacks do not retain stale instances.

## Validation

- `dotnet build OpenTelemetry.slnx --configuration Release`
- Focused self-observability tests on `net8.0`, `net9.0`, and `net10.0`
- `dotnet format OpenTelemetry.slnx --no-restore --verify-no-changes`
- Repository sanity check for changed files