### PR TITLE
[Infra] Fix hanging Blazor tests on Linux

### DIFF
--- a/.github/workflows/blazor-wasm-integration-test.yml
+++ b/.github/workflows/blazor-wasm-integration-test.yml
@@ -38,6 +38,23 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
 
+    - name: Stop background apt services
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -x
+        sudo systemctl stop apt-daily.service apt-daily-upgrade.service apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service 2>/dev/null || true
+        sudo systemctl disable apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
+        sudo killall apt.systemd.daily 2>/dev/null || true
+        for _ in $(seq 1 30); do
+          if sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1; then
+            echo "Waiting for apt/dpkg lock to be released..."
+            sleep 2
+          else
+            break
+          fi
+        done
+
     - name: Install wasm-tools workload
       shell: pwsh
       run: dotnet workload install wasm-tools

--- a/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
+++ b/test/OpenTelemetry.BlazorWasm.Tests/BlazorWasmAppFixture.cs
@@ -12,6 +12,7 @@ namespace OpenTelemetry.BlazorWasm.Tests;
 
 public sealed class BlazorWasmAppFixture : IAsyncLifetime
 {
+    private static readonly TimeSpan PlaywrightInstallTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan PublishTimeout = TimeSpan.FromMinutes(5);
 
     private string? publishDirectory;
@@ -75,12 +76,28 @@ public sealed class BlazorWasmAppFixture : IAsyncLifetime
             ? ["install", "chromium", "--with-deps"]
             : ["install", "chromium"];
 
-        var exitCode = Microsoft.Playwright.Program.Main(arguments);
+        var scriptPath = Path.Combine(AppContext.BaseDirectory, "playwright.ps1");
 
-        if (exitCode != 0)
+        var startInfo = new ProcessStartInfo("pwsh")
         {
-            throw new InvalidOperationException($"Playwright browser install exited with code {exitCode}.");
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(scriptPath);
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
         }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start the Playwright browser installer.");
+
+        WaitForProcess(process, PlaywrightInstallTimeout);
     }
 
     private static string CurrentTargetFramework()
@@ -160,6 +177,13 @@ public sealed class BlazorWasmAppFixture : IAsyncLifetime
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start 'dotnet publish' for the Blazor client.");
 
+        WaitForProcess(process, PublishTimeout);
+
+        return output;
+    }
+
+    private static void WaitForProcess(Process process, TimeSpan timeout)
+    {
         var stdout = new StringBuilder();
         var stderr = new StringBuilder();
 
@@ -182,22 +206,19 @@ public sealed class BlazorWasmAppFixture : IAsyncLifetime
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
-        if (!process.WaitForExit(PublishTimeout))
+        if (!process.WaitForExit(timeout))
         {
             process.Kill(entireProcessTree: true);
             throw new InvalidOperationException(
-                $"'dotnet publish' timed out after {PublishTimeout}.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+                $"Process timed out after {timeout}.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
         }
 
-        // Wait (again, with no timeout) for the async output handlers to flush.
         process.WaitForExit();
 
         if (process.ExitCode != 0)
         {
             throw new InvalidOperationException(
-                $"'dotnet publish' failed with exit code {process.ExitCode}.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+                $"Process exited with code {process.ExitCode}.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
         }
-
-        return output;
     }
 }


### PR DESCRIPTION
## Changes

The Blazor integration tests started randomly timing out yesterday on Linux - my hunch is that there's a now a mismatch between the pre-installed and Playwright Chrome versions, and it's now installing an older release which is taking a long time and/or hanging, causing the failure.

These changes should either avoid that, or make the job fail sooner. #7654 might also resolve any mismatch.

- Stop apt background services to avoid potential lock when installing Playwright browsers and dependencies on Linux.
- Add timeout to Playwright browser installation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
