### PR TITLE
[Config] Declarative config phase 2: Add ConfigProperties typed property bag

### DIFF
--- a/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
+++ b/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
@@ -7,13 +7,13 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Added internal `ConfigProperties` type - a typed, immutable property bag
-  for reading parsed YAML configuration values (scalars, nested mappings, and
-  sequences).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
-
 * Initial implementation of the `OpenTelemetry.Configuration.Declarative`
   package. Adds declarative configuration (YAML) support for the OpenTelemetry
   .NET SDK with support for `disabled` and `resource.attributes` /
   `resource.attributes_list`.
   ([#7413](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7413))
+
+* Added internal `ConfigProperties` type - a typed, immutable property bag
+  for reading parsed YAML configuration values (scalars, nested mappings, and
+  sequences).
+  ([#7657](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7657))

--- a/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
+++ b/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
@@ -7,6 +7,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added internal `ConfigProperties` type - a typed, immutable property bag
+  for reading parsed YAML configuration values (scalars, nested mappings, and
+  sequences).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 * Initial implementation of the `OpenTelemetry.Configuration.Declarative`
   package. Adds declarative configuration (YAML) support for the OpenTelemetry
   .NET SDK with support for `disabled` and `resource.attributes` /

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigProperties.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigProperties.cs
@@ -1,0 +1,401 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// An immutable, typed view over a flat mapping of configuration keys to <see cref="ConfigValue"/>s.
+/// </summary>
+internal sealed class ConfigProperties
+{
+    private readonly Dictionary<string, ConfigValue> values;
+
+    private ConfigProperties(Dictionary<string, ConfigValue> values)
+    {
+        this.values = values;
+    }
+
+    /// <summary>
+    /// Gets a shared empty <see cref="ConfigProperties"/> with no keys.
+    /// </summary>
+    public static ConfigProperties Empty { get; } =
+        new ConfigProperties(new Dictionary<string, ConfigValue>(0, StringComparer.Ordinal));
+
+    /// <summary>
+    /// Gets all keys present in this mapping.
+    /// </summary>
+    public IReadOnlyCollection<string> Keys => this.values.Keys;
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as a <see cref="string"/>.
+    /// </summary>
+    /// <param name="key">The key to read.</param>
+    /// <returns>A result with outcome <see cref="ConfigValueOutcome.Absent"/>, <see cref="ConfigValueOutcome.PresentNull"/>, <see cref="ConfigValueOutcome.Present"/>, or <see cref="ConfigValueOutcome.TypeMismatch"/>.</returns>
+    public ConfigValueResult<string> GetString(string key)
+    {
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<string>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<string>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind == ConfigValueKind.String)
+        {
+            return new ConfigValueResult<string>(ConfigValueOutcome.Present, value.AsString());
+        }
+
+        return new ConfigValueResult<string>(ConfigValueOutcome.TypeMismatch, default);
+    }
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as a <see cref="bool"/>.
+    /// </summary>
+    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    public ConfigValueResult<bool> GetBoolean(string key)
+    {
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<bool>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<bool>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Boolean)
+        {
+            return new ConfigValueResult<bool>(ConfigValueOutcome.Present, value.AsBoolean());
+        }
+
+        return new ConfigValueResult<bool>(ConfigValueOutcome.TypeMismatch, default);
+    }
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as an <see cref="int"/>.
+    /// </summary>
+    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    public ConfigValueResult<int> GetInt(string key)
+    {
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<int>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<int>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
+        {
+            var longValue = value.AsLong();
+            if (longValue >= int.MinValue && longValue <= int.MaxValue)
+            {
+                return new ConfigValueResult<int>(ConfigValueOutcome.Present, (int)longValue);
+            }
+        }
+
+        if (value.Kind == ConfigValueKind.Float && TryDoubleToInt(value.AsDouble(), out var intResult))
+        {
+            return new ConfigValueResult<int>(ConfigValueOutcome.Present, intResult);
+        }
+
+        return new ConfigValueResult<int>(ConfigValueOutcome.TypeMismatch, default);
+    }
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as a <see cref="long"/>.
+    /// </summary>
+    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    public ConfigValueResult<long> GetLong(string key)
+    {
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<long>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<long>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
+        {
+            return new ConfigValueResult<long>(ConfigValueOutcome.Present, value.AsLong());
+        }
+
+        if (value.Kind == ConfigValueKind.Float && TryDoubleToLong(value.AsDouble(), out var longResult))
+        {
+            return new ConfigValueResult<long>(ConfigValueOutcome.Present, longResult);
+        }
+
+        return new ConfigValueResult<long>(ConfigValueOutcome.TypeMismatch, default);
+    }
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as a <see cref="double"/>.
+    /// </summary>
+    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    public ConfigValueResult<double> GetDouble(string key)
+    {
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<double>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<double>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Float)
+        {
+            return new ConfigValueResult<double>(ConfigValueOutcome.Present, value.AsDouble());
+        }
+
+        if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
+        {
+            return new ConfigValueResult<double>(ConfigValueOutcome.Present, (double)value.AsLong());
+        }
+
+        return new ConfigValueResult<double>(ConfigValueOutcome.TypeMismatch, default);
+    }
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as a nested <see cref="ConfigProperties"/> mapping.
+    /// </summary>
+    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    public ConfigValueResult<ConfigProperties> GetProperties(string key)
+    {
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Mapping)
+        {
+            return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.Present, value.AsMapping());
+        }
+
+        return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.TypeMismatch, default);
+    }
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as a list of <see cref="ConfigProperties"/> mappings.
+    /// </summary>
+    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    public ConfigValueResult<IReadOnlyList<ConfigProperties>> GetPropertiesList(string key)
+    {
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind != ConfigValueKind.Sequence)
+        {
+            return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.TypeMismatch, default);
+        }
+
+        var sequence = value.AsSequence();
+        var list = new List<ConfigProperties>(sequence.Count);
+        foreach (var item in sequence)
+        {
+            // Null elements are also a mismatch: IReadOnlyList<ConfigProperties> has no slot for null.
+            // GetScalarList<T> applies the same rule.
+            if (item.Kind != ConfigValueKind.Mapping)
+            {
+                return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.TypeMismatch, default);
+            }
+
+            list.Add(item.AsMapping());
+        }
+
+        return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.Present, list.AsReadOnly());
+    }
+
+    /// <summary>
+    /// Returns the value of <paramref name="key"/> as a list of scalar values of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <remarks>
+    /// A sequence is readable only when every element is a scalar readable as <typeparamref name="T"/>.
+    /// A null element, an element of another kind, and a nested sequence or mapping each make the whole
+    /// sequence a mismatch, as they do for <see cref="GetPropertiesList"/>.
+    /// <para>
+    /// Element coercion mirrors the scalar getters: <see cref="long"/>, <see cref="double"/>, and
+    /// <see cref="int"/> elements accept numeric widening (e.g. a YAML float element is accepted for
+    /// <c>GetScalarList&lt;long&gt;</c> when it has no fractional part and fits the target range);
+    /// <see cref="string"/> and <see cref="bool"/> elements require an exact kind match.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The scalar element type. Supported types are <see cref="string"/>, <see cref="bool"/>, <see cref="long"/>, <see cref="double"/>, and <see cref="int"/>.</typeparam>
+    /// <param name="key">The key to read.</param>
+    /// <returns>A result with outcome <see cref="ConfigValueOutcome.Absent"/>, <see cref="ConfigValueOutcome.PresentNull"/>, <see cref="ConfigValueOutcome.Present"/>, or <see cref="ConfigValueOutcome.TypeMismatch"/>.</returns>
+    /// <exception cref="NotSupportedException">Thrown when <typeparamref name="T"/> is not one of the five supported scalar types. This is a programming error.</exception>
+    public ConfigValueResult<IReadOnlyList<T>> GetScalarList<T>(string key)
+    {
+        if (typeof(T) != typeof(string) && typeof(T) != typeof(bool) && typeof(T) != typeof(long)
+            && typeof(T) != typeof(double) && typeof(T) != typeof(int))
+        {
+            throw new NotSupportedException(
+                $"'{typeof(T).Name}' is not a supported scalar element type. Supported types are string, bool, long, double, and int.");
+        }
+
+        if (!this.TryGetValue(key, out var value))
+        {
+            return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.Absent, default);
+        }
+
+        if (value.Kind == ConfigValueKind.Null)
+        {
+            return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.PresentNull, default);
+        }
+
+        if (value.Kind != ConfigValueKind.Sequence)
+        {
+            return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.TypeMismatch, default);
+        }
+
+        var sequence = value.AsSequence();
+        var list = new List<T>(sequence.Count);
+        for (var i = 0; i < sequence.Count; i++)
+        {
+            var item = sequence[i];
+
+            // A null element mismatches the whole sequence, as it does for GetPropertiesList. An
+            // unconstrained T? is a nullable annotation only - for a value type it is T itself - so a
+            // null element could not be represented here without either corrupting it into default(T)
+            // or splitting the accessor per element type. No scalar sequence in the configuration
+            // schema permits a null element, so nothing readable is lost.
+            if (item.Kind == ConfigValueKind.Null)
+            {
+                return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.TypeMismatch, default);
+            }
+
+            if (!TryExtractScalar<T>(item, out var scalar))
+            {
+                return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.TypeMismatch, default);
+            }
+
+            list.Add(scalar!);
+        }
+
+        return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.Present, list.AsReadOnly());
+    }
+
+    internal static ConfigProperties Create(Dictionary<string, ConfigValue> values)
+        => new ConfigProperties(new Dictionary<string, ConfigValue>(values, StringComparer.Ordinal));
+
+    private static bool TryDoubleToLong(double value, out long result)
+    {
+        // long.MinValue = -2^63 is exactly representable; long.MaxValue = 2^63-1 rounds up to 2^63.
+        if (double.IsNaN(value) || double.IsInfinity(value) || value != Math.Floor(value)
+            || value < -9223372036854775808.0 || value >= 9223372036854775808.0)
+        {
+            result = 0;
+            return false;
+        }
+
+        result = (long)value;
+        return true;
+    }
+
+    private static bool TryDoubleToInt(double value, out int result)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value != Math.Floor(value)
+            || value < int.MinValue || value > int.MaxValue)
+        {
+            result = 0;
+            return false;
+        }
+
+        result = (int)value;
+        return true;
+    }
+
+    private static bool TryExtractScalar<T>(ConfigValue value, out T? result)
+    {
+        if (typeof(T) == typeof(string))
+        {
+            if (value.Kind == ConfigValueKind.String)
+            {
+                result = (T)(object)value.AsString();
+                return true;
+            }
+        }
+        else if (typeof(T) == typeof(bool))
+        {
+            if (value.Kind == ConfigValueKind.Boolean)
+            {
+                result = (T)(object)value.AsBoolean();
+                return true;
+            }
+        }
+        else if (typeof(T) == typeof(long))
+        {
+            if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
+            {
+                result = (T)(object)value.AsLong();
+                return true;
+            }
+
+            if (value.Kind == ConfigValueKind.Float && TryDoubleToLong(value.AsDouble(), out var longValue))
+            {
+                result = (T)(object)longValue;
+                return true;
+            }
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            if (value.Kind == ConfigValueKind.Float)
+            {
+                result = (T)(object)value.AsDouble();
+                return true;
+            }
+
+            if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
+            {
+                result = (T)(object)(double)value.AsLong();
+                return true;
+            }
+        }
+        else if (typeof(T) == typeof(int))
+        {
+            if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
+            {
+                var longValue = value.AsLong();
+                if (longValue >= int.MinValue && longValue <= int.MaxValue)
+                {
+                    result = (T)(object)(int)longValue;
+                    return true;
+                }
+            }
+
+            if (value.Kind == ConfigValueKind.Float && TryDoubleToInt(value.AsDouble(), out var intValue))
+            {
+                result = (T)(object)intValue;
+                return true;
+            }
+        }
+
+        result = default;
+        return false;
+    }
+
+    private bool TryGetValue(string key, out ConfigValue value)
+        => this.values.TryGetValue(key, out value);
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigProperties.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigProperties.cs
@@ -216,8 +216,7 @@ internal sealed class ConfigProperties
             && typeof(T) != typeof(int))
         {
             throw new NotSupportedException(
-                $"'{typeof(T).Name}' is not a supported scalar element type. " +
-                "Supported types are string, bool, long, double, and int.");
+                $"'{typeof(T).Name}' is not a supported scalar element type. Supported types are string, bool, long, double, and int.");
         }
 
         if (!this.TryGetValue(key, out var value))

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigProperties.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigProperties.cs
@@ -19,7 +19,7 @@ internal sealed class ConfigProperties
     /// Gets a shared empty <see cref="ConfigProperties"/> with no keys.
     /// </summary>
     public static ConfigProperties Empty { get; } =
-        new ConfigProperties(new Dictionary<string, ConfigValue>(0, StringComparer.Ordinal));
+        new(new Dictionary<string, ConfigValue>(0, StringComparer.Ordinal));
 
     /// <summary>
     /// Gets all keys present in this mapping.
@@ -27,284 +27,223 @@ internal sealed class ConfigProperties
     public IReadOnlyCollection<string> Keys => this.values.Keys;
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as a <see cref="string"/>.
+    /// Returns the value of <paramref name="key"/> as a <see cref="string"/> wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
     /// <param name="key">The key to read.</param>
-    /// <returns>A result with outcome <see cref="ConfigValueOutcome.Absent"/>, <see cref="ConfigValueOutcome.PresentNull"/>, <see cref="ConfigValueOutcome.Present"/>, or <see cref="ConfigValueOutcome.TypeMismatch"/>.</returns>
+    /// <returns>
+    /// A result with outcome <see cref="ConfigValueOutcome.Absent"/>, <see cref="ConfigValueOutcome.PresentNull"/>,
+    /// <see cref="ConfigValueOutcome.Present"/>, or <see cref="ConfigValueOutcome.TypeMismatch"/>.
+    /// </returns>
     public ConfigValueResult<string> GetString(string key)
     {
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<string>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<string>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind == ConfigValueKind.String)
-        {
-            return new ConfigValueResult<string>(ConfigValueOutcome.Present, value.AsString());
-        }
-
-        return new ConfigValueResult<string>(ConfigValueOutcome.TypeMismatch, default);
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.String => new(ConfigValueOutcome.Present, value.AsString()),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as a <see cref="bool"/>.
+    /// Returns the value of <paramref name="key"/> as a <see cref="bool"/> wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
-    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    /// <param name="key"><inheritdoc cref="GetString" path="/param"/></param>
+    /// <returns><inheritdoc cref="GetString" path="/returns"/></returns>
     public ConfigValueResult<bool> GetBoolean(string key)
     {
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<bool>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<bool>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind == ConfigValueKind.Boolean)
-        {
-            return new ConfigValueResult<bool>(ConfigValueOutcome.Present, value.AsBoolean());
-        }
-
-        return new ConfigValueResult<bool>(ConfigValueOutcome.TypeMismatch, default);
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.Boolean => new(ConfigValueOutcome.Present, value.AsBoolean()),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as an <see cref="int"/>.
+    /// Returns the value of <paramref name="key"/> as an <see cref="int"/> wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
-    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    /// <param name="key"><inheritdoc cref="GetString" path="/param"/></param>
+    /// <returns><inheritdoc cref="GetString" path="/returns"/></returns>
     public ConfigValueResult<int> GetInt(string key)
     {
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<int>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<int>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
-        {
-            var longValue = value.AsLong();
-            if (longValue >= int.MinValue && longValue <= int.MaxValue)
-            {
-                return new ConfigValueResult<int>(ConfigValueOutcome.Present, (int)longValue);
-            }
-        }
-
-        if (value.Kind == ConfigValueKind.Float && TryDoubleToInt(value.AsDouble(), out var intResult))
-        {
-            return new ConfigValueResult<int>(ConfigValueOutcome.Present, intResult);
-        }
-
-        return new ConfigValueResult<int>(ConfigValueOutcome.TypeMismatch, default);
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.Integer when !value.IsUnrepresentable && TryLongToInt(value.AsLong(), out var fromInteger)
+                => new(ConfigValueOutcome.Present, fromInteger),
+            ConfigValueKind.Double when TryDoubleToInt(value.AsDouble(), out var fromDouble)
+                => new(ConfigValueOutcome.Present, fromDouble),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as a <see cref="long"/>.
+    /// Returns the value of <paramref name="key"/> as a <see cref="long"/> wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
-    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    /// <param name="key"><inheritdoc cref="GetString" path="/param"/></param>
+    /// <returns><inheritdoc cref="GetString" path="/returns"/></returns>
     public ConfigValueResult<long> GetLong(string key)
     {
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<long>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<long>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
-        {
-            return new ConfigValueResult<long>(ConfigValueOutcome.Present, value.AsLong());
-        }
-
-        if (value.Kind == ConfigValueKind.Float && TryDoubleToLong(value.AsDouble(), out var longResult))
-        {
-            return new ConfigValueResult<long>(ConfigValueOutcome.Present, longResult);
-        }
-
-        return new ConfigValueResult<long>(ConfigValueOutcome.TypeMismatch, default);
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.Integer when !value.IsUnrepresentable => new(ConfigValueOutcome.Present, value.AsLong()),
+            ConfigValueKind.Double when TryDoubleToLong(value.AsDouble(), out var fromDouble)
+                => new(ConfigValueOutcome.Present, fromDouble),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as a <see cref="double"/>.
+    /// Returns the value of <paramref name="key"/> as a <see cref="double"/> wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
-    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    /// <param name="key"><inheritdoc cref="GetString" path="/param"/></param>
+    /// <returns><inheritdoc cref="GetString" path="/returns"/></returns>
     public ConfigValueResult<double> GetDouble(string key)
     {
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<double>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<double>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind == ConfigValueKind.Float)
-        {
-            return new ConfigValueResult<double>(ConfigValueOutcome.Present, value.AsDouble());
-        }
-
-        if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
-        {
-            return new ConfigValueResult<double>(ConfigValueOutcome.Present, (double)value.AsLong());
-        }
-
-        return new ConfigValueResult<double>(ConfigValueOutcome.TypeMismatch, default);
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.Double => new(ConfigValueOutcome.Present, value.AsDouble()),
+            ConfigValueKind.Integer when !value.IsUnrepresentable => new(ConfigValueOutcome.Present, (double)value.AsLong()),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as a nested <see cref="ConfigProperties"/> mapping.
+    /// Returns the value of <paramref name="key"/> as a nested <see cref="ConfigProperties"/> mapping
+    /// wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
-    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    /// <param name="key"><inheritdoc cref="GetString" path="/param"/></param>
+    /// <returns><inheritdoc cref="GetString" path="/returns"/></returns>
     public ConfigValueResult<ConfigProperties> GetProperties(string key)
     {
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind == ConfigValueKind.Mapping)
-        {
-            return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.Present, value.AsMapping());
-        }
-
-        return new ConfigValueResult<ConfigProperties>(ConfigValueOutcome.TypeMismatch, default);
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.Mapping => new(ConfigValueOutcome.Present, value.AsMapping()),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as a list of <see cref="ConfigProperties"/> mappings.
+    /// Returns the value of <paramref name="key"/> as a list of <see cref="ConfigProperties"/> mappings
+    /// wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
-    /// <inheritdoc cref="GetString" path="/param | /returns"/>
+    /// <param name="key"><inheritdoc cref="GetString" path="/param"/></param>
+    /// <returns><inheritdoc cref="GetString" path="/returns"/></returns>
     public ConfigValueResult<IReadOnlyList<ConfigProperties>> GetPropertiesList(string key)
     {
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind != ConfigValueKind.Sequence)
-        {
-            return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.TypeMismatch, default);
-        }
-
-        var sequence = value.AsSequence();
-        var list = new List<ConfigProperties>(sequence.Count);
-        foreach (var item in sequence)
-        {
-            // Null elements are also a mismatch: IReadOnlyList<ConfigProperties> has no slot for null.
-            // GetScalarList<T> applies the same rule.
-            if (item.Kind != ConfigValueKind.Mapping)
-            {
-                return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.TypeMismatch, default);
-            }
-
-            list.Add(item.AsMapping());
-        }
-
-        return new ConfigValueResult<IReadOnlyList<ConfigProperties>>(ConfigValueOutcome.Present, list.AsReadOnly());
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.Sequence when TryBuildPropertiesList(value.AsSequence(), out var list)
+                => new(ConfigValueOutcome.Present, list),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     /// <summary>
-    /// Returns the value of <paramref name="key"/> as a list of scalar values of type <typeparamref name="T"/>.
+    /// Returns the value of <paramref name="key"/> as a list of scalar values of type <typeparamref name="T"/>
+    /// wrapped as a <see cref="ConfigValueResult{T}"/>.
     /// </summary>
     /// <remarks>
     /// A sequence is readable only when every element is a scalar readable as <typeparamref name="T"/>.
-    /// A null element, an element of another kind, and a nested sequence or mapping each make the whole
-    /// sequence a mismatch, as they do for <see cref="GetPropertiesList"/>.
+    /// Any element of another kind - including null, a nested sequence, or a mapping - makes the whole
+    /// sequence a mismatch.
     /// <para>
     /// Element coercion mirrors the scalar getters: <see cref="long"/>, <see cref="double"/>, and
-    /// <see cref="int"/> elements accept numeric widening (e.g. a YAML float element is accepted for
-    /// <c>GetScalarList&lt;long&gt;</c> when it has no fractional part and fits the target range);
-    /// <see cref="string"/> and <see cref="bool"/> elements require an exact kind match.
+    /// <see cref="int"/> elements accept cross-kind numeric conversion where the value survives it
+    /// (e.g. a YAML float element is accepted for <c>GetScalarList&lt;long&gt;</c> when it has no
+    /// fractional part and fits the target range); <see cref="string"/> and <see cref="bool"/>
+    /// elements require an exact kind match.
     /// </para>
     /// </remarks>
-    /// <typeparam name="T">The scalar element type. Supported types are <see cref="string"/>, <see cref="bool"/>, <see cref="long"/>, <see cref="double"/>, and <see cref="int"/>.</typeparam>
+    /// <typeparam name="T">
+    /// The scalar element type. Supported types are <see cref="string"/>, <see cref="bool"/>,
+    /// <see cref="long"/>, <see cref="double"/>, and <see cref="int"/>.
+    /// </typeparam>
     /// <param name="key">The key to read.</param>
-    /// <returns>A result with outcome <see cref="ConfigValueOutcome.Absent"/>, <see cref="ConfigValueOutcome.PresentNull"/>, <see cref="ConfigValueOutcome.Present"/>, or <see cref="ConfigValueOutcome.TypeMismatch"/>.</returns>
-    /// <exception cref="NotSupportedException">Thrown when <typeparamref name="T"/> is not one of the five supported scalar types. This is a programming error.</exception>
+    /// <returns>
+    /// A result with outcome <see cref="ConfigValueOutcome.Absent"/>, <see cref="ConfigValueOutcome.PresentNull"/>,
+    /// <see cref="ConfigValueOutcome.Present"/>, or <see cref="ConfigValueOutcome.TypeMismatch"/>.
+    /// </returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <typeparamref name="T"/> is not one of the five supported scalar types. This is a
+    /// programming error.
+    /// </exception>
     public ConfigValueResult<IReadOnlyList<T>> GetScalarList<T>(string key)
     {
-        if (typeof(T) != typeof(string) && typeof(T) != typeof(bool) && typeof(T) != typeof(long)
-            && typeof(T) != typeof(double) && typeof(T) != typeof(int))
+        if (typeof(T) != typeof(string)
+            && typeof(T) != typeof(bool)
+            && typeof(T) != typeof(long)
+            && typeof(T) != typeof(double)
+            && typeof(T) != typeof(int))
         {
             throw new NotSupportedException(
-                $"'{typeof(T).Name}' is not a supported scalar element type. Supported types are string, bool, long, double, and int.");
+                $"'{typeof(T).Name}' is not a supported scalar element type. " +
+                "Supported types are string, bool, long, double, and int.");
         }
 
         if (!this.TryGetValue(key, out var value))
         {
-            return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.Absent, default);
+            return new(ConfigValueOutcome.Absent, default);
         }
 
-        if (value.Kind == ConfigValueKind.Null)
+        return value.Kind switch
         {
-            return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.PresentNull, default);
-        }
-
-        if (value.Kind != ConfigValueKind.Sequence)
-        {
-            return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.TypeMismatch, default);
-        }
-
-        var sequence = value.AsSequence();
-        var list = new List<T>(sequence.Count);
-        for (var i = 0; i < sequence.Count; i++)
-        {
-            var item = sequence[i];
-
-            // A null element mismatches the whole sequence, as it does for GetPropertiesList. An
-            // unconstrained T? is a nullable annotation only - for a value type it is T itself - so a
-            // null element could not be represented here without either corrupting it into default(T)
-            // or splitting the accessor per element type. No scalar sequence in the configuration
-            // schema permits a null element, so nothing readable is lost.
-            if (item.Kind == ConfigValueKind.Null)
-            {
-                return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.TypeMismatch, default);
-            }
-
-            if (!TryExtractScalar<T>(item, out var scalar))
-            {
-                return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.TypeMismatch, default);
-            }
-
-            list.Add(scalar!);
-        }
-
-        return new ConfigValueResult<IReadOnlyList<T>>(ConfigValueOutcome.Present, list.AsReadOnly());
+            ConfigValueKind.Null => new(ConfigValueOutcome.PresentNull, default),
+            ConfigValueKind.Sequence when TryBuildScalarList<T>(value.AsSequence(), out var list)
+                => new(ConfigValueOutcome.Present, list),
+            _ => new(ConfigValueOutcome.TypeMismatch, default),
+        };
     }
 
     internal static ConfigProperties Create(Dictionary<string, ConfigValue> values)
-        => new ConfigProperties(new Dictionary<string, ConfigValue>(values, StringComparer.Ordinal));
+        => new(new Dictionary<string, ConfigValue>(values, StringComparer.Ordinal));
 
     private static bool TryDoubleToLong(double value, out long result)
     {
         // long.MinValue = -2^63 is exactly representable; long.MaxValue = 2^63-1 rounds up to 2^63.
-        if (double.IsNaN(value) || double.IsInfinity(value) || value != Math.Floor(value)
-            || value < -9223372036854775808.0 || value >= 9223372036854775808.0)
+        if (double.IsNaN(value)
+            || double.IsInfinity(value)
+            || value != Math.Floor(value)
+            || value is < -9223372036854775808.0 or >= 9223372036854775808.0)
         {
             result = 0;
             return false;
@@ -316,8 +255,10 @@ internal sealed class ConfigProperties
 
     private static bool TryDoubleToInt(double value, out int result)
     {
-        if (double.IsNaN(value) || double.IsInfinity(value) || value != Math.Floor(value)
-            || value < int.MinValue || value > int.MaxValue)
+        if (double.IsNaN(value)
+            || double.IsInfinity(value)
+            || value != Math.Floor(value)
+            || value is < int.MinValue or > int.MaxValue)
         {
             result = 0;
             return false;
@@ -327,73 +268,90 @@ internal sealed class ConfigProperties
         return true;
     }
 
+    private static bool TryLongToInt(long value, out int result)
+    {
+        if (value is < int.MinValue or > int.MaxValue)
+        {
+            result = 0;
+            return false;
+        }
+
+        result = (int)value;
+        return true;
+    }
+
+    private static bool TryBuildPropertiesList(
+        IReadOnlyList<ConfigValue> sequence,
+        out IReadOnlyList<ConfigProperties>? result)
+    {
+        var list = new List<ConfigProperties>(sequence.Count);
+        foreach (var item in sequence)
+        {
+            // A null element is a mismatch too: the element type is non-nullable.
+            if (item.Kind != ConfigValueKind.Mapping)
+            {
+                result = null;
+                return false;
+            }
+
+            list.Add(item.AsMapping());
+        }
+
+        result = list.AsReadOnly();
+        return true;
+    }
+
+    private static bool TryBuildScalarList<T>(
+        IReadOnlyList<ConfigValue> sequence,
+        out IReadOnlyList<T>? result)
+    {
+        var list = new List<T>(sequence.Count);
+        foreach (var item in sequence)
+        {
+            // A null element is a mismatch: representing one would need IReadOnlyList<T?>, which for a
+            // value-type T means Nullable<T> and a per-type accessor split.
+            if (item.Kind == ConfigValueKind.Null || !TryExtractScalar<T>(item, out var scalar))
+            {
+                result = null;
+                return false;
+            }
+
+            list.Add(scalar!);
+        }
+
+        result = list.AsReadOnly();
+        return true;
+    }
+
+    // A null scalar means no arm matched. Unambiguous because no arm can yield null: ConfigValue.String
+    // rejects a null payload.
     private static bool TryExtractScalar<T>(ConfigValue value, out T? result)
     {
-        if (typeof(T) == typeof(string))
+        object? scalar = value.Kind switch
         {
-            if (value.Kind == ConfigValueKind.String)
-            {
-                result = (T)(object)value.AsString();
-                return true;
-            }
-        }
-        else if (typeof(T) == typeof(bool))
-        {
-            if (value.Kind == ConfigValueKind.Boolean)
-            {
-                result = (T)(object)value.AsBoolean();
-                return true;
-            }
-        }
-        else if (typeof(T) == typeof(long))
-        {
-            if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
-            {
-                result = (T)(object)value.AsLong();
-                return true;
-            }
+            ConfigValueKind.String when typeof(T) == typeof(string) => value.AsString(),
+            ConfigValueKind.Boolean when typeof(T) == typeof(bool) => value.AsBoolean(),
+            ConfigValueKind.Integer when typeof(T) == typeof(long) && !value.IsUnrepresentable => value.AsLong(),
+            ConfigValueKind.Integer when typeof(T) == typeof(double) && !value.IsUnrepresentable => (double)value.AsLong(),
+            ConfigValueKind.Integer when typeof(T) == typeof(int)
+                && !value.IsUnrepresentable
+                && TryLongToInt(value.AsLong(), out var intFromLong) => intFromLong,
+            ConfigValueKind.Double when typeof(T) == typeof(double) => value.AsDouble(),
+            ConfigValueKind.Double when typeof(T) == typeof(long)
+                && TryDoubleToLong(value.AsDouble(), out var longFromDouble) => longFromDouble,
+            ConfigValueKind.Double when typeof(T) == typeof(int)
+                && TryDoubleToInt(value.AsDouble(), out var intFromDouble) => intFromDouble,
+            _ => null,
+        };
 
-            if (value.Kind == ConfigValueKind.Float && TryDoubleToLong(value.AsDouble(), out var longValue))
-            {
-                result = (T)(object)longValue;
-                return true;
-            }
-        }
-        else if (typeof(T) == typeof(double))
+        if (scalar is null)
         {
-            if (value.Kind == ConfigValueKind.Float)
-            {
-                result = (T)(object)value.AsDouble();
-                return true;
-            }
-
-            if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
-            {
-                result = (T)(object)(double)value.AsLong();
-                return true;
-            }
-        }
-        else if (typeof(T) == typeof(int))
-        {
-            if (value.Kind == ConfigValueKind.Integer && !value.IsUnrepresentable)
-            {
-                var longValue = value.AsLong();
-                if (longValue >= int.MinValue && longValue <= int.MaxValue)
-                {
-                    result = (T)(object)(int)longValue;
-                    return true;
-                }
-            }
-
-            if (value.Kind == ConfigValueKind.Float && TryDoubleToInt(value.AsDouble(), out var intValue))
-            {
-                result = (T)(object)intValue;
-                return true;
-            }
+            result = default;
+            return false;
         }
 
-        result = default;
-        return false;
+        result = (T)scalar;
+        return true;
     }
 
     private bool TryGetValue(string key, out ConfigValue value)

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigPropertiesBuilder.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigPropertiesBuilder.cs
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// A mutable builder that accumulates key/value pairs and produces an immutable <see cref="ConfigProperties"/>.
+/// </summary>
+internal sealed class ConfigPropertiesBuilder
+{
+    private readonly Dictionary<string, ConfigValue> values = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Adds <paramref name="key"/> with <paramref name="value"/>.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="value">The value to associate with the key.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> already exists in this builder.</exception>
+    public ConfigPropertiesBuilder Add(string key, ConfigValue value)
+    {
+        Guard.ThrowIfNull(key);
+        this.values.Add(key, value);
+        return this;
+    }
+
+    /// <summary>
+    /// Creates an immutable <see cref="ConfigProperties"/> from the accumulated entries.
+    /// </summary>
+    /// <returns>A new <see cref="ConfigProperties"/> containing the entries added so far.</returns>
+    public ConfigProperties Build()
+        => ConfigProperties.Create(this.values);
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigPropertiesBuilder.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigPropertiesBuilder.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpenTelemetry.Internal;
-
 namespace OpenTelemetry.Configuration;
 
 /// <summary>
@@ -22,7 +20,6 @@ internal sealed class ConfigPropertiesBuilder
     /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> already exists in this builder.</exception>
     public ConfigPropertiesBuilder Add(string key, ConfigValue value)
     {
-        Guard.ThrowIfNull(key);
         this.values.Add(key, value);
         return this;
     }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValue.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValue.cs
@@ -1,0 +1,172 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// A discriminated-union value that can hold any type representable in the OTel configuration schema.
+/// </summary>
+/// <remarks>
+/// Use the <c>As*</c> accessors only after confirming <see cref="Kind"/>. Calling the wrong accessor
+/// throws <see cref="InvalidOperationException"/>. Factory methods are the only way to construct an instance.
+/// </remarks>
+internal readonly struct ConfigValue
+{
+    private readonly object? objectPayload;
+    private readonly long numericPayload;
+    private readonly double doublePayload;
+
+    private ConfigValue(ConfigValueKind kind, object? objectPayload, long numericPayload, double doublePayload, bool isUnrepresentable)
+    {
+        this.Kind = kind;
+        this.objectPayload = objectPayload;
+        this.numericPayload = numericPayload;
+        this.doublePayload = doublePayload;
+        this.IsUnrepresentable = isUnrepresentable;
+    }
+
+    /// <summary>
+    /// Gets the kind of value stored in this instance.
+    /// </summary>
+    internal ConfigValueKind Kind { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether an integer value could not be represented as a <see cref="long"/>.
+    /// When <see langword="true"/>, <see cref="AsLong"/> must not be called.
+    /// </summary>
+    internal bool IsUnrepresentable { get; }
+
+    /// <summary>
+    /// Creates a null value.
+    /// </summary>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Null"/>.</returns>
+    internal static ConfigValue Null() => new(ConfigValueKind.Null, null, 0L, 0.0, false);
+
+    /// <summary>
+    /// Creates a string value.
+    /// </summary>
+    /// <param name="value">The string to store.</param>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.String"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is <see langword="null"/>.</exception>
+    internal static ConfigValue String(string value)
+    {
+        Guard.ThrowIfNull(value);
+        return new(ConfigValueKind.String, value, 0L, 0.0, false);
+    }
+
+    /// <summary>
+    /// Creates a boolean value.
+    /// </summary>
+    /// <param name="value">The boolean to store.</param>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Boolean"/>.</returns>
+    internal static ConfigValue Boolean(bool value) => new(ConfigValueKind.Boolean, null, value ? 1L : 0L, 0.0, false);
+
+    /// <summary>
+    /// Creates an integer value representable as a <see cref="long"/>.
+    /// </summary>
+    /// <param name="value">The integer to store.</param>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Integer"/>.</returns>
+    internal static ConfigValue Integer(long value) => new(ConfigValueKind.Integer, null, value, 0.0, false);
+
+    /// <summary>
+    /// Creates an integer value that cannot be represented as a <see cref="long"/> (e.g. out-of-range).
+    /// </summary>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Integer"/> and <see cref="IsUnrepresentable"/> set to <see langword="true"/>.</returns>
+    internal static ConfigValue UnrepresentableInteger() => new(ConfigValueKind.Integer, null, 0L, 0.0, true);
+
+    /// <summary>
+    /// Creates a floating-point value.
+    /// </summary>
+    /// <param name="value">The double to store.</param>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Float"/>.</returns>
+    internal static ConfigValue Float(double value) => new(ConfigValueKind.Float, null, 0L, value, false);
+
+    /// <summary>
+    /// Creates a mapping value backed by <paramref name="properties"/>.
+    /// </summary>
+    /// <param name="properties">The <see cref="ConfigProperties"/> to store.</param>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Mapping"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="properties"/> is <see langword="null"/>.</exception>
+    internal static ConfigValue Mapping(ConfigProperties properties)
+    {
+        Guard.ThrowIfNull(properties);
+        return new(ConfigValueKind.Mapping, properties, 0L, 0.0, false);
+    }
+
+    /// <summary>Creates a sequence value from <paramref name="items"/>, snapshotting the list to ensure immutability.</summary>
+    /// <param name="items">The items to snapshot and store.</param>
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Sequence"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="items"/> is <see langword="null"/>.</exception>
+    internal static ConfigValue Sequence(IReadOnlyList<ConfigValue> items)
+    {
+        Guard.ThrowIfNull(items);
+
+        // Snapshot so a caller retaining a List/array cannot mutate a ConfigProperties that R13 requires
+        // to be immutable and shareable across threads.
+        var snapshot = new ConfigValue[items.Count];
+        for (var i = 0; i < snapshot.Length; i++)
+        {
+            snapshot[i] = items[i];
+        }
+
+        return new(ConfigValueKind.Sequence, Array.AsReadOnly(snapshot), 0L, 0.0, false);
+    }
+
+    /// <summary>
+    /// Returns the value as a string. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.String"/>.
+    /// </summary>
+    /// <returns>The stored string.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.String"/>.</exception>
+    internal string AsString() => this.Kind == ConfigValueKind.String
+        ? (string)this.objectPayload!
+        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as string.");
+
+    /// <summary>
+    /// Returns the value as a boolean. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Boolean"/>.
+    /// </summary>
+    /// <returns>The stored boolean.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Boolean"/>.</exception>
+    internal bool AsBoolean() => this.Kind == ConfigValueKind.Boolean
+        ? this.numericPayload != 0
+        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as boolean.");
+
+    /// <summary>
+    /// Returns the value as a long. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Integer"/> and <see cref="IsUnrepresentable"/> is <see langword="false"/>.
+    /// </summary>
+    /// <returns>The stored integer.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Integer"/> or <see cref="IsUnrepresentable"/> is <see langword="true"/>.</exception>
+    internal long AsLong() => this.Kind == ConfigValueKind.Integer && !this.IsUnrepresentable
+        ? this.numericPayload
+        : this.Kind != ConfigValueKind.Integer
+            ? throw new InvalidOperationException($"Cannot read a {this.Kind} value as long.")
+            : throw new InvalidOperationException("Cannot read an out-of-range integer value as long.");
+
+    /// <summary>
+    /// Returns the value as a double. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Float"/>.
+    /// </summary>
+    /// <returns>The stored double.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Float"/>.</exception>
+    internal double AsDouble() => this.Kind == ConfigValueKind.Float
+        ? this.doublePayload
+        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as double.");
+
+    /// <summary>
+    /// Returns the value as a <see cref="ConfigProperties"/>. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Mapping"/>.
+    /// </summary>
+    /// <returns>The stored <see cref="ConfigProperties"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Mapping"/>.</exception>
+    internal ConfigProperties AsMapping() => this.Kind == ConfigValueKind.Mapping
+        ? (ConfigProperties)this.objectPayload!
+        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as mapping.");
+
+    /// <summary>
+    /// Returns the value as a read-only list of <see cref="ConfigValue"/>s. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Sequence"/>.
+    /// </summary>
+    /// <returns>The stored sequence.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Sequence"/>.</exception>
+    internal IReadOnlyList<ConfigValue> AsSequence() => this.Kind == ConfigValueKind.Sequence
+        ? (IReadOnlyList<ConfigValue>)this.objectPayload!
+        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as sequence.");
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValue.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValue.cs
@@ -11,20 +11,24 @@ namespace OpenTelemetry.Configuration;
 /// <remarks>
 /// Use the <c>As*</c> accessors only after confirming <see cref="Kind"/>. Calling the wrong accessor
 /// throws <see cref="InvalidOperationException"/>. Factory methods are the only way to construct an instance.
+/// This is a hand-rolled discriminated union; it is intended to migrate to a C# union type once that
+/// language feature lands.
 /// </remarks>
 internal readonly struct ConfigValue
 {
-    private readonly object? objectPayload;
-    private readonly long numericPayload;
-    private readonly double doublePayload;
+    /// <summary>
+    /// The default instance. <see cref="ConfigValueKind.Null"/> has value 0, so zero-initializing the struct produces a null value.
+    /// </summary>
+    internal static readonly ConfigValue Null;
 
-    private ConfigValue(ConfigValueKind kind, object? objectPayload, long numericPayload, double doublePayload, bool isUnrepresentable)
+    private static readonly object UnrepresentableIntegerPayload = new();
+
+    private readonly object? payload;
+
+    private ConfigValue(ConfigValueKind kind, object? payload)
     {
         this.Kind = kind;
-        this.objectPayload = objectPayload;
-        this.numericPayload = numericPayload;
-        this.doublePayload = doublePayload;
-        this.IsUnrepresentable = isUnrepresentable;
+        this.payload = payload;
     }
 
     /// <summary>
@@ -36,13 +40,9 @@ internal readonly struct ConfigValue
     /// Gets a value indicating whether an integer value could not be represented as a <see cref="long"/>.
     /// When <see langword="true"/>, <see cref="AsLong"/> must not be called.
     /// </summary>
-    internal bool IsUnrepresentable { get; }
-
-    /// <summary>
-    /// Creates a null value.
-    /// </summary>
-    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Null"/>.</returns>
-    internal static ConfigValue Null() => new(ConfigValueKind.Null, null, 0L, 0.0, false);
+    internal bool IsUnrepresentable =>
+        this.Kind == ConfigValueKind.Integer
+        && ReferenceEquals(this.payload, UnrepresentableIntegerPayload);
 
     /// <summary>
     /// Creates a string value.
@@ -53,7 +53,7 @@ internal readonly struct ConfigValue
     internal static ConfigValue String(string value)
     {
         Guard.ThrowIfNull(value);
-        return new(ConfigValueKind.String, value, 0L, 0.0, false);
+        return new(ConfigValueKind.String, value);
     }
 
     /// <summary>
@@ -61,27 +61,27 @@ internal readonly struct ConfigValue
     /// </summary>
     /// <param name="value">The boolean to store.</param>
     /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Boolean"/>.</returns>
-    internal static ConfigValue Boolean(bool value) => new(ConfigValueKind.Boolean, null, value ? 1L : 0L, 0.0, false);
+    internal static ConfigValue Boolean(bool value) => new(ConfigValueKind.Boolean, value);
 
     /// <summary>
     /// Creates an integer value representable as a <see cref="long"/>.
     /// </summary>
     /// <param name="value">The integer to store.</param>
     /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Integer"/>.</returns>
-    internal static ConfigValue Integer(long value) => new(ConfigValueKind.Integer, null, value, 0.0, false);
+    internal static ConfigValue Integer(long value) => new(ConfigValueKind.Integer, value);
 
     /// <summary>
     /// Creates an integer value that cannot be represented as a <see cref="long"/> (e.g. out-of-range).
     /// </summary>
     /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Integer"/> and <see cref="IsUnrepresentable"/> set to <see langword="true"/>.</returns>
-    internal static ConfigValue UnrepresentableInteger() => new(ConfigValueKind.Integer, null, 0L, 0.0, true);
+    internal static ConfigValue UnrepresentableInteger() => new(ConfigValueKind.Integer, UnrepresentableIntegerPayload);
 
     /// <summary>
-    /// Creates a floating-point value.
+    /// Creates a double-precision floating-point value.
     /// </summary>
     /// <param name="value">The double to store.</param>
-    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Float"/>.</returns>
-    internal static ConfigValue Float(double value) => new(ConfigValueKind.Float, null, 0L, value, false);
+    /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Double"/>.</returns>
+    internal static ConfigValue Double(double value) => new(ConfigValueKind.Double, value);
 
     /// <summary>
     /// Creates a mapping value backed by <paramref name="properties"/>.
@@ -92,10 +92,15 @@ internal readonly struct ConfigValue
     internal static ConfigValue Mapping(ConfigProperties properties)
     {
         Guard.ThrowIfNull(properties);
-        return new(ConfigValueKind.Mapping, properties, 0L, 0.0, false);
+        return new(ConfigValueKind.Mapping, properties);
     }
 
-    /// <summary>Creates a sequence value from <paramref name="items"/>, snapshotting the list to ensure immutability.</summary>
+    /// <summary>
+    /// Creates a sequence value from <paramref name="items"/>.
+    /// </summary>
+    /// <remarks>
+    /// The list is snapshotted; callers may safely mutate <paramref name="items"/> after this call.
+    /// </remarks>
     /// <param name="items">The items to snapshot and store.</param>
     /// <returns>A <see cref="ConfigValue"/> with <see cref="Kind"/> <see cref="ConfigValueKind.Sequence"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="items"/> is <see langword="null"/>.</exception>
@@ -103,15 +108,15 @@ internal readonly struct ConfigValue
     {
         Guard.ThrowIfNull(items);
 
-        // Snapshot so a caller retaining a List/array cannot mutate a ConfigProperties that R13 requires
-        // to be immutable and shareable across threads.
+        // Snapshot so a caller retaining the original list or array cannot mutate this value,
+        // which must be immutable and thread-safe once constructed.
         var snapshot = new ConfigValue[items.Count];
         for (var i = 0; i < snapshot.Length; i++)
         {
             snapshot[i] = items[i];
         }
 
-        return new(ConfigValueKind.Sequence, Array.AsReadOnly(snapshot), 0L, 0.0, false);
+        return new(ConfigValueKind.Sequence, Array.AsReadOnly(snapshot));
     }
 
     /// <summary>
@@ -119,54 +124,52 @@ internal readonly struct ConfigValue
     /// </summary>
     /// <returns>The stored string.</returns>
     /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.String"/>.</exception>
-    internal string AsString() => this.Kind == ConfigValueKind.String
-        ? (string)this.objectPayload!
-        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as string.");
+    internal string AsString() => this.GetValue<string>(ConfigValueKind.String);
 
     /// <summary>
     /// Returns the value as a boolean. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Boolean"/>.
     /// </summary>
     /// <returns>The stored boolean.</returns>
     /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Boolean"/>.</exception>
-    internal bool AsBoolean() => this.Kind == ConfigValueKind.Boolean
-        ? this.numericPayload != 0
-        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as boolean.");
+    internal bool AsBoolean() => this.GetValue<bool>(ConfigValueKind.Boolean);
 
     /// <summary>
     /// Returns the value as a long. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Integer"/> and <see cref="IsUnrepresentable"/> is <see langword="false"/>.
     /// </summary>
     /// <returns>The stored integer.</returns>
     /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Integer"/> or <see cref="IsUnrepresentable"/> is <see langword="true"/>.</exception>
-    internal long AsLong() => this.Kind == ConfigValueKind.Integer && !this.IsUnrepresentable
-        ? this.numericPayload
-        : this.Kind != ConfigValueKind.Integer
-            ? throw new InvalidOperationException($"Cannot read a {this.Kind} value as long.")
-            : throw new InvalidOperationException("Cannot read an out-of-range integer value as long.");
+    internal long AsLong()
+    {
+        if (this.IsUnrepresentable)
+        {
+            throw new InvalidOperationException("Cannot read an out-of-range integer value as long.");
+        }
+
+        return this.GetValue<long>(ConfigValueKind.Integer);
+    }
 
     /// <summary>
-    /// Returns the value as a double. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Float"/>.
+    /// Returns the value as a double. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Double"/>.
     /// </summary>
     /// <returns>The stored double.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Float"/>.</exception>
-    internal double AsDouble() => this.Kind == ConfigValueKind.Float
-        ? this.doublePayload
-        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as double.");
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Double"/>.</exception>
+    internal double AsDouble() => this.GetValue<double>(ConfigValueKind.Double);
 
     /// <summary>
     /// Returns the value as a <see cref="ConfigProperties"/>. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Mapping"/>.
     /// </summary>
     /// <returns>The stored <see cref="ConfigProperties"/>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Mapping"/>.</exception>
-    internal ConfigProperties AsMapping() => this.Kind == ConfigValueKind.Mapping
-        ? (ConfigProperties)this.objectPayload!
-        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as mapping.");
+    internal ConfigProperties AsMapping() => this.GetValue<ConfigProperties>(ConfigValueKind.Mapping);
 
     /// <summary>
     /// Returns the value as a read-only list of <see cref="ConfigValue"/>s. Only valid when <see cref="Kind"/> is <see cref="ConfigValueKind.Sequence"/>.
     /// </summary>
     /// <returns>The stored sequence.</returns>
     /// <exception cref="InvalidOperationException">Thrown when <see cref="Kind"/> is not <see cref="ConfigValueKind.Sequence"/>.</exception>
-    internal IReadOnlyList<ConfigValue> AsSequence() => this.Kind == ConfigValueKind.Sequence
-        ? (IReadOnlyList<ConfigValue>)this.objectPayload!
-        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as sequence.");
+    internal IReadOnlyList<ConfigValue> AsSequence() => this.GetValue<IReadOnlyList<ConfigValue>>(ConfigValueKind.Sequence);
+
+    private T GetValue<T>(ConfigValueKind expectedKind) => this.Kind == expectedKind && this.payload is T value
+        ? value
+        : throw new InvalidOperationException($"Cannot read a {this.Kind} value as {expectedKind}.");
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueKind.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueKind.cs
@@ -7,8 +7,8 @@ namespace OpenTelemetry.Configuration;
 /// The kinds of value a <see cref="ConfigValue"/> can hold.
 /// </summary>
 /// <remarks>
-/// The scalar members mirror the YAML 1.2 core schema tags, but are restated here rather than
-/// reused from the YAML layer so that the value model stays independent of the source format.
+/// The scalar members cover the same set of types as the YAML 1.2 core schema tags, but are restated
+/// here rather than reused from the YAML layer so that the value model stays independent of the source format.
 /// A future JSON or OpAMP source maps onto the same kinds.
 /// </remarks>
 internal enum ConfigValueKind
@@ -16,7 +16,7 @@ internal enum ConfigValueKind
     /// <summary>
     /// A null value.
     /// </summary>
-    Null,
+    Null = 0,
 
     /// <summary>
     /// A string value.
@@ -34,9 +34,12 @@ internal enum ConfigValueKind
     Integer,
 
     /// <summary>
-    /// A floating-point value.
+    /// A double-precision floating-point value. The configuration specification describes this scalar
+    /// as "double precision floating point" and leaves the naming to whatever is idiomatic for the
+    /// language, so the member is named for the stored <see cref="double"/> representation rather than
+    /// for the YAML <c>!!float</c> tag that resolves to it.
     /// </summary>
-    Float,
+    Double,
 
     /// <summary>
     /// A nested mapping, represented as a <see cref="ConfigProperties"/>.

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueKind.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueKind.cs
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// The kinds of value a <see cref="ConfigValue"/> can hold.
+/// </summary>
+/// <remarks>
+/// The scalar members mirror the YAML 1.2 core schema tags, but are restated here rather than
+/// reused from the YAML layer so that the value model stays independent of the source format.
+/// A future JSON or OpAMP source maps onto the same kinds.
+/// </remarks>
+internal enum ConfigValueKind
+{
+    /// <summary>
+    /// A null value.
+    /// </summary>
+    Null,
+
+    /// <summary>
+    /// A string value.
+    /// </summary>
+    String,
+
+    /// <summary>
+    /// A boolean value.
+    /// </summary>
+    Boolean,
+
+    /// <summary>
+    /// An integer value.
+    /// </summary>
+    Integer,
+
+    /// <summary>
+    /// A floating-point value.
+    /// </summary>
+    Float,
+
+    /// <summary>
+    /// A nested mapping, represented as a <see cref="ConfigProperties"/>.
+    /// </summary>
+    Mapping,
+
+    /// <summary>
+    /// A sequence of <see cref="ConfigValue"/> items.
+    /// </summary>
+    Sequence,
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueOutcome.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueOutcome.cs
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// The four outcomes of a typed read from a <see cref="ConfigProperties"/>.
+/// </summary>
+/// <remarks>
+/// The OpenTelemetry configuration specification requires a key that is present with a null
+/// value to be distinguishable from one that is not set, because the two select different
+/// behaviour when a component is created. A value of the wrong type is a third distinct case,
+/// which a component provider needs in order to report an error rather than silently accept a
+/// default.
+/// </remarks>
+internal enum ConfigValueOutcome
+{
+    /// <summary>
+    /// The key did not appear in the mapping.
+    /// </summary>
+    Absent,
+
+    /// <summary>
+    /// The key appeared with a null value.
+    /// </summary>
+    PresentNull,
+
+    /// <summary>
+    /// The key appeared with a value of the requested type.
+    /// </summary>
+    Present,
+
+    /// <summary>
+    /// The key appeared with a value that is not of the requested type.
+    /// </summary>
+    TypeMismatch,
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueResult.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigValueResult.cs
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// The result of a typed read from <see cref="ConfigProperties"/>, combining a <see cref="ConfigValueOutcome"/>
+/// with the typed value when the outcome is <see cref="ConfigValueOutcome.Present"/>.
+/// </summary>
+/// <typeparam name="T">The type of the value.</typeparam>
+internal readonly struct ConfigValueResult<T>
+{
+    internal ConfigValueResult(ConfigValueOutcome outcome, T? value)
+    {
+        this.Outcome = outcome;
+        this.Value = value;
+    }
+
+    /// <summary>
+    /// Gets the outcome of the read operation.
+    /// </summary>
+    public ConfigValueOutcome Outcome { get; }
+
+    /// <summary>
+    /// Gets the value when <see cref="Outcome"/> is <see cref="ConfigValueOutcome.Present"/>; otherwise the default for <typeparamref name="T"/>.
+    /// </summary>
+    public T? Value { get; }
+
+    /// <summary>
+    /// Deconstructs into <paramref name="outcome"/> and <paramref name="value"/>.
+    /// </summary>
+    /// <param name="outcome">The outcome of the read operation.</param>
+    /// <param name="value">The value, or the default for <typeparamref name="T"/> when not <see cref="ConfigValueOutcome.Present"/>.</param>
+    public void Deconstruct(out ConfigValueOutcome outcome, out T? value)
+    {
+        outcome = this.Outcome;
+        value = this.Value;
+    }
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Model/DeclarativeConfiguration.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Model/DeclarativeConfiguration.cs
@@ -19,10 +19,10 @@ internal sealed record DeclarativeConfiguration(string FileFormat)
     /// <summary>
     /// Gets the <c>disabled</c> flag.
     /// </summary>
-    public ConfigProperty<bool> Disabled { get; init; }
+    public ModelProperty<bool> Disabled { get; init; }
 
     /// <summary>
     /// Gets the <c>resource</c> section.
     /// </summary>
-    public ConfigProperty<ResourceConfiguration> Resource { get; init; }
+    public ModelProperty<ResourceConfiguration> Resource { get; init; }
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Model/ModelProperty.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Model/ModelProperty.cs
@@ -6,76 +6,76 @@ using System.Diagnostics.CodeAnalysis;
 namespace OpenTelemetry.Configuration.Declarative;
 
 /// <summary>
-/// A three-state wrapper for a declarative-configuration value: <see cref="ConfigPropertyState.Absent"/>,
-/// <see cref="ConfigPropertyState.Null"/>, or <see cref="ConfigPropertyState.Present"/>.
+/// A three-state wrapper for a declarative-configuration value: <see cref="ModelPropertyState.Absent"/>,
+/// <see cref="ModelPropertyState.Null"/>, or <see cref="ModelPropertyState.Present"/>.
 /// </summary>
 /// <remarks>
 /// Nullable value/reference types cannot express the absent-versus-present-null distinction for scalar
 /// fields (both collapse to <see langword="null"/>), so this explicit wrapper is used throughout the
 /// typed in-memory model. It is a <see langword="readonly"/> <see langword="struct"/> to avoid per-field
-/// heap allocation, and its default value is <see cref="ConfigPropertyState.Absent"/>.
+/// heap allocation, and its default value is <see cref="ModelPropertyState.Absent"/>.
 /// </remarks>
 /// <typeparam name="T">The value type.</typeparam>
-internal readonly struct ConfigProperty<T>
+internal readonly struct ModelProperty<T>
 {
     /// <summary>
-    /// A <see cref="ConfigProperty{T}"/> whose key did not appear in the document.
+    /// A <see cref="ModelProperty{T}"/> whose key did not appear in the document.
     /// </summary>
-    public static readonly ConfigProperty<T> Absent;
+    public static readonly ModelProperty<T> Absent;
 
     /// <summary>
-    /// A <see cref="ConfigProperty{T}"/> whose key appeared with a null value.
+    /// A <see cref="ModelProperty{T}"/> whose key appeared with a null value.
     /// </summary>
-    public static readonly ConfigProperty<T> Null = new(ConfigPropertyState.Null, default);
+    public static readonly ModelProperty<T> Null = new(ModelPropertyState.Null, default);
 
     private readonly T? value;
 
-    private ConfigProperty(ConfigPropertyState state, T? value)
+    private ModelProperty(ModelPropertyState state, T? value)
     {
         this.State = state;
         this.value = value;
     }
 
     /// <summary>
-    /// Gets the <see cref="ConfigPropertyState"/> of this <see cref="ConfigProperty{T}"/>.
+    /// Gets the <see cref="ModelPropertyState"/> of this <see cref="ModelProperty{T}"/>.
     /// </summary>
-    public ConfigPropertyState State { get; }
+    public ModelPropertyState State { get; }
 
     /// <summary>
     /// Gets a value indicating whether the key did not appear in the document.
     /// </summary>
-    public bool IsAbsent => this.State == ConfigPropertyState.Absent;
+    public bool IsAbsent => this.State == ModelPropertyState.Absent;
 
     /// <summary>
     /// Gets a value indicating whether the key appeared with a null value.
     /// </summary>
-    public bool IsNull => this.State == ConfigPropertyState.Null;
+    public bool IsNull => this.State == ModelPropertyState.Null;
 
     /// <summary>
     /// Gets a value indicating whether the key appeared with a value.
     /// </summary>
-    public bool IsPresent => this.State == ConfigPropertyState.Present;
+    public bool IsPresent => this.State == ModelPropertyState.Present;
 
     /// <summary>
     /// Gets the present value.
     /// </summary>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when the property is not <see cref="ConfigPropertyState.Present"/>.
+    /// Thrown when the property is not <see cref="ModelPropertyState.Present"/>.
     /// </exception>
     public T Value => this.IsPresent
         ? this.value!
-        : throw new InvalidOperationException($"ConfigProperty is {this.State} and has no value.");
+        : throw new InvalidOperationException($"ModelProperty is {this.State} and has no value.");
 
     /// <summary>
-    /// Creates a <see cref="ConfigProperty{T}"/> whose key appeared with the supplied <paramref name="value"/>.
+    /// Creates a <see cref="ModelProperty{T}"/> whose key appeared with the supplied <paramref name="value"/>.
     /// </summary>
     /// <param name="value">
-    /// The value for the <see cref="ConfigProperty{T}"/>.
+    /// The value for the <see cref="ModelProperty{T}"/>.
     /// </param>
     /// <returns>
-    /// A <see cref="ConfigProperty{T}"/> holding the supplied <paramref name="value"/>.
+    /// A <see cref="ModelProperty{T}"/> holding the supplied <paramref name="value"/>.
     /// </returns>
-    public static ConfigProperty<T> Create(T value) => new(ConfigPropertyState.Present, value);
+    public static ModelProperty<T> Create(T value) => new(ModelPropertyState.Present, value);
 
     /// <summary>
     /// Gets the present value if there is one.

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Model/ModelPropertyState.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Model/ModelPropertyState.cs
@@ -4,16 +4,16 @@
 namespace OpenTelemetry.Configuration.Declarative;
 
 /// <summary>
-/// The three states a declarative-configuration <c>ConfigProperty&lt;T&gt;</c> can hold.
+/// The three states a declarative-configuration <c>ModelProperty&lt;T&gt;</c> can hold.
 /// </summary>
 /// <remarks>
-/// The OpenTelemetry configuration specification requires differentiating a <c>ConfigProperty&lt;T&gt;</c> that is
+/// The OpenTelemetry configuration specification requires differentiating a <c>ModelProperty&lt;T&gt;</c> that is
 /// <see cref="Absent"/> (the key did not appear in the document) from one that is <see cref="Null"/>
 /// (the key appeared with a null value). Those two states drive different behaviour at Create time
 /// (the schema's <c>defaultBehavior</c> versus <c>nullBehavior</c>), so they must be tracked
 /// distinctly rather than collapsed into a single "no value" state.
 /// </remarks>
-internal enum ConfigPropertyState
+internal enum ModelPropertyState
 {
     /// <summary>
     /// The key did not appear in the document.

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Model/ResourceConfiguration.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Model/ResourceConfiguration.cs
@@ -15,10 +15,10 @@ internal sealed record ResourceConfiguration
     /// <summary>
     /// Gets the pre-encoded <c>attributes_list</c> string (OTEL_RESOURCE_ATTRIBUTES format).
     /// </summary>
-    public ConfigProperty<string> AttributesList { get; init; }
+    public ModelProperty<string> AttributesList { get; init; }
 
     /// <summary>
     /// Gets the structured <c>attributes</c> entries, in document order.
     /// </summary>
-    public ConfigProperty<IReadOnlyList<ResourceAttributeEntry>> Attributes { get; init; }
+    public ModelProperty<IReadOnlyList<ResourceAttributeEntry>> Attributes { get; init; }
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationConverter.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationConverter.cs
@@ -43,7 +43,7 @@ internal static partial class DeclarativeConfigurationConverter
     }
 
     // disabled -> OTEL_SDK_DISABLED. Present emits canonical true/false; null/absent emit nothing.
-    private static void EmitDisabled(ConfigProperty<bool> disabled, IDictionary<string, string?> data)
+    private static void EmitDisabled(ModelProperty<bool> disabled, IDictionary<string, string?> data)
     {
         if (disabled.TryGetValue(out var value))
         {
@@ -52,7 +52,7 @@ internal static partial class DeclarativeConfigurationConverter
     }
 
     // resource.attributes / resource.attributes_list -> OTEL_RESOURCE_ATTRIBUTES.
-    private static void EmitResource(ConfigProperty<ResourceConfiguration> resource, IDictionary<string, string?> data)
+    private static void EmitResource(ModelProperty<ResourceConfiguration> resource, IDictionary<string, string?> data)
     {
         if (!resource.TryGetValue(out var resourceConfig))
         {

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/DeclarativeConfigurationParser.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/DeclarativeConfigurationParser.cs
@@ -41,10 +41,10 @@ internal static class DeclarativeConfigurationParser
             Resource = ReadResource(root),
         };
 
-    private static ConfigProperty<bool> ReadDisabled(YamlMappingNode node) =>
+    private static ModelProperty<bool> ReadDisabled(YamlMappingNode node) =>
         node.ReadBoolean(YamlKeys.Disabled);
 
-    private static ConfigProperty<ResourceConfiguration> ReadResource(YamlMappingNode node) =>
+    private static ModelProperty<ResourceConfiguration> ReadResource(YamlMappingNode node) =>
         node.ReadMapping(YamlKeys.Resource, ReadResourceConfiguration);
 
     private static ResourceConfiguration ReadResourceConfiguration(YamlMappingNode node)
@@ -60,15 +60,15 @@ internal static class DeclarativeConfigurationParser
         };
     }
 
-    private static ConfigProperty<string> ReadAttributesList(YamlMappingNode node) =>
+    private static ModelProperty<string> ReadAttributesList(YamlMappingNode node) =>
         node.ReadString(YamlKeys.AttributesList);
 
-    private static ConfigProperty<IReadOnlyList<ResourceAttributeEntry>> ReadAttributes(YamlMappingNode node)
+    private static ModelProperty<IReadOnlyList<ResourceAttributeEntry>> ReadAttributes(YamlMappingNode node)
     {
         var valueNode = node.GetValueNode(YamlKeys.Attributes);
         if (valueNode is null)
         {
-            return ConfigProperty<IReadOnlyList<ResourceAttributeEntry>>.Absent;
+            return ModelProperty<IReadOnlyList<ResourceAttributeEntry>>.Absent;
         }
 
         if (valueNode is not YamlSequenceNode sequence)
@@ -112,7 +112,7 @@ internal static class DeclarativeConfigurationParser
             entries.Add(ReadAttributeValue(attributeNode, name, type));
         }
 
-        return ConfigProperty<IReadOnlyList<ResourceAttributeEntry>>.Create(entries);
+        return ModelProperty<IReadOnlyList<ResourceAttributeEntry>>.Create(entries);
     }
 
     private static ResourceAttributeType ReadAttributeType(YamlMappingNode node, string entryName)

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlPropertyReader.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlPropertyReader.cs
@@ -6,7 +6,7 @@ using YamlDotNet.RepresentationModel;
 namespace OpenTelemetry.Configuration.Declarative;
 
 /// <summary>
-/// Extension methods that read typed values from a <see cref="YamlMappingNode"/> into <see cref="ConfigProperty{T}"/> results.
+/// Extension methods that read typed values from a <see cref="YamlMappingNode"/> into <see cref="ModelProperty{T}"/> results.
 /// </summary>
 /// <remarks>
 /// All type resolution here is delegated to <see cref="Yaml12ScalarResolver"/> so that the two
@@ -15,19 +15,28 @@ namespace OpenTelemetry.Configuration.Declarative;
 /// </remarks>
 internal static class YamlPropertyReader
 {
-    internal static ConfigProperty<bool> ReadBoolean(this YamlMappingNode node, string key)
+    /// <summary>
+    /// Reads a boolean-valued property.
+    /// </summary>
+    /// <param name="node">The mapping to read from.</param>
+    /// <param name="key">The key to read.</param>
+    /// <returns>The property value.</returns>
+    /// <exception cref="DeclarativeConfigurationException">
+    /// Thrown when the value does not resolve to a boolean or null.
+    /// </exception>
+    internal static ModelProperty<bool> ReadBoolean(this YamlMappingNode node, string key)
     {
         var valueNode = node.GetValueNode(key);
         if (valueNode is null)
         {
-            return ConfigProperty<bool>.Absent;
+            return ModelProperty<bool>.Absent;
         }
 
         var scalar = RequireScalar(valueNode, key);
         var resolved = scalar.ResolveScalar();
         if (resolved.Kind == YamlScalarKind.Null)
         {
-            return ConfigProperty<bool>.Null;
+            return ModelProperty<bool>.Null;
         }
 
         if (resolved.Kind != YamlScalarKind.Boolean ||
@@ -36,7 +45,7 @@ internal static class YamlPropertyReader
             throw CreateTypeMismatch(key, "boolean or null", resolved.Kind);
         }
 
-        return ConfigProperty<bool>.Create(boolValue);
+        return ModelProperty<bool>.Create(boolValue);
     }
 
     /// <summary>
@@ -48,18 +57,18 @@ internal static class YamlPropertyReader
     /// <exception cref="DeclarativeConfigurationException">
     /// Thrown when the value does not resolve to a string or null.
     /// </exception>
-    internal static ConfigProperty<string> ReadString(this YamlMappingNode node, string key)
+    internal static ModelProperty<string> ReadString(this YamlMappingNode node, string key)
     {
         var valueNode = node.GetValueNode(key);
         if (valueNode is null)
         {
-            return ConfigProperty<string>.Absent;
+            return ModelProperty<string>.Absent;
         }
 
         var resolved = RequireScalar(valueNode, key).ResolveScalar();
         if (resolved.Kind == YamlScalarKind.Null)
         {
-            return ConfigProperty<string>.Null;
+            return ModelProperty<string>.Null;
         }
 
         if (resolved.Kind != YamlScalarKind.String)
@@ -67,23 +76,39 @@ internal static class YamlPropertyReader
             throw CreateTypeMismatch(key, "string or null", resolved.Kind);
         }
 
-        return ConfigProperty<string>.Create(resolved.Value);
+        return ModelProperty<string>.Create(resolved.Value);
     }
 
-    internal static ConfigProperty<T> ReadMapping<T>(this YamlMappingNode node, string key, Func<YamlMappingNode, T> factory)
+    /// <summary>
+    /// Reads a nested mapping property, invoking <paramref name="factory"/> to construct the typed value.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="ReadBoolean"/> and <see cref="ReadString"/>, a present null value is not
+    /// modelled as <see cref="ModelProperty{T}.Null"/> - it is rejected as a type mismatch. The
+    /// configuration schema does not define a null-mapping state, so a null value here is always an error.
+    /// </remarks>
+    /// <typeparam name="T">The typed model type produced by <paramref name="factory"/>.</typeparam>
+    /// <param name="node">The mapping to read from.</param>
+    /// <param name="key">The key to read.</param>
+    /// <param name="factory">A delegate that converts the child <see cref="YamlMappingNode"/> into a <typeparamref name="T"/>.</param>
+    /// <returns>The property value.</returns>
+    /// <exception cref="DeclarativeConfigurationException">
+    /// Thrown when the value is present but is not a non-null YAML mapping node.
+    /// </exception>
+    internal static ModelProperty<T> ReadMapping<T>(this YamlMappingNode node, string key, Func<YamlMappingNode, T> factory)
     {
         var valueNode = node.GetValueNode(key);
 
         if (valueNode is null)
         {
-            return ConfigProperty<T>.Absent;
+            return ModelProperty<T>.Absent;
         }
 
         if (valueNode is YamlMappingNode mapping)
         {
             mapping.EnsureCoreCollectionTag(key);
             mapping.EnsureUniqueStringKeys(key);
-            return ConfigProperty<T>.Create(factory(mapping));
+            return ModelProperty<T>.Create(factory(mapping));
         }
 
         throw new DeclarativeConfigurationException(

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
@@ -602,6 +602,37 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
+    public void GetScalarList_NonSequenceValue_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("x")).GetScalarList<string>("k").Outcome);
+
+    [Fact]
+    public void ScalarList_Int64Type_FloatElementsWithNoFraction_Readable()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Float(2.0), ConfigValue.Float(10.0)]);
+        var result = Build("k", seq).GetScalarList<long>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal(2L, v), v => Assert.Equal(10L, v));
+    }
+
+    [Fact]
+    public void ScalarList_DoubleType_IntegerElements_Readable()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(3L), ConfigValue.Integer(7L)]);
+        var result = Build("k", seq).GetScalarList<double>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal(3.0, v), v => Assert.Equal(7.0, v));
+    }
+
+    [Fact]
+    public void ScalarList_Int32Type_FloatElementsWithNoFraction_Readable()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Float(4.0), ConfigValue.Float(9.0)]);
+        var result = Build("k", seq).GetScalarList<int>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal(4, v), v => Assert.Equal(9, v));
+    }
+
+    [Fact]
     public void Keys_IncludesNullValuedKeys()
     {
         var properties = new ConfigPropertiesBuilder()

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
@@ -40,7 +40,7 @@ public sealed class ConfigPropertiesTests
     [Fact]
     public void GetString_PresentNull_ReturnsPresentNull()
     {
-        var properties = Build("k", ConfigValue.Null());
+        var properties = Build("k", ConfigValue.Null);
         var result = properties.GetString("k");
         Assert.Equal(ConfigValueOutcome.PresentNull, result.Outcome);
         Assert.Null(result.Value);
@@ -48,31 +48,31 @@ public sealed class ConfigPropertiesTests
 
     [Fact]
     public void GetBoolean_PresentNull_ReturnsPresentNull() =>
-        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetBoolean("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null).GetBoolean("k").Outcome);
 
     [Fact]
     public void GetLong_PresentNull_ReturnsPresentNull() =>
-        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetLong("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null).GetLong("k").Outcome);
 
     [Fact]
     public void GetDouble_PresentNull_ReturnsPresentNull() =>
-        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetDouble("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null).GetDouble("k").Outcome);
 
     [Fact]
     public void GetInt_PresentNull_ReturnsPresentNull() =>
-        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetInt("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null).GetInt("k").Outcome);
 
     [Fact]
     public void GetProperties_PresentNull_ReturnsPresentNull() =>
-        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetProperties("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null).GetProperties("k").Outcome);
 
     [Fact]
     public void GetPropertiesList_PresentNull_ReturnsPresentNull() =>
-        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetPropertiesList("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null).GetPropertiesList("k").Outcome);
 
     [Fact]
     public void GetScalarList_PresentNull_ReturnsPresentNull() =>
-        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetScalarList<string>("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null).GetScalarList<string>("k").Outcome);
 
     [Fact]
     public void GetString_Present_ReturnsPresentWithValue()
@@ -101,7 +101,7 @@ public sealed class ConfigPropertiesTests
     [Fact]
     public void GetDouble_Present_ReturnsPresentWithValue()
     {
-        var result = Build("k", ConfigValue.Float(3.14)).GetDouble("k");
+        var result = Build("k", ConfigValue.Double(3.14)).GetDouble("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Equal(3.14, result.Value);
     }
@@ -213,42 +213,42 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
-    public void Float_IntegralValue_ReadsAsInt64()
+    public void Double_IntegralValue_ReadsAsInt64()
     {
-        var properties = Build("k", ConfigValue.Float(5.0));
+        var properties = Build("k", ConfigValue.Double(5.0));
         var result = properties.GetLong("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Equal(5L, result.Value);
     }
 
     [Fact]
-    public void Float_IntegralValue_ReadsAsInt32()
+    public void Double_IntegralValue_ReadsAsInt32()
     {
-        var properties = Build("k", ConfigValue.Float(5.0));
+        var properties = Build("k", ConfigValue.Double(5.0));
         var result = properties.GetInt("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Equal(5, result.Value);
     }
 
     [Fact]
-    public void Float_FractionalValue_IsMismatchForInt64()
+    public void Double_FractionalValue_IsMismatchForInt64()
     {
-        var properties = Build("k", ConfigValue.Float(5.7));
+        var properties = Build("k", ConfigValue.Double(5.7));
         Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
     }
 
     [Fact]
-    public void Float_FractionalValue_IsMismatchForInt32()
+    public void Double_FractionalValue_IsMismatchForInt32()
     {
-        var properties = Build("k", ConfigValue.Float(5.7));
+        var properties = Build("k", ConfigValue.Double(5.7));
         Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetInt("k").Outcome);
     }
 
     [Fact]
-    public void Float_OutsideLongRange_IsMismatchForInt64()
+    public void Double_OutsideLongRange_IsMismatchForInt64()
     {
         // 2^63 is one past long.MaxValue, not representable as long.
-        var properties = Build("k", ConfigValue.Float(9.3e18));
+        var properties = Build("k", ConfigValue.Double(9.3e18));
         Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
     }
 
@@ -281,29 +281,36 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
-    public void UnrepresentableInteger_HasKindInteger()
+    public void UnrepresentableInteger_RetainsIntegerKind()
     {
-        // Confirm it's retained as Integer-kind (not dropped) even though unrepresentable.
-        var properties = Build("k", ConfigValue.UnrepresentableInteger());
-
-        // It appears in Keys, meaning the key is present; mismatch on read confirms it's not dropped.
-        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
-        Assert.Contains("k", properties.Keys);
+        var value = ConfigValue.UnrepresentableInteger();
+        Assert.Equal(ConfigValueKind.Integer, value.Kind);
+        Assert.True(value.IsUnrepresentable);
+        var ex = Assert.Throws<InvalidOperationException>(() => value.AsLong());
+        Assert.Equal("Cannot read an out-of-range integer value as long.", ex.Message);
     }
 
     [Fact]
-    public void Float_PositiveInfinity_IsReadableAsDouble()
+    public void Null_EqualsDefaultAndHasNullKind()
     {
-        var properties = Build("k", ConfigValue.Float(double.PositiveInfinity));
+        Assert.Equal(default, ConfigValue.Null);
+        Assert.Equal(ConfigValueKind.Null, ConfigValue.Null.Kind);
+        Assert.False(ConfigValue.Null.IsUnrepresentable);
+    }
+
+    [Fact]
+    public void Double_PositiveInfinity_IsReadableAsDouble()
+    {
+        var properties = Build("k", ConfigValue.Double(double.PositiveInfinity));
         var result = properties.GetDouble("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Equal(double.PositiveInfinity, result.Value);
     }
 
     [Fact]
-    public void Float_PositiveInfinity_IsMismatchForInt64()
+    public void Double_PositiveInfinity_IsMismatchForInt64()
     {
-        var properties = Build("k", ConfigValue.Float(double.PositiveInfinity));
+        var properties = Build("k", ConfigValue.Double(double.PositiveInfinity));
         Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
     }
 
@@ -317,29 +324,29 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
-    public void Float_FivePointZero_ReadsAsInt64()
+    public void Double_FivePointZero_ReadsAsInt64()
     {
-        var properties = Build("timeout", ConfigValue.Float(5.0));
+        var properties = Build("timeout", ConfigValue.Double(5.0));
         var result = properties.GetLong("timeout");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Equal(5L, result.Value);
     }
 
     [Fact]
-    public void Float_ExactLongMinValue_ReadsAsInt64()
+    public void Double_ExactLongMinValue_ReadsAsInt64()
     {
         // -2^63 is exactly representable as double; the boundary check must admit it.
-        var properties = Build("k", ConfigValue.Float(-9223372036854775808.0));
+        var properties = Build("k", ConfigValue.Double(-9223372036854775808.0));
         var result = properties.GetLong("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Equal(long.MinValue, result.Value);
     }
 
     [Fact]
-    public void Float_LongMaxValueAsDouble_IsMismatchForInt64()
+    public void Double_LongMaxValueAsDouble_IsMismatchForInt64()
     {
         // (double)long.MaxValue rounds up to 2^63, which is one past long.MaxValue and must be rejected.
-        var properties = Build("k", ConfigValue.Float((double)long.MaxValue));
+        var properties = Build("k", ConfigValue.Double((double)long.MaxValue));
         Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
     }
 
@@ -446,7 +453,7 @@ public sealed class ConfigPropertiesTests
     {
         // The spec's MUST example: drop: (present-null) must select the drop aggregation.
         // GetProperties on a null key must return PresentNull, not Absent, not a null ConfigProperties.
-        var properties = Build("drop", ConfigValue.Null());
+        var properties = Build("drop", ConfigValue.Null);
         var result = properties.GetProperties("drop");
         Assert.Equal(ConfigValueOutcome.PresentNull, result.Outcome);
         Assert.Null(result.Value);
@@ -455,7 +462,7 @@ public sealed class ConfigPropertiesTests
     [Fact]
     public void GetPropertiesList_NullValue_ReturnsPresentNull()
     {
-        var properties = Build("k", ConfigValue.Null());
+        var properties = Build("k", ConfigValue.Null);
         var result = properties.GetPropertiesList("k");
         Assert.Equal(ConfigValueOutcome.PresentNull, result.Outcome);
     }
@@ -466,7 +473,7 @@ public sealed class ConfigPropertiesTests
         // A null element is not a scalar of T, so the whole sequence mismatches - the same rule
         // GetPropertiesList applies. It holds for every element type, including the reference type:
         // present-null is an outcome for a property, not for an element within one.
-        var seq = ConfigValue.Sequence([ConfigValue.String("a"), ConfigValue.Null(), ConfigValue.String("b")]);
+        var seq = ConfigValue.Sequence([ConfigValue.String("a"), ConfigValue.Null, ConfigValue.String("b")]);
         var properties = Build("k", seq);
         var result = properties.GetScalarList<string>("k");
         Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
@@ -479,7 +486,7 @@ public sealed class ConfigPropertiesTests
     {
         // An unconstrained T? is a nullable annotation only, so before this rule the null element was
         // added as default(T) and the caller received Present with a fabricated false.
-        var seq = ConfigValue.Sequence([ConfigValue.Boolean(true), ConfigValue.Null()]);
+        var seq = ConfigValue.Sequence([ConfigValue.Boolean(true), ConfigValue.Null]);
         var result = Build("k", seq).GetScalarList<bool>("k");
         Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
         Assert.Null(result.Value);
@@ -488,7 +495,7 @@ public sealed class ConfigPropertiesTests
     [Fact]
     public void ScalarList_NullElement_IsMismatch_Int64Type()
     {
-        var seq = ConfigValue.Sequence([ConfigValue.Integer(1L), ConfigValue.Null()]);
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(1L), ConfigValue.Null]);
         var result = Build("k", seq).GetScalarList<long>("k");
         Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
         Assert.Null(result.Value);
@@ -497,7 +504,7 @@ public sealed class ConfigPropertiesTests
     [Fact]
     public void ScalarList_NullElement_IsMismatch_DoubleType()
     {
-        var seq = ConfigValue.Sequence([ConfigValue.Float(1.5), ConfigValue.Null()]);
+        var seq = ConfigValue.Sequence([ConfigValue.Double(1.5), ConfigValue.Null]);
         var result = Build("k", seq).GetScalarList<double>("k");
         Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
         Assert.Null(result.Value);
@@ -506,7 +513,7 @@ public sealed class ConfigPropertiesTests
     [Fact]
     public void ScalarList_NullElement_IsMismatch_Int32Type()
     {
-        var seq = ConfigValue.Sequence([ConfigValue.Integer(1L), ConfigValue.Null()]);
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(1L), ConfigValue.Null]);
         var result = Build("k", seq).GetScalarList<int>("k");
         Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
         Assert.Null(result.Value);
@@ -517,7 +524,7 @@ public sealed class ConfigPropertiesTests
     {
         // Java's accessor removes null and mismatched elements and reports the remainder; a sequence of
         // nothing but nulls must not read as an empty list here, which would hide the data error.
-        var seq = ConfigValue.Sequence([ConfigValue.Null(), ConfigValue.Null()]);
+        var seq = ConfigValue.Sequence([ConfigValue.Null, ConfigValue.Null]);
         Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", seq).GetScalarList<long>("k").Outcome);
     }
 
@@ -529,7 +536,7 @@ public sealed class ConfigPropertiesTests
         var seq = ConfigValue.Sequence(
         [
             ConfigValue.Mapping(Build("x", ConfigValue.String("v"))),
-            ConfigValue.Null(),
+            ConfigValue.Null,
         ]);
         var properties = Build("k", seq);
         Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetPropertiesList("k").Outcome);
@@ -546,9 +553,9 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
-    public void ScalarList_DoubleType_FloatElements_Readable()
+    public void ScalarList_DoubleType_DoubleElements_Readable()
     {
-        var seq = ConfigValue.Sequence([ConfigValue.Float(1.1), ConfigValue.Float(2.2)]);
+        var seq = ConfigValue.Sequence([ConfigValue.Double(1.1), ConfigValue.Double(2.2)]);
         var result = Build("k", seq).GetScalarList<double>("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Equal(2, result.Value!.Count);
@@ -606,9 +613,9 @@ public sealed class ConfigPropertiesTests
         Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("x")).GetScalarList<string>("k").Outcome);
 
     [Fact]
-    public void ScalarList_Int64Type_FloatElementsWithNoFraction_Readable()
+    public void ScalarList_Int64Type_DoubleElementsWithNoFraction_Readable()
     {
-        var seq = ConfigValue.Sequence([ConfigValue.Float(2.0), ConfigValue.Float(10.0)]);
+        var seq = ConfigValue.Sequence([ConfigValue.Double(2.0), ConfigValue.Double(10.0)]);
         var result = Build("k", seq).GetScalarList<long>("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Collection(result.Value!, v => Assert.Equal(2L, v), v => Assert.Equal(10L, v));
@@ -624,9 +631,9 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
-    public void ScalarList_Int32Type_FloatElementsWithNoFraction_Readable()
+    public void ScalarList_Int32Type_DoubleElementsWithNoFraction_Readable()
     {
-        var seq = ConfigValue.Sequence([ConfigValue.Float(4.0), ConfigValue.Float(9.0)]);
+        var seq = ConfigValue.Sequence([ConfigValue.Double(4.0), ConfigValue.Double(9.0)]);
         var result = Build("k", seq).GetScalarList<int>("k");
         Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
         Assert.Collection(result.Value!, v => Assert.Equal(4, v), v => Assert.Equal(9, v));
@@ -637,7 +644,7 @@ public sealed class ConfigPropertiesTests
     {
         var properties = new ConfigPropertiesBuilder()
             .Add("present", ConfigValue.String("v"))
-            .Add("nulled", ConfigValue.Null())
+            .Add("nulled", ConfigValue.Null)
             .Build();
         var keys = properties.Keys.ToList();
         Assert.Contains("present", keys);

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
@@ -1,0 +1,850 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+public sealed class ConfigPropertiesTests
+{
+    [Fact]
+    public void GetString_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetString("x").Outcome);
+
+    [Fact]
+    public void GetBoolean_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetBoolean("x").Outcome);
+
+    [Fact]
+    public void GetLong_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetLong("x").Outcome);
+
+    [Fact]
+    public void GetDouble_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetDouble("x").Outcome);
+
+    [Fact]
+    public void GetInt_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetInt("x").Outcome);
+
+    [Fact]
+    public void GetProperties_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetProperties("x").Outcome);
+
+    [Fact]
+    public void GetPropertiesList_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetPropertiesList("x").Outcome);
+
+    [Fact]
+    public void GetScalarList_Absent_ReturnsAbsent() =>
+        Assert.Equal(ConfigValueOutcome.Absent, EmptyProperties().GetScalarList<string>("x").Outcome);
+
+    [Fact]
+    public void GetString_PresentNull_ReturnsPresentNull()
+    {
+        var properties = Build("k", ConfigValue.Null());
+        var result = properties.GetString("k");
+        Assert.Equal(ConfigValueOutcome.PresentNull, result.Outcome);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void GetBoolean_PresentNull_ReturnsPresentNull() =>
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetBoolean("k").Outcome);
+
+    [Fact]
+    public void GetLong_PresentNull_ReturnsPresentNull() =>
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetLong("k").Outcome);
+
+    [Fact]
+    public void GetDouble_PresentNull_ReturnsPresentNull() =>
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetDouble("k").Outcome);
+
+    [Fact]
+    public void GetInt_PresentNull_ReturnsPresentNull() =>
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetInt("k").Outcome);
+
+    [Fact]
+    public void GetProperties_PresentNull_ReturnsPresentNull() =>
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetProperties("k").Outcome);
+
+    [Fact]
+    public void GetPropertiesList_PresentNull_ReturnsPresentNull() =>
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetPropertiesList("k").Outcome);
+
+    [Fact]
+    public void GetScalarList_PresentNull_ReturnsPresentNull() =>
+        Assert.Equal(ConfigValueOutcome.PresentNull, Build("k", ConfigValue.Null()).GetScalarList<string>("k").Outcome);
+
+    [Fact]
+    public void GetString_Present_ReturnsPresentWithValue()
+    {
+        var result = Build("k", ConfigValue.String("hello")).GetString("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal("hello", result.Value);
+    }
+
+    [Fact]
+    public void GetBoolean_Present_ReturnsPresentWithValue()
+    {
+        var result = Build("k", ConfigValue.Boolean(true)).GetBoolean("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.True(result.Value);
+    }
+
+    [Fact]
+    public void GetLong_Present_ReturnsPresentWithValue()
+    {
+        var result = Build("k", ConfigValue.Integer(42L)).GetLong("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(42L, result.Value);
+    }
+
+    [Fact]
+    public void GetDouble_Present_ReturnsPresentWithValue()
+    {
+        var result = Build("k", ConfigValue.Float(3.14)).GetDouble("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(3.14, result.Value);
+    }
+
+    [Fact]
+    public void GetInt_Present_ReturnsPresentWithValue()
+    {
+        var result = Build("k", ConfigValue.Integer(7L)).GetInt("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(7, result.Value);
+    }
+
+    [Fact]
+    public void GetProperties_Present_ReturnsPresentWithValue()
+    {
+        var nested = Build("inner", ConfigValue.String("v"));
+        var result = Build("k", ConfigValue.Mapping(nested)).GetProperties("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.NotNull(result.Value);
+    }
+
+    [Fact]
+    public void GetPropertiesList_Present_ReturnsPresentWithList()
+    {
+        var nested = Build("x", ConfigValue.String("a"));
+        var seq = ConfigValue.Sequence([ConfigValue.Mapping(nested)]);
+        var result = Build("k", seq).GetPropertiesList("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Single(result.Value!);
+    }
+
+    [Fact]
+    public void GetScalarList_Present_ReturnsPresentWithList()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.String("a"), ConfigValue.String("b")]);
+        var result = Build("k", seq).GetScalarList<string>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal("a", v), v => Assert.Equal("b", v));
+    }
+
+    [Fact]
+    public void GetString_WrongKind_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.Boolean(true)).GetString("k").Outcome);
+
+    [Fact]
+    public void GetBoolean_WrongKind_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("hello")).GetBoolean("k").Outcome);
+
+    [Fact]
+    public void GetLong_WrongKind_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("42")).GetLong("k").Outcome);
+
+    [Fact]
+    public void GetDouble_WrongKind_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("3.14")).GetDouble("k").Outcome);
+
+    [Fact]
+    public void GetInt_WrongKind_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("7")).GetInt("k").Outcome);
+
+    [Fact]
+    public void GetProperties_WrongKind_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("x")).GetProperties("k").Outcome);
+
+    [Fact]
+    public void GetPropertiesList_WrongKind_ReturnsTypeMismatch() =>
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", ConfigValue.String("x")).GetPropertiesList("k").Outcome);
+
+    [Fact]
+    public void GetScalarList_WrongKind_ReturnsTypeMismatch()
+    {
+        var nested = Build("x", ConfigValue.String("v"));
+        var seq = ConfigValue.Sequence([ConfigValue.Mapping(nested)]);
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", seq).GetScalarList<string>("k").Outcome);
+    }
+
+    [Fact]
+    public void StringKind_TrueText_IsNotBool()
+    {
+        // "true" as a String-kind value must NOT be readable as bool (quoting forces string).
+        var properties = Build("k", ConfigValue.String("true"));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetBoolean("k").Outcome);
+    }
+
+    [Fact]
+    public void BooleanKind_IsNotString()
+    {
+        var properties = Build("k", ConfigValue.Boolean(true));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetString("k").Outcome);
+    }
+
+    [Fact]
+    public void IntegerOutsideIntRange_IsMismatchForGetInt32()
+    {
+        // long.MaxValue > int.MaxValue - mismatch for GetInt32, value for GetInt64
+        var properties = Build("k", ConfigValue.Integer(long.MaxValue));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetInt("k").Outcome);
+        Assert.Equal(ConfigValueOutcome.Present, properties.GetLong("k").Outcome);
+        Assert.Equal(long.MaxValue, properties.GetLong("k").Value);
+    }
+
+    [Fact]
+    public void Integer_ReadsAsDouble()
+    {
+        var properties = Build("k", ConfigValue.Integer(5L));
+        var result = properties.GetDouble("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(5.0, result.Value);
+    }
+
+    [Fact]
+    public void Float_IntegralValue_ReadsAsInt64()
+    {
+        var properties = Build("k", ConfigValue.Float(5.0));
+        var result = properties.GetLong("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(5L, result.Value);
+    }
+
+    [Fact]
+    public void Float_IntegralValue_ReadsAsInt32()
+    {
+        var properties = Build("k", ConfigValue.Float(5.0));
+        var result = properties.GetInt("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(5, result.Value);
+    }
+
+    [Fact]
+    public void Float_FractionalValue_IsMismatchForInt64()
+    {
+        var properties = Build("k", ConfigValue.Float(5.7));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
+    }
+
+    [Fact]
+    public void Float_FractionalValue_IsMismatchForInt32()
+    {
+        var properties = Build("k", ConfigValue.Float(5.7));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetInt("k").Outcome);
+    }
+
+    [Fact]
+    public void Float_OutsideLongRange_IsMismatchForInt64()
+    {
+        // 2^63 is one past long.MaxValue, not representable as long.
+        var properties = Build("k", ConfigValue.Float(9.3e18));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
+    }
+
+    [Fact]
+    public void UnrepresentableInteger_IsMismatchForInt64()
+    {
+        var properties = Build("k", ConfigValue.UnrepresentableInteger());
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
+    }
+
+    [Fact]
+    public void UnrepresentableInteger_IsMismatchForDouble()
+    {
+        var properties = Build("k", ConfigValue.UnrepresentableInteger());
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetDouble("k").Outcome);
+    }
+
+    [Fact]
+    public void UnrepresentableInteger_IsMismatchForInt32()
+    {
+        var properties = Build("k", ConfigValue.UnrepresentableInteger());
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetInt("k").Outcome);
+    }
+
+    [Fact]
+    public void UnrepresentableInteger_StillAppearsInKeys()
+    {
+        var properties = Build("k", ConfigValue.UnrepresentableInteger());
+        Assert.Contains("k", properties.Keys);
+    }
+
+    [Fact]
+    public void UnrepresentableInteger_HasKindInteger()
+    {
+        // Confirm it's retained as Integer-kind (not dropped) even though unrepresentable.
+        var properties = Build("k", ConfigValue.UnrepresentableInteger());
+
+        // It appears in Keys, meaning the key is present; mismatch on read confirms it's not dropped.
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
+        Assert.Contains("k", properties.Keys);
+    }
+
+    [Fact]
+    public void Float_PositiveInfinity_IsReadableAsDouble()
+    {
+        var properties = Build("k", ConfigValue.Float(double.PositiveInfinity));
+        var result = properties.GetDouble("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(double.PositiveInfinity, result.Value);
+    }
+
+    [Fact]
+    public void Float_PositiveInfinity_IsMismatchForInt64()
+    {
+        var properties = Build("k", ConfigValue.Float(double.PositiveInfinity));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
+    }
+
+    [Fact]
+    public void Integer_One_ReadsAsDouble()
+    {
+        var properties = Build("ratio", ConfigValue.Integer(1L));
+        var result = properties.GetDouble("ratio");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(1.0, result.Value);
+    }
+
+    [Fact]
+    public void Float_FivePointZero_ReadsAsInt64()
+    {
+        var properties = Build("timeout", ConfigValue.Float(5.0));
+        var result = properties.GetLong("timeout");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(5L, result.Value);
+    }
+
+    [Fact]
+    public void Float_ExactLongMinValue_ReadsAsInt64()
+    {
+        // -2^63 is exactly representable as double; the boundary check must admit it.
+        var properties = Build("k", ConfigValue.Float(-9223372036854775808.0));
+        var result = properties.GetLong("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(long.MinValue, result.Value);
+    }
+
+    [Fact]
+    public void Float_LongMaxValueAsDouble_IsMismatchForInt64()
+    {
+        // (double)long.MaxValue rounds up to 2^63, which is one past long.MaxValue and must be rejected.
+        var properties = Build("k", ConfigValue.Float((double)long.MaxValue));
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetLong("k").Outcome);
+    }
+
+    [Fact]
+    public void NestedProperties_ThreeLevels_AreReadable()
+    {
+        var level3 = Build("leaf", ConfigValue.String("deep"));
+        var level2 = Build("l3", ConfigValue.Mapping(level3));
+        var level1 = Build("l2", ConfigValue.Mapping(level2));
+
+        var r2 = level1.GetProperties("l2");
+        Assert.Equal(ConfigValueOutcome.Present, r2.Outcome);
+
+        var r3 = r2.Value!.GetProperties("l3");
+        Assert.Equal(ConfigValueOutcome.Present, r3.Outcome);
+
+        var leaf = r3.Value!.GetString("leaf");
+        Assert.Equal(ConfigValueOutcome.Present, leaf.Outcome);
+        Assert.Equal("deep", leaf.Value);
+    }
+
+    [Fact]
+    public void SequenceOfMappings_ReturnsAllMappings()
+    {
+        var m1 = Build("a", ConfigValue.String("1"));
+        var m2 = Build("a", ConfigValue.String("2"));
+        var seq = ConfigValue.Sequence([ConfigValue.Mapping(m1), ConfigValue.Mapping(m2)]);
+        var properties = Build("items", seq);
+
+        var result = properties.GetPropertiesList("items");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(2, result.Value!.Count);
+        Assert.Equal("1", result.Value[0].GetString("a").Value);
+        Assert.Equal("2", result.Value[1].GetString("a").Value);
+    }
+
+    [Fact]
+    public void SequenceOfScalars_ReturnsAllValues()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.String("x"), ConfigValue.String("y")]);
+        var result = Build("k", seq).GetScalarList<string>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal("x", v), v => Assert.Equal("y", v));
+    }
+
+    [Fact]
+    public void EmptySequence_ReturnsEmptyList_PropertiesList()
+    {
+        var seq = ConfigValue.Sequence(Array.Empty<ConfigValue>());
+        var result = Build("k", seq).GetPropertiesList("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Empty(result.Value!);
+    }
+
+    [Fact]
+    public void EmptySequence_ReturnsEmptyList_ScalarList()
+    {
+        var seq = ConfigValue.Sequence(Array.Empty<ConfigValue>());
+        var result = Build("k", seq).GetScalarList<string>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Empty(result.Value!);
+    }
+
+    [Fact]
+    public void EmptyMapping_ReturnsEmptyProperties()
+    {
+        var nested = new ConfigPropertiesBuilder().Build();
+        var properties = Build("k", ConfigValue.Mapping(nested));
+        var result = properties.GetProperties("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Empty(result.Value!.Keys);
+    }
+
+    [Fact]
+    public void MixedSequence_IsMismatchForPropertiesList()
+    {
+        // Sequence contains a scalar and a mapping - not a valid mapping sequence.
+        var seq = ConfigValue.Sequence(
+        [
+            ConfigValue.Mapping(Build("x", ConfigValue.String("v"))),
+            ConfigValue.String("not-a-mapping"),
+        ]);
+        var properties = Build("k", seq);
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetPropertiesList("k").Outcome);
+        Assert.Contains("k", properties.Keys); // key is retained despite mismatch
+    }
+
+    [Fact]
+    public void MixedSequence_IsMismatchForScalarList()
+    {
+        // Sequence contains a string and a mapping - not a valid scalar sequence.
+        var seq = ConfigValue.Sequence(
+        [
+            ConfigValue.String("ok"),
+            ConfigValue.Mapping(Build("x", ConfigValue.String("v"))),
+        ]);
+        var properties = Build("k", seq);
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetScalarList<string>("k").Outcome);
+        Assert.Contains("k", properties.Keys); // key is retained despite mismatch
+    }
+
+    [Fact]
+    public void GetProperties_NullValue_ReturnsPresentNull_AggregationDropCase()
+    {
+        // The spec's MUST example: drop: (present-null) must select the drop aggregation.
+        // GetProperties on a null key must return PresentNull, not Absent, not a null ConfigProperties.
+        var properties = Build("drop", ConfigValue.Null());
+        var result = properties.GetProperties("drop");
+        Assert.Equal(ConfigValueOutcome.PresentNull, result.Outcome);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void GetPropertiesList_NullValue_ReturnsPresentNull()
+    {
+        var properties = Build("k", ConfigValue.Null());
+        var result = properties.GetPropertiesList("k");
+        Assert.Equal(ConfigValueOutcome.PresentNull, result.Outcome);
+    }
+
+    [Fact]
+    public void ScalarList_NullElement_IsMismatch_StringType()
+    {
+        // A null element is not a scalar of T, so the whole sequence mismatches - the same rule
+        // GetPropertiesList applies. It holds for every element type, including the reference type:
+        // present-null is an outcome for a property, not for an element within one.
+        var seq = ConfigValue.Sequence([ConfigValue.String("a"), ConfigValue.Null(), ConfigValue.String("b")]);
+        var properties = Build("k", seq);
+        var result = properties.GetScalarList<string>("k");
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
+        Assert.Null(result.Value);
+        Assert.Contains("k", properties.Keys); // key is retained despite mismatch
+    }
+
+    [Fact]
+    public void ScalarList_NullElement_IsMismatch_BoolType()
+    {
+        // An unconstrained T? is a nullable annotation only, so before this rule the null element was
+        // added as default(T) and the caller received Present with a fabricated false.
+        var seq = ConfigValue.Sequence([ConfigValue.Boolean(true), ConfigValue.Null()]);
+        var result = Build("k", seq).GetScalarList<bool>("k");
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void ScalarList_NullElement_IsMismatch_Int64Type()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(1L), ConfigValue.Null()]);
+        var result = Build("k", seq).GetScalarList<long>("k");
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void ScalarList_NullElement_IsMismatch_DoubleType()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Float(1.5), ConfigValue.Null()]);
+        var result = Build("k", seq).GetScalarList<double>("k");
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void ScalarList_NullElement_IsMismatch_Int32Type()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(1L), ConfigValue.Null()]);
+        var result = Build("k", seq).GetScalarList<int>("k");
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, result.Outcome);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public void ScalarList_AllNullElements_IsMismatch_NotAnEmptyOrDefaultedList()
+    {
+        // Java's accessor removes null and mismatched elements and reports the remainder; a sequence of
+        // nothing but nulls must not read as an empty list here, which would hide the data error.
+        var seq = ConfigValue.Sequence([ConfigValue.Null(), ConfigValue.Null()]);
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, Build("k", seq).GetScalarList<long>("k").Outcome);
+    }
+
+    [Fact]
+    public void PropertiesList_NullElement_IsMismatch()
+    {
+        // IReadOnlyList<ConfigProperties> has no slot for null; the whole sequence mismatches.
+        // GetScalarList applies the same rule to its elements.
+        var seq = ConfigValue.Sequence(
+        [
+            ConfigValue.Mapping(Build("x", ConfigValue.String("v"))),
+            ConfigValue.Null(),
+        ]);
+        var properties = Build("k", seq);
+        Assert.Equal(ConfigValueOutcome.TypeMismatch, properties.GetPropertiesList("k").Outcome);
+        Assert.Contains("k", properties.Keys); // key is retained despite mismatch
+    }
+
+    [Fact]
+    public void ScalarList_Int64Type_IntegerElements_Readable()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(1L), ConfigValue.Integer(2L)]);
+        var result = Build("k", seq).GetScalarList<long>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal(1L, v), v => Assert.Equal(2L, v));
+    }
+
+    [Fact]
+    public void ScalarList_DoubleType_FloatElements_Readable()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Float(1.1), ConfigValue.Float(2.2)]);
+        var result = Build("k", seq).GetScalarList<double>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(2, result.Value!.Count);
+    }
+
+    [Fact]
+    public void ScalarList_BoolType_BooleanElements_Readable()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Boolean(true), ConfigValue.Boolean(false)]);
+        var result = Build("k", seq).GetScalarList<bool>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.True(v), v => Assert.False(v));
+    }
+
+    [Fact]
+    public void ScalarList_Int32Type_IntegerElements_InRange_Readable()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(10L), ConfigValue.Integer(20L)]);
+        var result = Build("k", seq).GetScalarList<int>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal(10, v), v => Assert.Equal(20, v));
+    }
+
+    [Fact]
+    public void ScalarList_Present_ElementTypeIsNotNullable()
+    {
+        // The signature is IReadOnlyList<T>, not IReadOnlyList<T?>. With the null-element rule in place
+        // the annotation is accurate for a value element type as well as a reference one, which it was
+        // not while an unconstrained T? claimed to carry per-element nulls.
+        IReadOnlyList<long> longs = Build("k", ConfigValue.Sequence([ConfigValue.Integer(1L)])).GetScalarList<long>("k").Value!;
+        IReadOnlyList<string> strings = Build("k", ConfigValue.Sequence([ConfigValue.String("a")])).GetScalarList<string>("k").Value!;
+        Assert.Equal(1L, longs[0]);
+        Assert.Equal("a", strings[0]);
+    }
+
+    [Fact]
+    public void GetScalarList_UnsupportedType_Throws()
+    {
+        // An unsupported T is a programming error and must throw, not return TypeMismatch.
+        var seq = ConfigValue.Sequence([ConfigValue.String("2026-01-01")]);
+        Assert.Throws<NotSupportedException>(() => Build("k", seq).GetScalarList<DateTime>("k"));
+    }
+
+    [Fact]
+    public void GetScalarList_UnsupportedType_EmptySequence_AlsoThrows()
+    {
+        // Without a guard, an empty sequence would return Present for any T because TryExtractScalar is
+        // never called. The check must fire before the loop, not inside it.
+        var seq = ConfigValue.Sequence(Array.Empty<ConfigValue>());
+        Assert.Throws<NotSupportedException>(() => Build("k", seq).GetScalarList<DateTime>("k"));
+    }
+
+    [Fact]
+    public void Keys_IncludesNullValuedKeys()
+    {
+        var properties = new ConfigPropertiesBuilder()
+            .Add("present", ConfigValue.String("v"))
+            .Add("nulled", ConfigValue.Null())
+            .Build();
+        var keys = properties.Keys.ToList();
+        Assert.Contains("present", keys);
+        Assert.Contains("nulled", keys);
+    }
+
+    [Fact]
+    public void Keys_ExcludesAbsentKeys()
+    {
+        var properties = Build("present", ConfigValue.String("v"));
+        Assert.DoesNotContain("absent", properties.Keys);
+    }
+
+    [Fact]
+    public void Keys_OrdinalComparison_CaseSensitive()
+    {
+        var properties = new ConfigPropertiesBuilder()
+            .Add("Key", ConfigValue.String("upper"))
+            .Add("key", ConfigValue.String("lower"))
+            .Build();
+        var keys = properties.Keys.ToList();
+        Assert.Contains("Key", keys);
+        Assert.Contains("key", keys);
+        Assert.Equal(2, keys.Count);
+
+        // Ordinal: "Key" and "key" are distinct
+        Assert.Equal("upper", properties.GetString("Key").Value);
+        Assert.Equal("lower", properties.GetString("key").Value);
+    }
+
+    [Fact]
+    public void Keys_RejectsMutation()
+    {
+        var properties = Build("k", ConfigValue.String("v"));
+        var keys = properties.Keys;
+        Assert.Throws<NotSupportedException>(() => ((ICollection<string>)keys).Add("injected"));
+    }
+
+    [Fact]
+    public void Builder_Add_DuplicateKey_Throws()
+    {
+        var builder = new ConfigPropertiesBuilder().Add("k", ConfigValue.String("v1"));
+        Assert.Throws<ArgumentException>(() => builder.Add("k", ConfigValue.String("v2")));
+    }
+
+    [Fact]
+    public void Builder_Add_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ConfigPropertiesBuilder().Add(null!, ConfigValue.String("v")));
+    }
+
+    [Fact]
+    public void BuilderMutatedAfterBuild_DoesNotAffectBuiltProperties()
+    {
+        var builder = new ConfigPropertiesBuilder()
+            .Add("k", ConfigValue.String("original"));
+
+        var properties = builder.Build();
+
+        // Mutation after build must not affect already-built ConfigProperties.
+        // (A second Add on the same key would throw; use a fresh builder call via a new key.)
+        builder.Add("new", ConfigValue.String("added"));
+
+        Assert.Equal("original", properties.GetString("k").Value);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetString("new").Outcome);
+    }
+
+    [Fact]
+    public void BuildCanBeCalledMultipleTimes_EachInstanceIsIndependent()
+    {
+        var builder = new ConfigPropertiesBuilder()
+            .Add("k", ConfigValue.String("v1"));
+
+        var properties1 = builder.Build();
+        var properties2 = builder.Build();
+
+        Assert.Equal("v1", properties1.GetString("k").Value);
+        Assert.Equal("v1", properties2.GetString("k").Value);
+        Assert.NotSame(properties1, properties2);
+    }
+
+    [Fact]
+    public void ConfigValue_String_NullArgument_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ConfigValue.String(null!));
+
+    [Fact]
+    public void ConfigValue_Mapping_NullArgument_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ConfigValue.Mapping(null!));
+
+    [Fact]
+    public void ConfigValue_Sequence_NullArgument_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ConfigValue.Sequence(null!));
+
+    [Fact]
+    public void SequenceListMutatedAfterAdd_DoesNotAffectBuiltProperties()
+    {
+        var items = new List<ConfigValue> { ConfigValue.String("a") };
+        var properties = new ConfigPropertiesBuilder()
+            .Add("k", ConfigValue.Sequence(items))
+            .Build();
+
+        items.Add(ConfigValue.String("b"));
+        items[0] = ConfigValue.String("mutated");
+
+        var result = properties.GetScalarList<string>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal("a", v));
+    }
+
+    [Fact]
+    public void SequenceArrayMutatedAfterConstruction_DoesNotAffectBuiltProperties()
+    {
+        var items = new[] { ConfigValue.String("a"), ConfigValue.String("b") };
+        var properties = Build("k", ConfigValue.Sequence(items));
+
+        items[0] = ConfigValue.String("mutated");
+        items[1] = ConfigValue.String("also-mutated");
+
+        var result = properties.GetScalarList<string>("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Collection(result.Value!, v => Assert.Equal("a", v), v => Assert.Equal("b", v));
+    }
+
+    [Fact]
+    public void SequenceOfMappings_SourceListMutatedAfterAdd_DoesNotAffectBuiltProperties()
+    {
+        var m1 = Build("a", ConfigValue.String("1"));
+        var m2 = Build("a", ConfigValue.String("2"));
+        var items = new List<ConfigValue> { ConfigValue.Mapping(m1), ConfigValue.Mapping(m2) };
+        var properties = Build("items", ConfigValue.Sequence(items));
+
+        items.Clear();
+        items.Add(ConfigValue.Mapping(Build("a", ConfigValue.String("replaced"))));
+
+        var result = properties.GetPropertiesList("items");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(2, result.Value!.Count);
+        Assert.Equal("1", result.Value[0].GetString("a").Value);
+        Assert.Equal("2", result.Value[1].GetString("a").Value);
+    }
+
+    [Fact]
+    public void Sequence_AsSequence_RejectsMutation()
+    {
+        var seq = ConfigValue.Sequence(new List<ConfigValue> { ConfigValue.String("a") });
+        var list = seq.AsSequence();
+
+        Assert.Throws<NotSupportedException>(() => ((IList<ConfigValue>)list).Add(ConfigValue.String("b")));
+        Assert.Throws<NotSupportedException>(() => ((IList<ConfigValue>)list)[0] = ConfigValue.String("mutated"));
+        Assert.Equal("a", list[0].AsString());
+    }
+
+    [Fact]
+    public void PropertiesList_ReturnedList_RejectsMutation()
+    {
+        var nested = Build("x", ConfigValue.String("v"));
+        var properties = Build("k", ConfigValue.Sequence([ConfigValue.Mapping(nested)]));
+        var list = properties.GetPropertiesList("k").Value!;
+
+        Assert.Throws<NotSupportedException>(() => ((IList<ConfigProperties>)list).Clear());
+        Assert.Single(list);
+    }
+
+    [Fact]
+    public void ScalarList_ReturnedList_RejectsMutation()
+    {
+        var properties = Build("k", ConfigValue.Sequence([ConfigValue.String("a")]));
+        var list = properties.GetScalarList<string>("k").Value!;
+
+        Assert.Throws<NotSupportedException>(() => ((IList<string>)list).Add("b"));
+        Assert.Collection(list, v => Assert.Equal("a", v));
+    }
+
+    [Fact]
+    public void Create_CopiesSourceDictionary()
+    {
+        var source = new Dictionary<string, ConfigValue>(StringComparer.Ordinal)
+        {
+            ["k"] = ConfigValue.String("original"),
+        };
+
+        var properties = ConfigProperties.Create(source);
+        source["k"] = ConfigValue.String("mutated");
+        source["added"] = ConfigValue.String("new");
+
+        Assert.Equal("original", properties.GetString("k").Value);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetString("added").Outcome);
+    }
+
+    [Fact]
+    public void Empty_AllKeysAbsent()
+    {
+        var properties = ConfigProperties.Empty;
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetString("x").Outcome);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetBoolean("x").Outcome);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetLong("x").Outcome);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetDouble("x").Outcome);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetInt("x").Outcome);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetProperties("x").Outcome);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetPropertiesList("x").Outcome);
+        Assert.Equal(ConfigValueOutcome.Absent, properties.GetScalarList<string>("x").Outcome);
+    }
+
+    [Fact]
+    public void Empty_Keys_ReturnsEmpty() =>
+        Assert.Empty(ConfigProperties.Empty.Keys);
+
+    [Fact]
+    public void Empty_IsSafeToPassAsNestedMapping()
+    {
+        var properties = Build("k", ConfigValue.Mapping(ConfigProperties.Empty));
+        var result = properties.GetProperties("k");
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Empty(result.Value!.Keys);
+    }
+
+    [Fact]
+    public void Empty_IsSameInstance() => Assert.Same(ConfigProperties.Empty, ConfigProperties.Empty);
+
+    [Fact]
+    public void ConfigValueResult_Deconstruct_Works()
+    {
+        var properties = Build("k", ConfigValue.String("hello"));
+        var (outcome, value) = properties.GetString("k");
+        Assert.Equal(ConfigValueOutcome.Present, outcome);
+        Assert.Equal("hello", value);
+    }
+
+    [Fact]
+    public void ConfigValueResult_Deconstruct_Absent_Works()
+    {
+        var (outcome, value) = EmptyProperties().GetString("missing");
+        Assert.Equal(ConfigValueOutcome.Absent, outcome);
+        Assert.Null(value);
+    }
+
+    private static ConfigProperties EmptyProperties() => ConfigProperties.Empty;
+
+    private static ConfigProperties Build(string key, ConfigValue value)
+        => new ConfigPropertiesBuilder().Add(key, value).Build();
+}

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/ModelPropertyTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/ModelPropertyTests.cs
@@ -3,50 +3,50 @@
 
 namespace OpenTelemetry.Configuration.Declarative.Tests;
 
-public sealed class ConfigPropertyTests
+public sealed class ModelPropertyTests
 {
     [Fact]
     public void IsAbsent_WhenAbsent_ReturnsTrue() =>
-        Assert.True(ConfigProperty<string>.Absent.IsAbsent);
+        Assert.True(ModelProperty<string>.Absent.IsAbsent);
 
     [Fact]
     public void IsAbsent_WhenNull_ReturnsFalse() =>
-        Assert.False(ConfigProperty<string>.Null.IsAbsent);
+        Assert.False(ModelProperty<string>.Null.IsAbsent);
 
     [Fact]
     public void IsAbsent_WhenPresent_ReturnsFalse() =>
-        Assert.False(ConfigProperty<string>.Create("x").IsAbsent);
+        Assert.False(ModelProperty<string>.Create("x").IsAbsent);
 
     [Fact]
     public void IsNull_WhenNull_ReturnsTrue() =>
-        Assert.True(ConfigProperty<string>.Null.IsNull);
+        Assert.True(ModelProperty<string>.Null.IsNull);
 
     [Fact]
     public void IsNull_WhenAbsent_ReturnsFalse() =>
-        Assert.False(ConfigProperty<string>.Absent.IsNull);
+        Assert.False(ModelProperty<string>.Absent.IsNull);
 
     [Fact]
     public void IsNull_WhenPresent_ReturnsFalse() =>
-        Assert.False(ConfigProperty<string>.Create("x").IsNull);
+        Assert.False(ModelProperty<string>.Create("x").IsNull);
 
     [Fact]
     public void Value_WhenPresent_ReturnsValue() =>
-        Assert.Equal("hello", ConfigProperty<string>.Create("hello").Value);
+        Assert.Equal("hello", ModelProperty<string>.Create("hello").Value);
 
     [Fact]
     public void Value_WhenAbsent_ThrowsInvalidOperationException() =>
-        Assert.Throws<InvalidOperationException>(() => ConfigProperty<string>.Absent.Value);
+        Assert.Throws<InvalidOperationException>(() => ModelProperty<string>.Absent.Value);
 
     [Fact]
     public void Value_WhenNull_ThrowsInvalidOperationException() =>
-        Assert.Throws<InvalidOperationException>(() => ConfigProperty<string>.Null.Value);
+        Assert.Throws<InvalidOperationException>(() => ModelProperty<string>.Null.Value);
 
     [Fact]
     public void TryGetValue_WhenPresent_ReturnsTrueAndValue()
     {
-        var result = ConfigProperty<string>.Create("hello");
+        var result = ModelProperty<string>.Create("hello");
 
-        Assert.Equal(ConfigPropertyState.Present, result.State);
+        Assert.Equal(ModelPropertyState.Present, result.State);
         Assert.True(result.TryGetValue(out var value));
         Assert.Equal("hello", value);
     }
@@ -54,9 +54,9 @@ public sealed class ConfigPropertyTests
     [Fact]
     public void TryGetValue_WhenAbsent_ReturnsFalse()
     {
-        var result = ConfigProperty<string>.Absent;
+        var result = ModelProperty<string>.Absent;
 
-        Assert.Equal(ConfigPropertyState.Absent, result.State);
+        Assert.Equal(ModelPropertyState.Absent, result.State);
         Assert.False(result.TryGetValue(out var value));
         Assert.Null(value);
     }
@@ -64,9 +64,9 @@ public sealed class ConfigPropertyTests
     [Fact]
     public void TryGetValue_WhenNull_ReturnsFalse()
     {
-        var result = ConfigProperty<string>.Null;
+        var result = ModelProperty<string>.Null;
 
-        Assert.Equal(ConfigPropertyState.Null, result.State);
+        Assert.Equal(ModelPropertyState.Null, result.State);
         Assert.False(result.TryGetValue(out var value));
         Assert.Null(value);
     }


### PR DESCRIPTION
Contibutes to #6380

## Changes

Introduces an internal ConfigProperties type - an immutable, typed view over parsed YAML configuration values supporting scalars, nested mappings, and sequences. Renames ConfigProperty/ConfigPropertyState model types to ModelProperty/ModelPropertyState to avoid naming conflicts.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)