### PR TITLE
[API] Improve Baggage perf when setting same key/value 

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -249,6 +249,13 @@ public readonly struct Baggage : IEquatable<Baggage>
             return this.RemoveBaggage(name);
         }
 
+        if (this.baggage != null &&
+            this.baggage.TryGetValue(name, out var existingValue) &&
+            existingValue == value)
+        {
+            return this;
+        }
+
         return new Baggage(
             new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.Ordinal)
             {

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Improved `Baggage.SetBaggage` performance by avoiding a full copy when
+  the specified key already has the requested value.
+  ([#7660](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7660))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -75,6 +75,15 @@ public class BaggageTests
     }
 
     [Fact]
+    public void SetExistingValueNoOpTest()
+    {
+        var baggage = default(Baggage).SetBaggage(K1, V1);
+        var unchanged = baggage.SetBaggage(K1, V1);
+
+        Assert.Same(baggage.GetBaggage(), unchanged.GetBaggage());
+    }
+
+    [Fact]
     public void SetEmptyNameTest()
     {
         var baggage = Baggage.Current;


### PR DESCRIPTION
## Changes

Uses the same check as #7131 and returns the original dictionary when calling `SetBaggage` with the same key and same value.

Quick benchmark:

| Existing entries | Current         | Previous                |
|------------------|---------------|---------------------|
| 1                | 6.2 ns, 0 B   | 32.6 ns, 216 B      |
| 3                | 7.1 ns, 0 B   | 47.3 ns, 216 B      |
| 20               | 6.4 ns, 0 B   | 204.9 ns, 776 B     |
| 180              | 8.4 ns, 0 B   | 1.50 µs, 5648 B     |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
