### PR TITLE
[OTLP] Improve benchmarks

### DIFF
--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarConverter.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarConverter.cs
@@ -106,7 +106,7 @@ internal static class YamlScalarConverter
             accumulator = (accumulator * numberBase) + digit;
         }
 
-        return accumulator > (ulong)long.MaxValue
+        return accumulator > long.MaxValue
             ? ConfigValue.UnrepresentableInteger()
             : ConfigValue.Integer((long)accumulator);
     }

--- a/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
@@ -4,6 +4,11 @@
 extern alias OpenTelemetryProtocol;
 
 using System.Diagnostics;
+using System.Net;
+#if NETFRAMEWORK
+using System.Net.Http;
+using System.Net.Http.Headers;
+#endif
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using OpenTelemetry;
@@ -32,7 +37,10 @@ public class OtlpGrpcExporterBenchmarks
     [GlobalSetup]
     public void GlobalSetup()
     {
-        var options = new OtlpExporterOptions();
+        var options = new OtlpExporterOptions
+        {
+            HttpClientFactory = () => new HttpClient(new StubHttpClientHandler(), true),
+        };
         this.exporter = new OtlpTraceExporter(
             options,
             new SdkLimitOptions(),
@@ -65,5 +73,35 @@ public class OtlpGrpcExporterBenchmarks
 
             this.exporter!.Export(new Batch<Activity>(this.activityBatch!, this.NumberOfSpans));
         }
+    }
+
+    private sealed class StubHttpClientHandler : DelegatingHandler
+    {
+#if NET
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) => CreateResponse();
+#endif
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(CreateResponse());
+
+        private static HttpResponseMessage CreateResponse()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+#if NET
+            response.TrailingHeaders.Add("grpc-status", "0");
+#else
+            response.RequestMessage.Properties.Add("__ResponseTrailers", new ResponseTrailers()
+            {
+                { "grpc-status", "0" },
+            });
+#endif
+
+            return response;
+        }
+
+#if NETFRAMEWORK
+        private sealed class ResponseTrailers : HttpHeaders;
+#endif
     }
 }

--- a/test/Benchmarks/Exporter/OtlpLogExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpLogExporterBenchmarks.cs
@@ -18,20 +18,6 @@ using OpenTelemetry.Tests;
 using OpenTelemetryProtocol::OpenTelemetry.Exporter;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
 
-/*
-BenchmarkDotNet v0.13.6, Windows 11 (10.0.22621.2134/22H2/2022Update/SunValley2) (Hyper-V)
-AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores
-.NET SDK 7.0.400
-  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
-
-
-|               Method |     Mean |   Error |  StdDev |   Gen0 |   Gen1 | Allocated |
-|--------------------- |---------:|--------:|--------:|-------:|-------:|----------:|
-| OtlpLogExporter_Http | 138.7 us | 2.08 us | 1.95 us | 0.4883 | 0.2441 |   9.85 KB |
-| OtlpLogExporter_Grpc | 268.3 us | 2.57 us | 2.28 us | 0.4883 |      - |   9.54 KB |
-*/
-
 namespace Benchmarks.Exporter;
 
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
@@ -46,6 +32,9 @@ public class OtlpLogExporterBenchmarks
     private IDisposable? server;
     private string? serverHost;
     private int serverPort;
+
+    [Params(1, 512, 2048)]
+    public int BatchSize { get; set; }
 
     [GlobalSetup(Target = nameof(OtlpLogExporter_Grpc))]
     public void GlobalSetupGrpc()
@@ -72,8 +61,11 @@ public class OtlpLogExporterBenchmarks
         this.exporter = new OtlpLogExporter(options);
 
         this.logRecord = LogRecordHelper.CreateTestLogRecord();
-        this.logRecordBatch = new CircularBuffer<LogRecord>(1);
-        this.logRecordBatch.Add(this.logRecord);
+        this.logRecordBatch = new CircularBuffer<LogRecord>(this.BatchSize);
+        for (var i = 0; i < this.BatchSize; i++)
+        {
+            this.logRecordBatch.Add(this.logRecord);
+        }
     }
 
     [GlobalSetup(Target = nameof(OtlpLogExporter_Http))]
@@ -96,8 +88,11 @@ public class OtlpLogExporterBenchmarks
         this.exporter = new OtlpLogExporter(options);
 
         this.logRecord = LogRecordHelper.CreateTestLogRecord();
-        this.logRecordBatch = new CircularBuffer<LogRecord>(1);
-        this.logRecordBatch.Add(this.logRecord);
+        this.logRecordBatch = new CircularBuffer<LogRecord>(this.BatchSize);
+        for (var i = 0; i < this.BatchSize; i++)
+        {
+            this.logRecordBatch.Add(this.logRecord);
+        }
     }
 
     [GlobalCleanup(Target = nameof(OtlpLogExporter_Grpc))]
@@ -119,13 +114,13 @@ public class OtlpLogExporterBenchmarks
     [Benchmark]
     public void OtlpLogExporter_Http()
     {
-        this.exporter!.Export(new Batch<LogRecord>(this.logRecordBatch!, 1));
+        this.exporter!.Export(new Batch<LogRecord>(this.logRecordBatch!, this.BatchSize));
     }
 
     [Benchmark]
     public void OtlpLogExporter_Grpc()
     {
-        this.exporter!.Export(new Batch<LogRecord>(this.logRecordBatch!, 1));
+        this.exporter!.Export(new Batch<LogRecord>(this.logRecordBatch!, this.BatchSize));
     }
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes

--- a/test/Benchmarks/Exporter/OtlpTraceExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpTraceExporterBenchmarks.cs
@@ -18,20 +18,6 @@ using OpenTelemetry.Tests;
 using OpenTelemetryProtocol::OpenTelemetry.Exporter;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
 
-/*
-BenchmarkDotNet v0.13.6, Windows 11 (10.0.22621.2134/22H2/2022Update/SunValley2) (Hyper-V)
-AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores
-.NET SDK 7.0.400
-  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
-
-
-|                 Method |     Mean |   Error |  StdDev |   Gen0 |   Gen1 | Allocated |
-|----------------------- |---------:|--------:|--------:|-------:|-------:|----------:|
-| OtlpTraceExporter_Http | 139.4 us | 1.41 us | 1.32 us | 0.4883 | 0.2441 |    9.8 KB |
-| OtlpTraceExporter_Grpc | 263.0 us | 3.47 us | 3.24 us | 0.4883 |      - |   9.34 KB |
-*/
-
 namespace Benchmarks.Exporter;
 
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable - handled by GlobalCleanup
@@ -46,6 +32,9 @@ public class OtlpTraceExporterBenchmarks
     private IDisposable? server;
     private string? serverHost;
     private int serverPort;
+
+    [Params(1, 512, 2048)]
+    public int BatchSize { get; set; }
 
     [GlobalSetup(Target = nameof(OtlpTraceExporter_Grpc))]
     public void GlobalSetupGrpc()
@@ -72,8 +61,11 @@ public class OtlpTraceExporterBenchmarks
         this.exporter = new OtlpTraceExporter(options);
 
         this.activity = ActivityHelper.CreateTestActivity();
-        this.activityBatch = new CircularBuffer<Activity>(1);
-        this.activityBatch.Add(this.activity);
+        this.activityBatch = new CircularBuffer<Activity>(this.BatchSize);
+        for (var i = 0; i < this.BatchSize; i++)
+        {
+            this.activityBatch.Add(this.activity);
+        }
     }
 
     [GlobalSetup(Target = nameof(OtlpTraceExporter_Http))]
@@ -96,8 +88,11 @@ public class OtlpTraceExporterBenchmarks
         this.exporter = new OtlpTraceExporter(options);
 
         this.activity = ActivityHelper.CreateTestActivity();
-        this.activityBatch = new CircularBuffer<Activity>(1);
-        this.activityBatch.Add(this.activity);
+        this.activityBatch = new CircularBuffer<Activity>(this.BatchSize);
+        for (var i = 0; i < this.BatchSize; i++)
+        {
+            this.activityBatch.Add(this.activity);
+        }
     }
 
     [GlobalCleanup(Target = nameof(OtlpTraceExporter_Grpc))]
@@ -121,13 +116,13 @@ public class OtlpTraceExporterBenchmarks
     [Benchmark]
     public void OtlpTraceExporter_Http()
     {
-        this.exporter!.Export(new Batch<Activity>(this.activityBatch!, 1));
+        this.exporter!.Export(new Batch<Activity>(this.activityBatch!, this.BatchSize));
     }
 
     [Benchmark]
     public void OtlpTraceExporter_Grpc()
     {
-        this.exporter!.Export(new Batch<Activity>(this.activityBatch!, 1));
+        this.exporter!.Export(new Batch<Activity>(this.activityBatch!, this.BatchSize));
     }
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarConverterTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarConverterTests.cs
@@ -198,7 +198,7 @@ public sealed class YamlScalarConverterTests
 
         Assert.Equal(ConfigValueKind.Double, result.Kind);
         var d = result.AsDouble();
-        Assert.True(d > 4e21 && d < 5e21, $"Expected ~4.72e21 but got {d}.");
+        Assert.True(d is > 4e21 and < 5e21, $"Expected ~4.72e21 but got {d}.");
     }
 
     // Fails if a new YamlScalarKind member is added without a matching case in YamlScalarConverter.

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -1039,7 +1039,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
         // Framework), the buffer is a byte short and growth is refused first.
         Assert.Contains(
             listener.Messages,
-            e => e.EventId == RequestDiscardedEventId || e.EventId == BufferExceededMaxSizeEventId);
+            e => e.EventId is RequestDiscardedEventId or BufferExceededMaxSizeEventId);
     }
 
     [Theory]


### PR DESCRIPTION
## Changes

Found while running the OTLP benchmarks locally to compare 1.17 against main (TL;DR: 10-40% improvement):

- Use a stub for the gRPC benchmarks to avoid (caught) errors that slowed them down.
- Add more realistic batch sizes for log and trace exports.

Also cherry-picks some new code analysis warning fixes from #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
