### PR TITLE
[Declarative config] Add YAML scalar conversion

### DIFF
--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlNodeReader.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlNodeReader.cs
@@ -17,7 +17,7 @@ namespace OpenTelemetry.Configuration.Declarative;
 /// <b>Resolution order.</b> <see cref="ResolveScalar(YamlScalarNode)"/> is the single entry point
 /// through which every scalar in this package is read, and it establishes one deterministic order:
 /// YAML parse, then environment variable substitution on the decoded scalar content, then YAML 1.2
-/// type resolution (<see cref="Yaml12ScalarResolver"/>). The OTel spec limits substitution to
+/// type resolution (<see cref="YamlScalarResolver"/>). The OTel spec limits substitution to
 /// scalar values and requires it to happen before type interpretation. Consequently,
 /// <c>${PORT}</c> resolving to <c>4317</c> is an integer on every code path and
 /// <c>"${PORT}"</c> is a string on every code path.
@@ -68,7 +68,7 @@ internal static class YamlNodeReader
 
             // Mapping keys are not candidates for environment substitution. Resolve the authored
             // key directly so equivalent spellings such as `key` and `!!str key` compare equally.
-            var resolved = Yaml12ScalarResolver.Resolve(keyNode, keyNode.Value ?? string.Empty);
+            var resolved = YamlScalarResolver.Resolve(keyNode, keyNode.Value ?? string.Empty);
             if (resolved.Kind != YamlScalarKind.String)
             {
                 throw new DeclarativeConfigurationException(
@@ -110,11 +110,11 @@ internal static class YamlNodeReader
     /// </para>
     /// <para>
     /// The scalar's <see cref="YamlScalarNode.Style"/> still matters, but only to
-    /// <see cref="Yaml12ScalarResolver"/> for the type decision that follows.
+    /// <see cref="YamlScalarResolver"/> for the type decision that follows.
     /// </para>
     /// </remarks>
     public static ResolvedYamlScalar ResolveScalar(this YamlScalarNode scalar) =>
-        Yaml12ScalarResolver.Resolve(
+        YamlScalarResolver.Resolve(
             scalar,
             EnvironmentSubstitution.Substitute(scalar.Value ?? string.Empty));
 

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlPropertyReader.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlPropertyReader.cs
@@ -9,7 +9,7 @@ namespace OpenTelemetry.Configuration.Declarative;
 /// Extension methods that read typed values from a <see cref="YamlMappingNode"/> into <see cref="ModelProperty{T}"/> results.
 /// </summary>
 /// <remarks>
-/// All type resolution here is delegated to <see cref="Yaml12ScalarResolver"/> so that the two
+/// All type resolution here is delegated to <see cref="YamlScalarResolver"/> so that the two
 /// readers cannot disagree about what a given piece of text means. Substitution always runs before
 /// core-schema type resolution.
 /// </remarks>
@@ -40,7 +40,7 @@ internal static class YamlPropertyReader
         }
 
         if (resolved.Kind != YamlScalarKind.Boolean ||
-            !Yaml12ScalarResolver.TryGetBoolean(resolved.Value, out var boolValue))
+            !YamlScalarResolver.TryGetBoolean(resolved.Value, out var boolValue))
         {
             throw CreateTypeMismatch(key, "boolean or null", resolved.Kind);
         }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarConverter.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarConverter.cs
@@ -1,0 +1,142 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
+
+namespace OpenTelemetry.Configuration.Declarative;
+
+/// <summary>
+/// Converts a <see cref="ResolvedYamlScalar"/> produced by <see cref="YamlScalarResolver"/>
+/// to a <see cref="ConfigValue"/>.
+/// </summary>
+internal static class YamlScalarConverter
+{
+    /// <summary>
+    /// Converts a resolved YAML scalar to a <see cref="ConfigValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method is total for scalars produced by <see cref="YamlScalarResolver"/>: it never
+    /// throws and has no failure outcome. An integer that exceeds the <see cref="long"/> range is
+    /// returned as <see cref="ConfigValue.UnrepresentableInteger()"/> rather than causing an error.
+    /// <para/>
+    /// Hand-built <see cref="ResolvedYamlScalar"/> values whose kind does not match the text
+    /// (for example an unknown kind, a non-boolean under <see cref="YamlScalarKind.Boolean"/>, or a
+    /// character that is not valid for hex/octal integer text) may throw
+    /// <see cref="InvalidOperationException"/>. That is a programming error, not a conversion failure.
+    /// </remarks>
+    /// <param name="scalar">The resolved scalar to convert.</param>
+    /// <returns>A <see cref="ConfigValue"/> representing the scalar.</returns>
+    internal static ConfigValue Convert(ResolvedYamlScalar scalar) =>
+        scalar.Kind switch
+        {
+            YamlScalarKind.Null => ConfigValue.Null,
+            YamlScalarKind.String => ConfigValue.String(scalar.Value),
+            YamlScalarKind.Boolean => ConvertBoolean(scalar.Value),
+            YamlScalarKind.Integer => ConvertInteger(scalar.Value),
+            YamlScalarKind.Float => ConvertFloat(scalar.Value),
+            _ => throw new InvalidOperationException($"Unhandled {nameof(YamlScalarKind)}: {scalar.Kind}."),
+        };
+
+    private static ConfigValue ConvertBoolean(string value) =>
+        YamlScalarResolver.TryGetBoolean(value, out var boolValue)
+            ? ConfigValue.Boolean(boolValue)
+            : throw new InvalidOperationException(
+                $"Boolean kind requires a YAML 1.2 boolean value, got '{value}'.");
+
+    private static ConfigValue ConvertInteger(string value) =>
+        value switch
+        {
+            { Length: >= 3 } when value[0] == '0' && value[1] == 'x' =>
+                AccumulateUnsigned(value, start: 2, radix: 16),
+            { Length: >= 3 } when value[0] == '0' && value[1] == 'o' =>
+                AccumulateUnsigned(value, start: 2, radix: 8),
+
+            // A false return can only mean out of range; the resolver guarantees the decimal form is valid.
+            _ when long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var l) =>
+                ConfigValue.Integer(l),
+            _ => ConfigValue.UnrepresentableInteger(),
+        };
+
+    // !!float accepts integer notation, so hex and octal values can arrive with Float kind.
+    // Accumulate directly into double so values beyond the long range saturate to +Infinity
+    // naturally rather than becoming unrepresentable integers.
+    private static ConfigValue ConvertFloat(string value) =>
+        value switch
+        {
+            _ when YamlScalarResolver.IsInfinity(value) =>
+                ConfigValue.Double(IsNegative(value) ? double.NegativeInfinity : double.PositiveInfinity),
+            ".nan" or ".NaN" or ".NAN" => ConfigValue.Double(double.NaN),
+            { Length: >= 3 } when value[0] == '0' && value[1] == 'x' =>
+                ConfigValue.Double(AccumulateDouble(value, start: 2, radix: 16)),
+            { Length: >= 3 } when value[0] == '0' && value[1] == 'o' =>
+                ConfigValue.Double(AccumulateDouble(value, start: 2, radix: 8)),
+            _ => ConvertDecimalFloat(value),
+        };
+
+    // On .NET Framework, double.TryParse returns false for magnitude overflow (unlike .NET Core
+    // which saturates to +/-Infinity), and does not preserve negative zero for "-0.0" or negative
+    // underflow inputs. Apply the sign from the value when the parsed result is positive zero.
+    private static ConfigValue ConvertDecimalFloat(string value) =>
+        double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) switch
+        {
+            true when d == 0.0 && IsNegative(value) && BitConverter.DoubleToInt64Bits(d) >= 0 =>
+                ConfigValue.Double(-d),
+            true => ConfigValue.Double(d),
+
+            // A false return means overflow for resolver-validated forms; .NET Core never reaches here.
+            false when IsNegative(value) => ConfigValue.Double(double.NegativeInfinity),
+            false => ConfigValue.Double(double.PositiveInfinity),
+        };
+
+    private static bool IsNegative(string value) =>
+        value is { Length: > 0 } && value[0] == '-';
+
+    private static ConfigValue AccumulateUnsigned(string value, int start, int radix)
+    {
+        var accumulator = 0UL;
+        for (var i = start; i < value.Length; i++)
+        {
+            var digit = (ulong)DigitValue(value[i], radix);
+            if (accumulator > (ulong.MaxValue - digit) / (ulong)radix)
+            {
+                return ConfigValue.UnrepresentableInteger();
+            }
+
+            accumulator = (accumulator * (ulong)radix) + digit;
+        }
+
+        return accumulator > (ulong)long.MaxValue
+            ? ConfigValue.UnrepresentableInteger()
+            : ConfigValue.Integer((long)accumulator);
+    }
+
+    private static double AccumulateDouble(string value, int start, int radix)
+    {
+        var accumulator = 0.0;
+        for (var i = start; i < value.Length; i++)
+        {
+            accumulator = (accumulator * radix) + DigitValue(value[i], radix);
+        }
+
+        return accumulator;
+    }
+
+    private static int DigitValue(char c, int radix)
+    {
+        var digit = c switch
+        {
+            >= '0' and <= '9' => c - '0',
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            _ => throw new InvalidOperationException($"Not a valid digit: '{c}'."),
+        };
+
+        if (digit >= radix)
+        {
+            var form = radix == 16 ? "hexadecimal" : "octal";
+            throw new InvalidOperationException($"Digit '{c}' is not valid in {form} integer text.");
+        }
+
+        return digit;
+    }
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarConverter.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarConverter.cs
@@ -29,11 +29,11 @@ internal static class YamlScalarConverter
     internal static ConfigValue Convert(ResolvedYamlScalar scalar) =>
         scalar.Kind switch
         {
+            YamlScalarKind.Boolean => ConvertBoolean(scalar.Value),
+            YamlScalarKind.Float => ConvertFloat(scalar.Value),
+            YamlScalarKind.Integer => ConvertInteger(scalar.Value),
             YamlScalarKind.Null => ConfigValue.Null,
             YamlScalarKind.String => ConfigValue.String(scalar.Value),
-            YamlScalarKind.Boolean => ConvertBoolean(scalar.Value),
-            YamlScalarKind.Integer => ConvertInteger(scalar.Value),
-            YamlScalarKind.Float => ConvertFloat(scalar.Value),
             _ => throw new InvalidOperationException($"Unhandled {nameof(YamlScalarKind)}: {scalar.Kind}."),
         };
 
@@ -47,9 +47,9 @@ internal static class YamlScalarConverter
         value switch
         {
             { Length: >= 3 } when value[0] == '0' && value[1] == 'x' =>
-                AccumulateUnsigned(value, start: 2, radix: 16),
+                AccumulateUnsigned(value, start: 2, numberBase: 16),
             { Length: >= 3 } when value[0] == '0' && value[1] == 'o' =>
-                AccumulateUnsigned(value, start: 2, radix: 8),
+                AccumulateUnsigned(value, start: 2, numberBase: 8),
 
             // A false return can only mean out of range; the resolver guarantees the decimal form is valid.
             _ when long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var l) =>
@@ -65,25 +65,26 @@ internal static class YamlScalarConverter
         {
             _ when YamlScalarResolver.IsInfinity(value) =>
                 ConfigValue.Double(IsNegative(value) ? double.NegativeInfinity : double.PositiveInfinity),
-            ".nan" or ".NaN" or ".NAN" => ConfigValue.Double(double.NaN),
+            _ when YamlScalarResolver.IsNaN(value) => ConfigValue.Double(double.NaN),
             { Length: >= 3 } when value[0] == '0' && value[1] == 'x' =>
-                ConfigValue.Double(AccumulateDouble(value, start: 2, radix: 16)),
+                ConfigValue.Double(AccumulateDouble(value, start: 2, numberBase: 16)),
             { Length: >= 3 } when value[0] == '0' && value[1] == 'o' =>
-                ConfigValue.Double(AccumulateDouble(value, start: 2, radix: 8)),
+                ConfigValue.Double(AccumulateDouble(value, start: 2, numberBase: 8)),
             _ => ConvertDecimalFloat(value),
         };
 
-    // On .NET Framework, double.TryParse returns false for magnitude overflow (unlike .NET Core
-    // which saturates to +/-Infinity), and does not preserve negative zero for "-0.0" or negative
-    // underflow inputs. Apply the sign from the value when the parsed result is positive zero.
+    // Before .NET Core 3.0, double.TryParse fails instead of saturating to +/-Infinity on overflow,
+    // and does not preserve negative zero. The extra arms keep behavior consistent across TFMs.
     private static ConfigValue ConvertDecimalFloat(string value) =>
         double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) switch
         {
+#if !NET
             true when d == 0.0 && IsNegative(value) && BitConverter.DoubleToInt64Bits(d) >= 0 =>
                 ConfigValue.Double(-d),
+#endif
             true => ConfigValue.Double(d),
 
-            // A false return means overflow for resolver-validated forms; .NET Core never reaches here.
+            // Overflow on those frameworks, or text that is not a float at all.
             false when IsNegative(value) => ConfigValue.Double(double.NegativeInfinity),
             false => ConfigValue.Double(double.PositiveInfinity),
         };
@@ -91,18 +92,18 @@ internal static class YamlScalarConverter
     private static bool IsNegative(string value) =>
         value is { Length: > 0 } && value[0] == '-';
 
-    private static ConfigValue AccumulateUnsigned(string value, int start, int radix)
+    private static ConfigValue AccumulateUnsigned(string value, int start, ulong numberBase)
     {
         var accumulator = 0UL;
         for (var i = start; i < value.Length; i++)
         {
-            var digit = (ulong)DigitValue(value[i], radix);
-            if (accumulator > (ulong.MaxValue - digit) / (ulong)radix)
+            var digit = DigitValue(value[i], numberBase);
+            if (accumulator > (ulong.MaxValue - digit) / numberBase)
             {
                 return ConfigValue.UnrepresentableInteger();
             }
 
-            accumulator = (accumulator * (ulong)radix) + digit;
+            accumulator = (accumulator * numberBase) + digit;
         }
 
         return accumulator > (ulong)long.MaxValue
@@ -110,30 +111,30 @@ internal static class YamlScalarConverter
             : ConfigValue.Integer((long)accumulator);
     }
 
-    private static double AccumulateDouble(string value, int start, int radix)
+    private static double AccumulateDouble(string value, int start, ulong numberBase)
     {
         var accumulator = 0.0;
         for (var i = start; i < value.Length; i++)
         {
-            accumulator = (accumulator * radix) + DigitValue(value[i], radix);
+            accumulator = (accumulator * numberBase) + DigitValue(value[i], numberBase);
         }
 
         return accumulator;
     }
 
-    private static int DigitValue(char c, int radix)
+    private static ulong DigitValue(char c, ulong numberBase)
     {
-        var digit = c switch
+        var digit = (ulong)(c switch
         {
-            >= '0' and <= '9' => c - '0',
-            >= 'a' and <= 'f' => c - 'a' + 10,
-            >= 'A' and <= 'F' => c - 'A' + 10,
+            _ when char.IsAsciiDigit(c) => c - '0',
+            _ when char.IsAsciiLetterLower(c) && c <= 'f' => c - 'a' + 10,
+            _ when char.IsAsciiLetterUpper(c) && c <= 'F' => c - 'A' + 10,
             _ => throw new InvalidOperationException($"Not a valid digit: '{c}'."),
-        };
+        });
 
-        if (digit >= radix)
+        if (digit >= numberBase)
         {
-            var form = radix == 16 ? "hexadecimal" : "octal";
+            var form = numberBase == 16 ? "hexadecimal" : "octal";
             throw new InvalidOperationException($"Digit '{c}' is not valid in {form} integer text.");
         }
 

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarResolver.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarResolver.cs
@@ -133,9 +133,18 @@ internal static class YamlScalarResolver
         return suffix.SequenceEqual("inf") || suffix.SequenceEqual("Inf") || suffix.SequenceEqual("INF");
     }
 
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="value"/> is a YAML 1.2 core-schema
+    /// NaN form (<c>.nan</c>, <c>.NaN</c>, <c>.NAN</c>). No leading sign is permitted.
+    /// </summary>
+    /// <param name="value">The scalar value to test.</param>
+    /// <returns><see langword="true"/> for a NaN form.</returns>
+    internal static bool IsNaN(string value) =>
+        value is ".nan" or ".NaN" or ".NAN";
+
     internal static bool IsFloat(string value)
     {
-        if (IsInfinity(value) || value is ".nan" or ".NaN" or ".NAN")
+        if (IsInfinity(value) || IsNaN(value))
         {
             return true;
         }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarResolver.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/YamlScalarResolver.cs
@@ -9,7 +9,7 @@ namespace OpenTelemetry.Configuration.Declarative;
 /// <summary>
 /// Resolves scalar nodes according to the YAML 1.2 core schema.
 /// </summary>
-internal static class Yaml12ScalarResolver
+internal static class YamlScalarResolver
 {
     internal const string StringTag = "tag:yaml.org,2002:str";
     internal const string BooleanTag = "tag:yaml.org,2002:bool";
@@ -113,6 +113,24 @@ internal static class Yaml12ScalarResolver
             'x' => IsDigitRun(value, 2, char.IsAsciiHexDigit),
             _ => false,
         };
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="value"/> is a YAML 1.2 core-schema
+    /// infinity form (<c>.inf</c>, <c>.Inf</c>, <c>.INF</c>, with an optional leading sign).
+    /// </summary>
+    /// <param name="value">The scalar value to test.</param>
+    /// <returns><see langword="true"/> for an infinity form.</returns>
+    internal static bool IsInfinity(string value)
+    {
+        var i = HasSign(value) ? 1 : 0;
+        if ((value.Length - i) != 4 || value[i] != '.')
+        {
+            return false;
+        }
+
+        var suffix = value.AsSpan(i + 1);
+        return suffix.SequenceEqual("inf") || suffix.SequenceEqual("Inf") || suffix.SequenceEqual("INF");
     }
 
     internal static bool IsFloat(string value)
@@ -262,18 +280,6 @@ internal static class Yaml12ScalarResolver
         }
 
         return true;
-    }
-
-    private static bool IsInfinity(string value)
-    {
-        var i = HasSign(value) ? 1 : 0;
-        if ((value.Length - i) != 4 || value[i] != '.')
-        {
-            return false;
-        }
-
-        var suffix = value.AsSpan(i + 1);
-        return suffix.SequenceEqual("inf") || suffix.SequenceEqual("Inf") || suffix.SequenceEqual("INF");
     }
 
     private static bool HasSign(string value) =>

--- a/test/OpenTelemetry.Configuration.Declarative.FuzzTests/YamlScalarConverterFuzzTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.FuzzTests/YamlScalarConverterFuzzTests.cs
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace OpenTelemetry.Configuration.Declarative.FuzzTests;
+
+public class YamlScalarConverterFuzzTests
+{
+    private const int MaxTests = 500;
+
+    private static readonly Arbitrary<string> ScalarStringArbitrary = Gen.Sized(size =>
+        Gen.ArrayOf(
+            Gen.Choose(0, 127).Select(c => (char)c),
+            Math.Min(size + 1, 256))
+        .Select(chars => new string(chars))).ToArbitrary();
+
+    [Property(MaxTest = MaxTests)]
+    public Property ResolveAndConvertNeverThrowsForArbitraryPlainScalar() =>
+        Prop.ForAll(
+            ScalarStringArbitrary,
+            value =>
+            {
+                var node = new YamlScalarNode(value) { Style = ScalarStyle.Plain };
+                var resolved = YamlScalarResolver.Resolve(node, value);
+                _ = YamlScalarConverter.Convert(resolved);
+            });
+}

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationReaderTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationReaderTests.cs
@@ -1622,7 +1622,7 @@ public sealed class DeclarativeConfigurationReaderTests
     public void Translate_DisabledFromEnvVarSetToNullLiteral_DoesNotSetKey(string envVarValue)
     {
         // When an env var is set to a YAML null spelling, substitution produces a plain
-        // scalar with that value. Yaml12ScalarResolver.ResolvesToNull treats it as
+        // scalar with that value. YamlScalarResolver.ResolvesToNull treats it as
         // present-null -> no key emitted.
         const string envVarName = "OTEL_DECLARATIVE_TEST_DISABLED_NULL_LITERAL";
         const string yaml = """

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/YamlNodeReaderTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/YamlNodeReaderTests.cs
@@ -46,6 +46,7 @@ public sealed class YamlNodeReaderTests
     [InlineData("~")]
     [InlineData("true")]
     [InlineData("42")]
+    [InlineData("3.14")]
     public void EnsureUniqueStringKeys_NonStringKey_Throws(string key)
     {
         var stream = new YamlStream();
@@ -54,5 +55,58 @@ public sealed class YamlNodeReaderTests
 
         Assert.Throws<DeclarativeConfigurationException>(() =>
             mapping.EnsureUniqueStringKeys("<root>"));
+    }
+
+    [Fact]
+    public void GetScalarString_Mapping_AbsentKey_ReturnsNull()
+    {
+        var mapping = new YamlMappingNode();
+        Assert.Null(mapping.GetScalarString("missing"));
+    }
+
+    [Fact]
+    public void GetScalarString_Mapping_NonScalarValue_ReturnsNull()
+    {
+        var stream = new YamlStream();
+        stream.Load(new StringReader("key:\n  nested: value"));
+        var mapping = Assert.IsType<YamlMappingNode>(stream.Documents[0].RootNode);
+        Assert.Null(mapping.GetScalarString("key"));
+    }
+
+    [Fact]
+    public void GetScalarString_Mapping_ScalarNullValue_ReturnsNull()
+    {
+        var stream = new YamlStream();
+        stream.Load(new StringReader("key: ~"));
+        var mapping = Assert.IsType<YamlMappingNode>(stream.Documents[0].RootNode);
+        Assert.Null(mapping.GetScalarString("key"));
+    }
+
+    [Fact]
+    public void GetScalarString_Mapping_StringValue_ReturnsString()
+    {
+        var stream = new YamlStream();
+        stream.Load(new StringReader("key: hello"));
+        var mapping = Assert.IsType<YamlMappingNode>(stream.Documents[0].RootNode);
+        Assert.Equal("hello", mapping.GetScalarString("key"));
+    }
+
+    [Fact]
+    public void EnsureCoreCollectionTag_ScalarNode_ThrowsArgumentException()
+    {
+        var scalar = new YamlScalarNode("value");
+        Assert.Throws<ArgumentException>(() => scalar.EnsureCoreCollectionTag("context"));
+    }
+
+    [Fact]
+    public void EnsureNoUnrecognizedProperties_NonScalarKey_Throws()
+    {
+        var mapping = new YamlMappingNode
+        {
+            { new YamlSequenceNode("a", "b"), new YamlScalarNode("value") },
+        };
+
+        Assert.Throws<DeclarativeConfigurationException>(() =>
+            mapping.EnsureNoUnrecognizedProperties("root", []));
     }
 }

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarConverterTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarConverterTests.cs
@@ -140,6 +140,8 @@ public sealed class YamlScalarConverterTests
     [InlineData("+.5", 0.5)]
     [InlineData("+12e03", 12000.0)]
     [InlineData("-2E+05", -200000.0)]
+    [InlineData("1.5", 1.5)]
+    [InlineData("3.14", 3.14)]
     [InlineData(".inf", double.PositiveInfinity)]
     [InlineData("+.INF", double.PositiveInfinity)]
     [InlineData("-.Inf", double.NegativeInfinity)]

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarConverterTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarConverterTests.cs
@@ -1,0 +1,254 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+public sealed class YamlScalarConverterTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("~")]
+    [InlineData("null")]
+    [InlineData("Null")]
+    [InlineData("NULL")]
+    public void Convert_Null_ReturnsNull(string value)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.Null));
+
+        Assert.Equal(ConfigValueKind.Null, result.Kind);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("True", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("false", false)]
+    [InlineData("False", false)]
+    [InlineData("FALSE", false)]
+    public void Convert_Boolean_ReturnsExpectedValue(string value, bool expected)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.Boolean));
+
+        Assert.Equal(ConfigValueKind.Boolean, result.Kind);
+        Assert.Equal(expected, result.AsBoolean());
+    }
+
+    [Fact]
+    public void Convert_Boolean_InvalidValue_Throws() =>
+        Assert.Throws<InvalidOperationException>(() =>
+            YamlScalarConverter.Convert(new("maybe", YamlScalarKind.Boolean)));
+
+    [Theory]
+    [InlineData("hello")]
+    [InlineData("-0o7")]
+    [InlineData("+0x3A")]
+    [InlineData("0O17")]
+    public void Convert_String_ReturnsValueVerbatim(string value)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.String));
+
+        Assert.Equal(ConfigValueKind.String, result.Kind);
+        Assert.Equal(value, result.AsString());
+    }
+
+    [Theory]
+    [InlineData("0", 0L)]
+    [InlineData("+42", 42L)]
+    [InlineData("-19", -19L)]
+    [InlineData("007", 7L)]
+    [InlineData("0000000000000000000000042", 42L)]
+    [InlineData("9223372036854775807", long.MaxValue)]
+    [InlineData("-9223372036854775808", long.MinValue)]
+    [InlineData("0x3A", 58L)]
+    [InlineData("0xdeadbeef", 3735928559L)]
+    [InlineData("0x7FFFFFFFFFFFFFFF", long.MaxValue)]
+    [InlineData("0x000000000000000000001F", 31L)]
+    [InlineData("0o7", 7L)]
+    [InlineData("0o17", 15L)]
+    [InlineData("0o777777777777777777777", long.MaxValue)]
+    public void Convert_Integer_RepresentableRange_ReturnsExpectedLong(string value, long expected)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.Integer));
+
+        Assert.Equal(ConfigValueKind.Integer, result.Kind);
+        Assert.False(result.IsUnrepresentable);
+        Assert.Equal(expected, result.AsLong());
+    }
+
+    [Theory]
+    [InlineData("9223372036854775808")]
+    [InlineData("-9223372036854775809")]
+    [InlineData("123456789012345678901234567890")]
+    [InlineData("0x8000000000000000")]
+    [InlineData("0xFFFFFFFFFFFFFFFFFF")]
+    [InlineData("0o1000000000000000000000")]
+    public void Convert_Integer_OutOfRange_ReturnsUnrepresentable(string value)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.Integer));
+
+        Assert.Equal(ConfigValueKind.Integer, result.Kind);
+        Assert.True(result.IsUnrepresentable);
+    }
+
+    [Theory]
+    [InlineData("0o8")]
+    [InlineData("0o19")]
+    [InlineData("0xG")]
+    public void Convert_Integer_InvalidDigit_Throws(string value) =>
+        Assert.Throws<InvalidOperationException>(() =>
+            YamlScalarConverter.Convert(new(value, YamlScalarKind.Integer)));
+
+    [Theory]
+    [InlineData("0o8")]
+    [InlineData("0o19")]
+    [InlineData("0xG")]
+    public void Convert_Float_InvalidDigit_Throws(string value) =>
+        Assert.Throws<InvalidOperationException>(() =>
+            YamlScalarConverter.Convert(new(value, YamlScalarKind.Float)));
+
+    [Theory]
+    [InlineData(".nan")]
+    [InlineData(".NaN")]
+    [InlineData(".NAN")]
+    public void Convert_Float_NanForms_ReturnsNaN(string value)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.Float));
+
+        Assert.Equal(ConfigValueKind.Double, result.Kind);
+        Assert.True(double.IsNaN(result.AsDouble()));
+    }
+
+    [Fact]
+    public void Convert_Float_NegativeZero_PreservesSign()
+    {
+        var result = YamlScalarConverter.Convert(new("-0.0", YamlScalarKind.Float));
+
+        Assert.Equal(ConfigValueKind.Double, result.Kind);
+        var d = result.AsDouble();
+        Assert.Equal(0.0, d);
+
+        // double.IsNegative is not available on net462; this is the idiomatic substitute.
+        Assert.Equal(double.NegativeInfinity, 1.0 / d);
+    }
+
+    [Theory]
+    [InlineData("0.", 0.0)]
+    [InlineData(".5", 0.5)]
+    [InlineData("+.5", 0.5)]
+    [InlineData("+12e03", 12000.0)]
+    [InlineData("-2E+05", -200000.0)]
+    [InlineData(".inf", double.PositiveInfinity)]
+    [InlineData("+.INF", double.PositiveInfinity)]
+    [InlineData("-.Inf", double.NegativeInfinity)]
+    [InlineData("1e999", double.PositiveInfinity)]
+    [InlineData("-1e999", double.NegativeInfinity)]
+    [InlineData("1e-999", 0.0)]
+    public void Convert_Float_StandardForms_ReturnsExpectedDouble(string value, double expected)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.Float));
+
+        Assert.Equal(ConfigValueKind.Double, result.Kind);
+        Assert.Equal(expected, result.AsDouble());
+    }
+
+    [Fact]
+    public void Convert_Float_NegativeUnderflow_ReturnsNegativeZero()
+    {
+        var result = YamlScalarConverter.Convert(new("-1e-999", YamlScalarKind.Float));
+
+        Assert.Equal(ConfigValueKind.Double, result.Kind);
+        var d = result.AsDouble();
+        Assert.Equal(0.0, d);
+        Assert.Equal(double.NegativeInfinity, 1.0 / d);
+    }
+
+    // Empty value cannot come from the resolver as Float; overflow fallback must not index [0].
+    [Fact]
+    public void Convert_Float_EmptyValue_DoesNotThrow_ReturnsPositiveInfinity()
+    {
+        var result = YamlScalarConverter.Convert(new(string.Empty, YamlScalarKind.Float));
+
+        Assert.Equal(ConfigValueKind.Double, result.Kind);
+        Assert.Equal(double.PositiveInfinity, result.AsDouble());
+    }
+
+    [Theory]
+    [InlineData("5", 5.0)]
+    [InlineData("+5", 5.0)]
+    [InlineData("0x1F", 31.0)]
+    [InlineData("0o17", 15.0)]
+    public void Convert_Float_IntegerNotationViaExplicitTag_ReturnsDouble(string value, double expected)
+    {
+        var result = YamlScalarConverter.Convert(new(value, YamlScalarKind.Float));
+
+        Assert.Equal(ConfigValueKind.Double, result.Kind);
+        Assert.Equal(expected, result.AsDouble());
+    }
+
+    // !!float 0xFFFFFFFFFFFFFFFFFF exceeds long.MaxValue and must produce ~4.72e21, not UnrepresentableInteger.
+    [Fact]
+    public void Convert_Float_HexBeyondLongRange_SaturatesToDouble()
+    {
+        var result = YamlScalarConverter.Convert(new("0xFFFFFFFFFFFFFFFFFF", YamlScalarKind.Float));
+
+        Assert.Equal(ConfigValueKind.Double, result.Kind);
+        var d = result.AsDouble();
+        Assert.True(d > 4e21 && d < 5e21, $"Expected ~4.72e21 but got {d}.");
+    }
+
+    // Fails if a new YamlScalarKind member is added without a matching case in YamlScalarConverter.
+    [Fact]
+    public void Convert_AllCurrentKinds_DoNotThrow()
+    {
+        var cases = new (string Value, YamlScalarKind Kind)[]
+        {
+            ("null", YamlScalarKind.Null),
+            ("hello", YamlScalarKind.String),
+            ("true", YamlScalarKind.Boolean),
+            ("0", YamlScalarKind.Integer),
+            ("0.", YamlScalarKind.Float),
+        };
+
+        foreach (var (value, kind) in cases)
+        {
+            _ = YamlScalarConverter.Convert(new(value, kind));
+        }
+
+        // If YamlScalarKind gains a new member, this count check fails, prompting an update here
+        // and a new case in YamlScalarConverter.
+#if NET
+        Assert.Equal(cases.Length, Enum.GetNames<YamlScalarKind>().Length);
+#else
+        Assert.Equal(cases.Length, Enum.GetNames(typeof(YamlScalarKind)).Length);
+#endif
+    }
+
+    [Fact]
+    public void Convert_UnknownKind_Throws() =>
+        Assert.Throws<InvalidOperationException>(() =>
+            YamlScalarConverter.Convert(new("x", (YamlScalarKind)42)));
+
+    [Theory]
+    [MemberData(nameof(YamlScalarResolverTests.CoreSchemaExamples), MemberType = typeof(YamlScalarResolverTests))]
+    public void Convert_CoreSchemaExamples_KindMatchesResolver(string value, string expectedKindName)
+    {
+        var node = new YamlScalarNode(value) { Style = ScalarStyle.Plain };
+        var resolved = YamlScalarResolver.Resolve(node, value);
+        var result = YamlScalarConverter.Convert(resolved);
+
+        var expectedConfigKind = expectedKindName switch
+        {
+            "Null" => ConfigValueKind.Null,
+            "Boolean" => ConfigValueKind.Boolean,
+            "Integer" => ConfigValueKind.Integer,
+            "Float" => ConfigValueKind.Double, // YamlScalarKind.Float maps to ConfigValueKind.Double
+            "String" => ConfigValueKind.String,
+            _ => throw new InvalidOperationException($"Unexpected kind name: {expectedKindName}"),
+        };
+
+        Assert.Equal(expectedConfigKind, result.Kind);
+    }
+}

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarResolverTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarResolverTests.cs
@@ -122,6 +122,17 @@ public sealed class YamlScalarResolverTests
         Assert.Equal(expected, YamlScalarResolver.IsInfinity(value));
 
     [Theory]
+    [InlineData(".nan", true)]
+    [InlineData(".NaN", true)]
+    [InlineData(".NAN", true)]
+    [InlineData("+.nan", false)]
+    [InlineData("-.NAN", false)]
+    [InlineData("NaN", false)]
+    [InlineData(".inf", false)]
+    public void IsNaN_CoreSchemaForms_ReturnsExpected(string value, bool expected) =>
+        Assert.Equal(expected, YamlScalarResolver.IsNaN(value));
+
+    [Theory]
     [InlineData(YamlScalarResolver.StringTag, "1.0", "String")]
     [InlineData(YamlScalarResolver.NullTag, "null", "Null")]
     [InlineData(YamlScalarResolver.BooleanTag, "true", "Boolean")]

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarResolverTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/YamlScalarResolverTests.cs
@@ -6,7 +6,7 @@ using YamlDotNet.RepresentationModel;
 
 namespace OpenTelemetry.Configuration.Declarative.Tests;
 
-public sealed class Yaml12ScalarResolverTests
+public sealed class YamlScalarResolverTests
 {
     public static TheoryData<string, string> CoreSchemaExamples => new()
     {
@@ -74,7 +74,7 @@ public sealed class Yaml12ScalarResolverTests
     [MemberData(nameof(CoreSchemaExamples))]
     public void Resolve_ImplicitPlainScalar_MatchesYaml12CoreSchema(string value, string expected)
     {
-        var resolved = Yaml12ScalarResolver.Resolve(Scalar(value, ScalarStyle.Plain), value);
+        var resolved = YamlScalarResolver.Resolve(Scalar(value, ScalarStyle.Plain), value);
 
         Assert.Equal(expected, resolved.Kind.ToString());
         Assert.Equal(value, resolved.Value);
@@ -83,7 +83,7 @@ public sealed class Yaml12ScalarResolverTests
     [Theory]
     [MemberData(nameof(CoreSchemaStrings))]
     public void Resolve_ImplicitPlainString_MatchesYaml12CoreSchemaFallback(string value) =>
-        Assert.Equal(YamlScalarKind.String, Yaml12ScalarResolver.Resolve(Scalar(value), value).Kind);
+        Assert.Equal(YamlScalarKind.String, YamlScalarResolver.Resolve(Scalar(value), value).Kind);
 
     [Theory]
     [InlineData(ScalarStyle.SingleQuoted)]
@@ -94,7 +94,7 @@ public sealed class Yaml12ScalarResolverTests
     {
         foreach (var value in new[] { "null", "true", "42", "1.5", "value" })
         {
-            Assert.Equal(YamlScalarKind.String, Yaml12ScalarResolver.Resolve(Scalar(value, style), value).Kind);
+            Assert.Equal(YamlScalarKind.String, YamlScalarResolver.Resolve(Scalar(value, style), value).Kind);
         }
     }
 
@@ -107,37 +107,47 @@ public sealed class Yaml12ScalarResolverTests
     [InlineData("FALSE", false)]
     public void TryGetBoolean_CoreSchemaRepresentation_ReturnsValue(string value, bool expected)
     {
-        Assert.True(Yaml12ScalarResolver.TryGetBoolean(value, out var actual));
+        Assert.True(YamlScalarResolver.TryGetBoolean(value, out var actual));
         Assert.Equal(expected, actual);
     }
 
     [Theory]
-    [InlineData(Yaml12ScalarResolver.StringTag, "1.0", "String")]
-    [InlineData(Yaml12ScalarResolver.NullTag, "null", "Null")]
-    [InlineData(Yaml12ScalarResolver.BooleanTag, "true", "Boolean")]
-    [InlineData(Yaml12ScalarResolver.IntegerTag, "0x3A", "Integer")]
-    [InlineData(Yaml12ScalarResolver.FloatTag, "1", "Float")]
-    [InlineData(Yaml12ScalarResolver.FloatTag, "1.5", "Float")]
+    [InlineData(".inf", true)]
+    [InlineData("+.INF", true)]
+    [InlineData("-.Inf", true)]
+    [InlineData(".nan", false)]
+    [InlineData("Infinity", false)]
+    [InlineData("1.0", false)]
+    public void IsInfinity_CoreSchemaForms_ReturnsExpected(string value, bool expected) =>
+        Assert.Equal(expected, YamlScalarResolver.IsInfinity(value));
+
+    [Theory]
+    [InlineData(YamlScalarResolver.StringTag, "1.0", "String")]
+    [InlineData(YamlScalarResolver.NullTag, "null", "Null")]
+    [InlineData(YamlScalarResolver.BooleanTag, "true", "Boolean")]
+    [InlineData(YamlScalarResolver.IntegerTag, "0x3A", "Integer")]
+    [InlineData(YamlScalarResolver.FloatTag, "1", "Float")]
+    [InlineData(YamlScalarResolver.FloatTag, "1.5", "Float")]
     public void Resolve_ValidExplicitCoreTag_OverridesStyle(string tag, string value, string expected)
     {
-        var resolved = Yaml12ScalarResolver.Resolve(Tagged(value, tag, ScalarStyle.DoubleQuoted), value);
+        var resolved = YamlScalarResolver.Resolve(Tagged(value, tag, ScalarStyle.DoubleQuoted), value);
 
         Assert.Equal(expected, resolved.Kind.ToString());
     }
 
     [Theory]
-    [InlineData(Yaml12ScalarResolver.NullTag, "nil")]
-    [InlineData(Yaml12ScalarResolver.BooleanTag, "yes")]
-    [InlineData(Yaml12ScalarResolver.IntegerTag, "1.5")]
-    [InlineData(Yaml12ScalarResolver.FloatTag, "number")]
+    [InlineData(YamlScalarResolver.NullTag, "nil")]
+    [InlineData(YamlScalarResolver.BooleanTag, "yes")]
+    [InlineData(YamlScalarResolver.IntegerTag, "1.5")]
+    [InlineData(YamlScalarResolver.FloatTag, "number")]
     public void Resolve_InvalidExplicitCoreTagRepresentation_Throws(string tag, string value) =>
         Assert.Throws<DeclarativeConfigurationException>(() =>
-            Yaml12ScalarResolver.Resolve(Tagged(value, tag), value));
+            YamlScalarResolver.Resolve(Tagged(value, tag), value));
 
     [Fact]
     public void Resolve_UnsupportedExplicitTag_Throws() =>
         Assert.Throws<DeclarativeConfigurationException>(() =>
-            Yaml12ScalarResolver.Resolve(Tagged("value", "!custom"), "value"));
+            YamlScalarResolver.Resolve(Tagged("value", "!custom"), "value"));
 
     [Theory]
     [InlineData("1.0")]
@@ -147,7 +157,7 @@ public sealed class Yaml12ScalarResolverTests
     {
         var scalar = Tagged(value, "!");
 
-        Assert.Equal(YamlScalarKind.String, Yaml12ScalarResolver.Resolve(scalar, value).Kind);
+        Assert.Equal(YamlScalarKind.String, YamlScalarResolver.Resolve(scalar, value).Kind);
     }
 
     [Theory]
@@ -158,7 +168,7 @@ public sealed class Yaml12ScalarResolverTests
     {
         var scalar = Tagged(value, "?");
 
-        Assert.Equal(expected, Yaml12ScalarResolver.Resolve(scalar, value).Kind.ToString());
+        Assert.Equal(expected, YamlScalarResolver.Resolve(scalar, value).Kind.ToString());
     }
 
     private static YamlScalarNode Scalar(string value, ScalarStyle style = ScalarStyle.Plain) =>


### PR DESCRIPTION
Contributes to #7658

## Changes

This is a between phases PR to introduce YAML scalar conversion.

- Add `YamlScalarConverter` to convert resolved YAML 1.2 scalars into typed `ConfigValue` instances.
- Support null, string, boolean, decimal, hexadecimal, octal, floating-point, infinity, and NaN values.
- Represent integers outside the `long` range as unrepresentable integers.
- Preserve consistent floating-point behavior across target frameworks, including overflow and negative zero.
- Rename `Yaml12ScalarResolver` to `YamlScalarResolver`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~