### PR TITLE
[API] Skip exception formatting on unrecorded spans

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,9 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Improved `Baggage.SetBaggage` performance by avoiding a full copy when
-  the specified key already has the requested value.
-  ([#7660](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7660))
+* Avoid formatting exceptions and creating exception attributes when
+  `RecordException` is called on a span that is not recorded.
+  ([#7669](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7669))
 
 ## 1.17.0
 

--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -288,6 +288,11 @@ public class TelemetrySpan : IDisposable
             return this;
         }
 
+        if (!this.IsRecording)
+        {
+            return this;
+        }
+
         return this.RecordException(ex.GetType().Name, ex.Message, ex.ToInvariantString());
     }
 
@@ -300,6 +305,11 @@ public class TelemetrySpan : IDisposable
     /// <returns>The <see cref="TelemetrySpan"/> instance for chaining.</returns>
     public TelemetrySpan RecordException(string? type, string? message, string? stacktrace)
     {
+        if (!this.IsRecording)
+        {
+            return this;
+        }
+
         var attributes = new SpanAttributes();
 
         if (!string.IsNullOrWhiteSpace(type))

--- a/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
@@ -64,9 +64,6 @@ public class TelemetrySpanTests
         var exception = new ExceptionWithThrowingToString();
 
         telemetrySpan.RecordException(exception);
-
-        // placeholder assertion
-        Assert.Empty(activity.Events);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
@@ -55,6 +55,21 @@ public class TelemetrySpanTests
     }
 
     [Fact]
+    public void RecordExceptionDoesNotFormatExceptionWhenNotRecording()
+    {
+        using var activity = new Activity("exception-test");
+        activity.IsAllDataRequested = false;
+        using var telemetrySpan = new TelemetrySpan(activity);
+
+        var exception = new ExceptionWithThrowingToString();
+
+        telemetrySpan.RecordException(exception);
+
+        // placeholder assertion
+        Assert.Empty(activity.Events);
+    }
+
+    [Fact]
     public void ParentIds()
     {
         using var parentActivity = new Activity("parentOperation");
@@ -131,5 +146,26 @@ public class TelemetrySpanTests
         span.AddLink(context, null);
 
         Assert.Empty(activity.Links);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1064", Justification = "The private exception type is test-only and verifies RecordException does not format unrecorded exceptions.")]
+    private sealed class ExceptionWithThrowingToString : Exception
+    {
+        public ExceptionWithThrowingToString()
+        {
+        }
+
+        public ExceptionWithThrowingToString(string message)
+            : base(message)
+        {
+        }
+
+        public ExceptionWithThrowingToString(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1065", Justification = "The throwing override verifies RecordException does not format unrecorded exceptions.")]
+        public override string ToString() => throw new InvalidOperationException();
     }
 }


### PR DESCRIPTION
## Changes

Skips extracting and formatting exception fields, generating a stack trace, and creating span attributes when the span is not recorded.

| IsRecording = false | Before | After |
| --- | --- | --- |
| RecordException(Exception) with deep stack | 69.58 µs / 100,263 B | 0.80 ns / 0 B |
| RecordException(string, string, string) | 42.26 ns / 144 B | 0.98 ns / 0 B |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
