### PR TITLE
[SDK] Optimize `CircularBufferBuckets.Copy` to use bulk array copies

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -31,6 +31,9 @@ Notes](../../RELEASENOTES.md).
   exception is thrown by their constructor after resource creation.
   ([#7615](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7615))
 
+* `CircularBufferBuckets.Copy` optimized to use bulk array copies.
+  ([#7670](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7670))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
+++ b/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
@@ -281,9 +281,14 @@ internal sealed class CircularBufferBuckets
 
         if (this.trait != null)
         {
-            for (var i = 0; i < this.Size; ++i)
+            var size = this.Size;
+            var offset = this.ModuloIndex(this.Offset);
+            var first = Math.Min(size, this.Capacity - offset);
+            Array.Copy(this.trait, offset, dst, 0, first);
+
+            if (first < size)
             {
-                dst[i] = this[this.Offset + i];
+                Array.Copy(this.trait, 0, dst, first, size - first);
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Metrics/CircularBufferBucketsTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/CircularBufferBucketsTests.cs
@@ -352,6 +352,31 @@ public class CircularBufferBucketsTests
     }
 
     [Theory]
+    [InlineData(5, 0, 4)] // Contiguous storage (first == size).
+    [InlineData(5, 3, 4)] // Wrapped storage (first < size).
+    [InlineData(5, 3, 5)] // Full-capacity wrapped storage.
+    public void CopyHandlesContiguousAndWrappedStorage(int capacity, int start, int count)
+    {
+        var buckets = new CircularBufferBuckets(capacity);
+
+        for (var i = 0; i < count; i++)
+        {
+            buckets.TryIncrement(start + i, i + 1);
+        }
+
+        var copy = new long[capacity];
+        buckets.Copy(copy);
+
+        var expected = new long[capacity];
+        for (var i = 0; i < count; i++)
+        {
+            expected[i] = i + 1;
+        }
+
+        Assert.Equal(expected, copy);
+    }
+
+    [Theory]
     [InlineData(14, 10, 4)]
     [InlineData(10, 10, 0)]
     [InlineData(4, 10, 4)]


### PR DESCRIPTION
## Changes

Optimizes `CircularBufferBuckets.Copy` to use bulk array copies instead of computing indices per-item.

`Copy` populates a snapshot from the circular bucket storage on every histogram collection. It previously iterated over all array items, computing a modulo for each to translate the logical index into the ring position.

The loop has been replaced with at most two `Array.Copy` calls. On the first copy, the items from the offset to the end of the array are copied. If there were too many elements to fit (offset + size > capacity), the values wrap, and a second copy moves the remaining items to the start of the destination array.

160 bucket benchmark run:

| Scenario | Before | After | Improvement |
| --- | --- | --- | --- |
| CircularBufferBuckets.Copy, non-wrapped | 257 ns | 20.1 ns | ~12.8× |
| ExponentialHistogramBuckets.SnapshotBuckets, non-wrapped | 263 ns | 18.5 ns | ~14.2× |
| CircularBufferBuckets.Copy, wrapped | 249 ns | 21.8 ns | ~11.4× |
| ExponentialHistogramBuckets.SnapshotBuckets, wrapped | 241 ns | 19.8 ns | ~12.2× |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
