### PR TITLE
[SDK] Restore configured `MaxScale` after delta histogram collection

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -31,6 +31,9 @@ Notes](../../RELEASENOTES.md).
   exception is thrown by their constructor after resource creation.
   ([#7615](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7615))
 
+* Restored configured `MaxScale` after delta exponential histogram collection.
+  ([#7671](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7671))
+
 ## 1.17.0
 
 Released 2026-Jul-16

--- a/src/OpenTelemetry/Metrics/MetricPoint/Base2ExponentialBucketHistogram.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint/Base2ExponentialBucketHistogram.cs
@@ -26,6 +26,7 @@ internal sealed partial class Base2ExponentialBucketHistogram
 
     internal ExponentialHistogramData SnapshotExponentialHistogramData = new();
 
+    private readonly int maxScale;
     private int scale;
     private double scalingFactor; // 2 ^ scale / log(2)
 
@@ -90,6 +91,7 @@ internal sealed partial class Base2ExponentialBucketHistogram
         */
         Guard.ThrowIfOutOfRange(maxBuckets, min: 2);
 
+        this.maxScale = scale;
         this.Scale = scale;
         this.PositiveBuckets = new CircularBufferBuckets(maxBuckets);
         this.NegativeBuckets = new CircularBufferBuckets(maxBuckets);
@@ -213,7 +215,7 @@ internal sealed partial class Base2ExponentialBucketHistogram
             this.RunningMax = double.NegativeInfinity;
         }
 
-        this.Scale = Metric.DefaultExponentialHistogramMaxScale;
+        this.Scale = this.maxScale;
         this.RunningSum = 0;
         this.ZeroCount = 0;
         this.PositiveBuckets.Reset();
@@ -235,8 +237,9 @@ internal sealed partial class Base2ExponentialBucketHistogram
     {
         Debug.Assert(this.PositiveBuckets.Capacity == this.NegativeBuckets.Capacity, "Capacity of positive and negative buckets are not equal.");
 
-        return new Base2ExponentialBucketHistogram(this.PositiveBuckets.Capacity, this.SnapshotExponentialHistogramData.Scale)
+        return new Base2ExponentialBucketHistogram(this.PositiveBuckets.Capacity, this.maxScale)
         {
+            Scale = this.SnapshotExponentialHistogramData.Scale,
             SnapshotSum = this.SnapshotSum,
             SnapshotMin = this.SnapshotMin,
             SnapshotMax = this.SnapshotMax,

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
@@ -552,6 +552,39 @@ public class AggregatorTests
     }
 
     [Theory]
+    [InlineData(-5)]
+    [InlineData(5)]
+    internal void ExponentialMaxScaleConfigPersistsAfterDeltaSnapshot(int maxScale)
+    {
+        var streamConfiguration = new Base2ExponentialBucketHistogramConfiguration { MaxScale = maxScale };
+        var metricStreamIdentity = new MetricStreamIdentity(Instrument, streamConfiguration);
+
+        var aggregatorStore = new AggregatorStore(
+            metricStreamIdentity,
+            AggregationType.Base2ExponentialHistogram,
+            AggregationTemporality.Delta,
+            cardinalityLimit: 1024);
+
+        aggregatorStore.Update(10, []);
+        aggregatorStore.Snapshot();
+
+        var metricPoints = new List<MetricPoint>();
+        foreach (ref readonly var mp in aggregatorStore.GetMetricPoints())
+        {
+            metricPoints.Add(mp);
+        }
+
+        Assert.Single(metricPoints);
+        var metricPoint = metricPoints[0];
+        Assert.Equal(maxScale, metricPoint.GetExponentialHistogramData().Scale);
+
+        // A subsequent delta snapshot should retain the configured maximum scale.
+        metricPoint.TakeSnapshot(outputDelta: true);
+
+        Assert.Equal(maxScale, metricPoint.GetExponentialHistogramData().Scale);
+    }
+
+    [Theory]
 #pragma warning disable xUnit1045 // Avoid using TheoryData type arguments that might not be serializable
     [MemberData(nameof(HistogramBoundaryTestCase.HistogramInfinityBoundariesTestCases))]
 #pragma warning restore xUnit1045 // Avoid using TheoryData type arguments that might not be serializable

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
@@ -574,8 +574,7 @@ public class AggregatorTests
             metricPoints.Add(mp);
         }
 
-        Assert.Single(metricPoints);
-        var metricPoint = metricPoints[0];
+        var metricPoint = Assert.Single(metricPoints);
         Assert.Equal(maxScale, metricPoint.GetExponentialHistogramData().Scale);
 
         // A subsequent delta snapshot should retain the configured maximum scale.


### PR DESCRIPTION
## Changes

Restores configured `MaxScale` after a delta exponential-histogram is collected.

`MaxScale` is the maximum scale available to an exponential histogram stream, so resetting or copying the histogram should not discard that configuration, [per the metrics SDK spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#base2-exponential-bucket-histogram-aggregation).

This restores the config after collection and when copying a histogram, while preserving the reset behavior introduced in #6557.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
