### PR TITLE
[Repo] Add missing release tags

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,6 +8,7 @@ on:
         options:
         - core-
         - coreunstable-
+        - declarativeconfig-
         description: 'Release tag prefix'
         required: true
       version:

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -13,6 +13,7 @@ on:
     tags:
       - 'core-*'
       - 'coreunstable-*'
+      - 'declarativeconfig-*'
   schedule:
     - cron: '0 0 * * *' # Once a day at 00:00 UTC
 


### PR DESCRIPTION
## Changes

Add missing release tags to be able to release the `declarativeconfig-` tag prefix when the time comes.

I noticed it wasn't in the workflow dropdowns while doing the 1.18.0 release.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
