### PR TITLE
[API] Avoid empty baggage allocation

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -60,7 +60,23 @@ public readonly struct Baggage : IEquatable<Baggage>
     public static Baggage Current
     {
         get => RuntimeContextSlot.Get()?.Baggage ?? default;
-        set => EnsureBaggageHolder().Baggage = value;
+        set
+        {
+            if (value == default)
+            {
+                // Avoid allocating a new BaggageHolder if nothing is being set
+                var existingHolder = RuntimeContextSlot.Get();
+                if (existingHolder == null)
+                {
+                    return;
+                }
+
+                existingHolder.Baggage = value;
+                return;
+            }
+
+            EnsureBaggageHolder().Baggage = value;
+        }
     }
 
     /// <summary>

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -185,6 +185,43 @@ public class BaggageTests
     }
 
     [Fact]
+    public async Task SetCurrentToDefaultInNewContextDoesNotThrowTest()
+    {
+        Task task;
+        using (ExecutionContext.SuppressFlow())
+        {
+            task = Task.Run(() =>
+            {
+                Baggage.Current = default;
+
+                Assert.Equal(default, Baggage.Current);
+            });
+        }
+
+        await task;
+    }
+
+    [Fact]
+    public async Task SetCurrentToDefaultClearsExistingBaggageTest()
+    {
+        Task task;
+        using (ExecutionContext.SuppressFlow())
+        {
+            task = Task.Run(() =>
+            {
+                Baggage.SetBaggage(K1, V1);
+                Assert.Equal(1, Baggage.Current.Count);
+
+                Baggage.Current = default;
+
+                Assert.Equal(0, Baggage.Current.Count);
+            });
+        }
+
+        await task;
+    }
+
+    [Fact]
     public void ContextFlowTest()
     {
         var baggage = Baggage.SetBaggage(K1, V1);


### PR DESCRIPTION
## Changes

Avoid allocating a slot if no baggage is being set.

Found by investigating profile allocations in an application after upgrading to 1.18.0.

| Benchmark | Before Mean | After Mean | Delta Mean | Before Alloc | After Alloc |
|:--|--:|--:|--:|--:|--:|
| SetDefaultBaggageInNewContext | 1178 ns | 747.1 ns | -37% | 168 B | 72 B |

<details>

<summary>Benchmark</summary>

```csharp
using BenchmarkDotNet.Attributes;
using OpenTelemetry;

namespace Benchmarks.Context;

[MemoryDiagnoser(false)]
public class BaggageCurrentBenchmarks
{
    [Benchmark]
    public void SetDefaultBaggageInNewContext()
    {
        using (ExecutionContext.SuppressFlow())
        {
            Task.Run(static () => Baggage.Current = default).GetAwaiter().GetResult();
        }
    }
}
```

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
