### PR TITLE
[OpenTelemetry] Avoid enumerator allocations

### DIFF
--- a/src/OpenTelemetry/Logs/LogRecordScope.cs
+++ b/src/OpenTelemetry/Logs/LogRecordScope.cs
@@ -32,7 +32,8 @@ public readonly struct LogRecordScope
     /// </summary>
     public struct Enumerator : IEnumerator<KeyValuePair<string, object?>>
     {
-        private readonly IReadOnlyList<KeyValuePair<string, object?>> scope;
+        private readonly IReadOnlyList<KeyValuePair<string, object?>>? scope;
+        private readonly IEnumerator<KeyValuePair<string, object?>>? enumerator;
         private int position;
 
         /// <summary>
@@ -44,14 +45,17 @@ public readonly struct LogRecordScope
             if (scope is IReadOnlyList<KeyValuePair<string, object?>> scopeList)
             {
                 this.scope = scopeList;
+                this.enumerator = null;
             }
             else if (scope is IEnumerable<KeyValuePair<string, object?>> scopeEnumerable)
             {
-                this.scope = [.. scopeEnumerable];
+                this.scope = null;
+                this.enumerator = scopeEnumerable.GetEnumerator();
             }
             else
             {
                 this.scope = [new KeyValuePair<string, object?>(string.Empty, scope)];
+                this.enumerator = null;
             }
 
             this.position = 0;
@@ -66,7 +70,18 @@ public readonly struct LogRecordScope
         /// <inheritdoc/>
         public bool MoveNext()
         {
-            if (this.position < this.scope.Count)
+            if (this.enumerator != null)
+            {
+                if (this.enumerator.MoveNext())
+                {
+                    this.Current = this.enumerator.Current;
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (this.scope != null && this.position < this.scope.Count)
             {
                 this.Current = this.scope[this.position++];
                 return true;
@@ -77,8 +92,7 @@ public readonly struct LogRecordScope
 
         /// <inheritdoc/>
         public readonly void Dispose()
-        {
-        }
+            => this.enumerator?.Dispose();
 
         /// <inheritdoc/>
         public void Reset()

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -471,6 +471,28 @@ internal sealed class TracerProviderSdk : TracerProvider
         return 1.0;
     }
 
+    private static void ApplySamplingAttributes<TState>(
+        IEnumerable<KeyValuePair<string, object>> attributes,
+        TState state,
+        Action<TState, string, object> setTag)
+    {
+        if (attributes is IReadOnlyList<KeyValuePair<string, object>> attributeList)
+        {
+            for (var i = 0; i < attributeList.Count; i++)
+            {
+                var att = attributeList[i];
+                setTag(state, att.Key, att.Value);
+            }
+        }
+        else
+        {
+            foreach (var att in attributes)
+            {
+                setTag(state, att.Key, att.Value);
+            }
+        }
+    }
+
     private static ActivitySamplingResult ComputeActivitySamplingResult(
         ref ActivityCreationOptions<ActivityContext> options,
         Sampler sampler)
@@ -501,21 +523,8 @@ internal sealed class TracerProviderSdk : TracerProvider
         {
             if (samplingResult.AttributesOrNull is { } attributes)
             {
-                if (attributes is IReadOnlyList<KeyValuePair<string, object>> attributeList)
-                {
-                    for (var i = 0; i < attributeList.Count; i++)
-                    {
-                        var att = attributeList[i];
-                        options.SamplingTags[att.Key] = att.Value;
-                    }
-                }
-                else
-                {
-                    foreach (var att in attributes)
-                    {
-                        options.SamplingTags[att.Key] = att.Value;
-                    }
-                }
+                var tags = options.SamplingTags;
+                ApplySamplingAttributes(attributes, tags, static (tags, key, value) => tags[key] = value);
             }
         }
 
@@ -658,10 +667,7 @@ internal sealed class TracerProviderSdk : TracerProvider
         {
             if (samplingResult.AttributesOrNull is { } attributes)
             {
-                foreach (var att in attributes)
-                {
-                    activity.SetTag(att.Key, att.Value);
-                }
+                ApplySamplingAttributes(attributes, activity, static (activity, key, value) => activity.SetTag(key, value));
             }
         }
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -501,9 +501,20 @@ internal sealed class TracerProviderSdk : TracerProvider
         {
             if (samplingResult.AttributesOrNull is { } attributes)
             {
-                foreach (var att in attributes)
+                if (attributes is IReadOnlyList<KeyValuePair<string, object>> attributeList)
                 {
-                    options.SamplingTags[att.Key] = att.Value;
+                    for (var i = 0; i < attributeList.Count; i++)
+                    {
+                        var att = attributeList[i];
+                        options.SamplingTags[att.Key] = att.Value;
+                    }
+                }
+                else
+                {
+                    foreach (var att in attributes)
+                    {
+                        options.SamplingTags[att.Key] = att.Value;
+                    }
                 }
             }
         }

--- a/test/OpenTelemetry.Tests/Logs/LogRecordScopeTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordScopeTests.cs
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections;
+using OpenTelemetry.Logs;
+
+namespace OpenTelemetry.Tests.Logs;
+
+public static class LogRecordScopeTests
+{
+    [Fact]
+    public static void EnumeratorUsesDelegatedEnumeratorForNonReadOnlyListEnumerableScopeTest()
+    {
+        var innerScope = new Dictionary<string, object?>
+        {
+            ["item1"] = "value1",
+            ["item2"] = "value2",
+        };
+
+        var trackingScope = new DisposeTrackingEnumerable(innerScope);
+
+        var items = new List<KeyValuePair<string, object?>>();
+
+        using (var enumerator = new LogRecordScope.Enumerator(trackingScope))
+        {
+            while (enumerator.MoveNext())
+            {
+                items.Add(enumerator.Current);
+            }
+        }
+
+        Assert.Equal(2, items.Count);
+        Assert.Contains(new KeyValuePair<string, object?>("item1", "value1"), items);
+        Assert.Contains(new KeyValuePair<string, object?>("item2", "value2"), items);
+
+        Assert.Equal(1, trackingScope.EnumeratorsCreated);
+        Assert.True(trackingScope.LastEnumeratorDisposed);
+    }
+
+    private sealed class DisposeTrackingEnumerable(IEnumerable<KeyValuePair<string, object?>> inner)
+        : IEnumerable<KeyValuePair<string, object?>>
+    {
+        public int EnumeratorsCreated { get; private set; }
+
+        public bool LastEnumeratorDisposed { get; private set; }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            this.EnumeratorsCreated++;
+            this.LastEnumeratorDisposed = false;
+            return new DisposeTrackingEnumerator(inner.GetEnumerator(), () => this.LastEnumeratorDisposed = true);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+
+    private sealed class DisposeTrackingEnumerator(IEnumerator<KeyValuePair<string, object?>> inner, Action onDispose)
+        : IEnumerator<KeyValuePair<string, object?>>
+    {
+        public KeyValuePair<string, object?> Current => inner.Current;
+
+        object IEnumerator.Current => this.Current;
+
+        public bool MoveNext() => inner.MoveNext();
+
+        public void Reset() => inner.Reset();
+
+        public void Dispose()
+        {
+            onDispose();
+            inner.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Avoid allocating array when enumerating log scopes.
- Avoid allocating enumerator when sampling attributes are a list.

Found by investigating profile allocations in an application after upgrading to 1.18.0.

### SamplingResultBenchmarks:

| Method | Before (Allocated) | After (Allocated) | Difference | % Reduction |
|---|---:|---:|---:|---:|
| NoAttributes | 328 B | 328 B | 0 B | 0% |
| WithAttributeArray | 672 B | 640 B | -32 B | 4.8% |
| WithAttributeList | 752 B | 720 B | -32 B | 4.3% |
| Drop | 328 B | 328 B | 0 B | 0% |
| ParentBasedSampled | 328 B | 328 B | 0 B | 0% |

### Scope Benchmarks

| Benchmark | Before Mean | After Mean | Delta Mean | Before Alloc | After Alloc |
|:--|--:|--:|--:|--:|--:|
| ForEachScope | 35.84 ns | 27.16 ns | -24% | 144 B | 56 B |

<details>

<summary>Scope Benchmarks</summary>

```csharp
using BenchmarkDotNet.Attributes;
using Microsoft.Extensions.Logging;
using OpenTelemetry.Logs;

namespace Benchmarks.Logs;

[MemoryDiagnoser]
public class LogScopeDictionaryBenchmarks
{
    private readonly LoggerExternalScopeProvider scopeProvider = new();

    private readonly Action<LogRecordScope, object> callback = (scope, state) =>
    {
        foreach (var scopeItem in scope)
        {
            _ = scopeItem.Key;
            _ = scopeItem.Value;
        }
    };

    private readonly LogRecord logRecord;

    public LogScopeDictionaryBenchmarks()
    {
        this.scopeProvider.Push(new Dictionary<string, object>
        {
            ["RequestId"] = "abc123",
            ["UserId"] = 42,
            ["TenantId"] = Guid.NewGuid(),
            ["StartedAt"] = DateTime.UtcNow,
        });

        this.logRecord = new LogRecord(
            this.scopeProvider,
            DateTime.UtcNow,
            "Benchmark",
            LogLevel.Information,
            0,
            "Message",
            null,
            null,
            null);
    }

    [Benchmark]
    public void ForEachScope()
    {
        this.logRecord.ForEachScope(this.callback!, null);
    }
}
```

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
