### PR TITLE
[OTLP] Avoid heap allocations in TagWriter

### DIFF
--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -92,23 +92,6 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case float f:
                 this.WriteFloatingPointTag(ref state, key, f);
                 break;
-#if NET
-            case DateTime dt:
-                this.WriteSpanFormattableTag(ref state, key, dt, stackalloc char[64], tagValueMaxLength);
-                break;
-            case DateTimeOffset dto:
-                this.WriteSpanFormattableTag(ref state, key, dto, stackalloc char[64], tagValueMaxLength);
-                break;
-            case TimeSpan ts:
-                this.WriteSpanFormattableTag(ref state, key, ts, stackalloc char[32], tagValueMaxLength);
-                break;
-            case Guid g:
-                this.WriteSpanFormattableTag(ref state, key, g, stackalloc char[36], tagValueMaxLength);
-                break;
-            case decimal m:
-                this.WriteSpanFormattableTag(ref state, key, m, stackalloc char[32], tagValueMaxLength);
-                break;
-#endif
             case IEnumerable<KeyValuePair<string, object?>> kvList:
                 if (recursionDepth >= MaxRecursionDepth)
                 {
@@ -183,12 +166,31 @@ internal abstract class TagWriter<TTagState, TArrayState>
 
                 break;
 
+#if NET
+            // Buffer lengths below are sized for the invariant-culture's default-format ("G") output
+            case DateTime dt:
+                this.WriteSpanFormattableTag(ref state, key, dt, bufferLength: 64, tagValueMaxLength);
+                break;
+            case DateTimeOffset dto:
+                this.WriteSpanFormattableTag(ref state, key, dto, bufferLength: 64, tagValueMaxLength);
+                break;
+            case TimeSpan ts:
+                this.WriteSpanFormattableTag(ref state, key, ts, bufferLength: 32, tagValueMaxLength);
+                break;
+            case Guid g:
+                this.WriteSpanFormattableTag(ref state, key, g, bufferLength: 36, tagValueMaxLength);
+                break;
+            case decimal m:
+                this.WriteSpanFormattableTag(ref state, key, m, bufferLength: 32, tagValueMaxLength);
+                break;
+#endif
+
             // All other types are converted to strings including the following
             // built-in value types:
             // case nint:    Pointer type.
             // case nuint:   Pointer type.
             // case ulong:   May throw an exception on overflow.
-            // case decimal: Converting to double produces rounding errors.
+            // case decimal: Converting to double produces rounding errors (where ISpanFormattable not available).
             default:
                 try
                 {
@@ -251,9 +253,10 @@ internal abstract class TagWriter<TTagState, TArrayState>
     }
 
 #if NET
-    private void WriteSpanFormattableTag<T>(ref TTagState state, string key, T value, Span<char> destination, int? tagValueMaxLength)
+    private void WriteSpanFormattableTag<T>(ref TTagState state, string key, T value, int bufferLength, int? tagValueMaxLength)
         where T : ISpanFormattable
     {
+        Span<char> destination = stackalloc char[bufferLength];
         if (value.TryFormat(destination, out var charsWritten, format: default, CultureInfo.InvariantCulture))
         {
             this.WriteStringTag(ref state, key, TruncateString(destination[..charsWritten], tagValueMaxLength));

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -94,19 +94,19 @@ internal abstract class TagWriter<TTagState, TArrayState>
                 break;
 #if NET
             case DateTime dt:
-                this.WriteSpanFormattableTag(ref state, key, dt, stackalloc char[64]);
+                this.WriteSpanFormattableTag(ref state, key, dt, stackalloc char[64], tagValueMaxLength);
                 break;
             case DateTimeOffset dto:
-                this.WriteSpanFormattableTag(ref state, key, dto, stackalloc char[64]);
+                this.WriteSpanFormattableTag(ref state, key, dto, stackalloc char[64], tagValueMaxLength);
                 break;
             case TimeSpan ts:
-                this.WriteSpanFormattableTag(ref state, key, ts, stackalloc char[32]);
+                this.WriteSpanFormattableTag(ref state, key, ts, stackalloc char[32], tagValueMaxLength);
                 break;
             case Guid g:
-                this.WriteSpanFormattableTag(ref state, key, g, stackalloc char[36]);
+                this.WriteSpanFormattableTag(ref state, key, g, stackalloc char[36], tagValueMaxLength);
                 break;
             case decimal m:
-                this.WriteSpanFormattableTag(ref state, key, m, stackalloc char[32]);
+                this.WriteSpanFormattableTag(ref state, key, m, stackalloc char[32], tagValueMaxLength);
                 break;
 #endif
             case IEnumerable<KeyValuePair<string, object?>> kvList:
@@ -251,16 +251,17 @@ internal abstract class TagWriter<TTagState, TArrayState>
     }
 
 #if NET
-    private void WriteSpanFormattableTag<T>(ref TTagState state, string key, T value, Span<char> destination)
+    private void WriteSpanFormattableTag<T>(ref TTagState state, string key, T value, Span<char> destination, int? tagValueMaxLength)
         where T : ISpanFormattable
     {
         if (value.TryFormat(destination, out var charsWritten, format: default, CultureInfo.InvariantCulture))
         {
-            this.WriteStringTag(ref state, key, destination[..charsWritten]);
+            this.WriteStringTag(ref state, key, TruncateString(destination[..charsWritten], tagValueMaxLength));
         }
         else
         {
-            this.WriteStringTag(ref state, key, value.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty);
+            var stringValue = value.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty;
+            this.WriteStringTag(ref state, key, TruncateString(stringValue.AsSpan(), tagValueMaxLength));
         }
     }
 #endif

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -92,6 +92,11 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case float f:
                 this.WriteFloatingPointTag(ref state, key, f);
                 break;
+#if NET
+            case ulong ul:
+                this.WriteSpanFormattableTag(ref state, key, ul, bufferLength: 20, tagValueMaxLength);
+                break;
+#endif
             case IEnumerable<KeyValuePair<string, object?>> kvList:
                 if (recursionDepth >= MaxRecursionDepth)
                 {
@@ -189,7 +194,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
             // built-in value types:
             // case nint:    Pointer type.
             // case nuint:   Pointer type.
-            // case ulong:   May throw an exception on overflow.
+            // case ulong:   May throw an exception on overflow (where ISpanFormattable not available).
             // case decimal: Converting to double produces rounding errors (where ISpanFormattable not available).
             default:
                 try

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -92,6 +92,23 @@ internal abstract class TagWriter<TTagState, TArrayState>
             case float f:
                 this.WriteFloatingPointTag(ref state, key, f);
                 break;
+#if NET
+            case DateTime dt:
+                this.WriteSpanFormattableTag(ref state, key, dt, stackalloc char[64]);
+                break;
+            case DateTimeOffset dto:
+                this.WriteSpanFormattableTag(ref state, key, dto, stackalloc char[64]);
+                break;
+            case TimeSpan ts:
+                this.WriteSpanFormattableTag(ref state, key, ts, stackalloc char[32]);
+                break;
+            case Guid g:
+                this.WriteSpanFormattableTag(ref state, key, g, stackalloc char[36]);
+                break;
+            case decimal m:
+                this.WriteSpanFormattableTag(ref state, key, m, stackalloc char[32]);
+                break;
+#endif
             case IEnumerable<KeyValuePair<string, object?>> kvList:
                 if (recursionDepth >= MaxRecursionDepth)
                 {
@@ -232,6 +249,21 @@ internal abstract class TagWriter<TTagState, TArrayState>
         Span<char> destination = [value];
         this.WriteStringTag(ref state, key, destination);
     }
+
+#if NET
+    private void WriteSpanFormattableTag<T>(ref TTagState state, string key, T value, Span<char> destination)
+        where T : ISpanFormattable
+    {
+        if (value.TryFormat(destination, out var charsWritten, format: default, CultureInfo.InvariantCulture))
+        {
+            this.WriteStringTag(ref state, key, destination[..charsWritten]);
+        }
+        else
+        {
+            this.WriteStringTag(ref state, key, value.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+    }
+#endif
 
     private void WriteCharValue(ref TArrayState state, char value)
     {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
@@ -144,6 +144,7 @@ public class OtlpAttributeTests
     [Theory]
     [InlineData(char.MaxValue)]
     [InlineData("string")]
+    [InlineData(ulong.MaxValue)]
     public void StringTypesSupported(object value)
     {
         var kvp = new KeyValuePair<string, object?>("key", value);
@@ -225,8 +226,13 @@ public class OtlpAttributeTests
     {
         var testValues = new object[]
         {
+#if NET
+            nint.MaxValue,
+            nuint.MaxValue,
+#else
             (nint)int.MaxValue,
             (nuint)uint.MaxValue,
+#endif
             decimal.MaxValue,
             new(),
         };
@@ -281,6 +287,7 @@ public class OtlpAttributeTests
         AssertTruncated(TimeSpan.FromMilliseconds(123456.789), tagValueMaxLength);
         AssertTruncated(Guid.NewGuid(), tagValueMaxLength);
         AssertTruncated(12345.6789m, tagValueMaxLength);
+        AssertTruncated(ulong.MaxValue, tagValueMaxLength);
 
         static void AssertTruncated<T>(T value, int tagValueMaxLength)
             where T : notnull

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
@@ -271,6 +271,34 @@ public class OtlpAttributeTests
         }
     }
 
+    [Theory]
+    [InlineData(4)]
+    [InlineData(100)]
+    public void ScalarSpanFormattableTypesRespectTagValueMaxLength(int tagValueMaxLength)
+    {
+        AssertTruncated(new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc), tagValueMaxLength);
+        AssertTruncated(new DateTimeOffset(2024, 5, 6, 7, 8, 9, TimeSpan.FromHours(2)), tagValueMaxLength);
+        AssertTruncated(TimeSpan.FromMilliseconds(123456.789), tagValueMaxLength);
+        AssertTruncated(Guid.NewGuid(), tagValueMaxLength);
+        AssertTruncated(12345.6789m, tagValueMaxLength);
+
+        static void AssertTruncated<T>(T value, int tagValueMaxLength)
+            where T : notnull
+        {
+            var expected = Convert.ToString(value, CultureInfo.InvariantCulture)!;
+            var kvp = new KeyValuePair<string, object?>("key", value);
+
+            Assert.True(TryTransformTag(kvp, out var attribute, tagValueMaxLength));
+            Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.StringValue, attribute.Value.ValueCase);
+
+            var expectedValue = expected.Length > tagValueMaxLength
+                ? expected.Substring(0, tagValueMaxLength)
+                : expected;
+
+            Assert.Equal(expectedValue, attribute.Value.StringValue);
+        }
+    }
+
     [Fact]
     public void ExceptionInToStringIsCaught()
     {
@@ -353,7 +381,7 @@ public class OtlpAttributeTests
         }
     }
 
-    private static bool TryTransformTag(KeyValuePair<string, object?> tag, [NotNullWhen(true)] out OtlpCommon.KeyValue? attribute)
+    private static bool TryTransformTag(KeyValuePair<string, object?> tag, [NotNullWhen(true)] out OtlpCommon.KeyValue? attribute, int? tagValueMaxLength = null)
     {
         var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
@@ -361,7 +389,7 @@ public class OtlpAttributeTests
             WritePosition = 0,
         };
 
-        if (ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag))
+        if (ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag, tagValueMaxLength))
         {
             // Deserialize the ResourceSpans and validate the attributes.
             using var stream = new MemoryStream(otlpTagWriterState.Buffer, 0, otlpTagWriterState.WritePosition);


### PR DESCRIPTION
## Changes

Avoid heap allocations when writing tags by specialising for more types in .NET by using `ISpanFormattable`.

Found by investigating profile allocations in an application after upgrading to 1.18.0.

| Benchmark | Before Mean | After Mean | Delta Mean | Before Alloc | After Alloc |
|:--|--:|--:|--:|--:|--:|
| `WriteDateTime` | 58.53 ns | 27.13 ns | -54% | 88 B | 24 B |
| `WriteDateTimeOffset` | 50.32 ns | 30.59 ns | -39% | 112 B | 32 B |
| `WriteTimeSpan` | 35.75 ns | 29.07 ns | -19% | 80 B | 24 B |
| `WriteGuid` | 29.23 ns | 35.78 ns (noisy/bimodal) | +22% (noisy) | 128 B | 32 B |
| `WriteDecimal` | 46.51 ns | 58.66 ns (noisy/bimodal) | +26% (noisy) | 80 B | 32 B |

<details>

<summary>Benchmarks</summary>

```csharp
extern alias OpenTelemetryProtocol;

using BenchmarkDotNet.Attributes;
using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;

namespace Benchmarks.Exporter;

[MemoryDiagnoser]
public class TagWriterScalarBenchmarks
{
    private readonly byte[] buffer = new byte[4 * 1024];
    private readonly DateTime dateTimeValue = new(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc);
    private readonly DateTimeOffset dateTimeOffsetValue = new(2024, 5, 6, 7, 8, 9, TimeSpan.FromHours(2));
    private readonly TimeSpan timeSpanValue = TimeSpan.FromMilliseconds(123456.789);
    private readonly Guid guidValue = Guid.NewGuid();
    private readonly decimal decimalValue = 12345.6789m;

    [Benchmark]
    public int WriteDateTime()
    {
        var state = new ProtobufOtlpTagWriter.OtlpTagWriterState { Buffer = this.buffer };
        ProtobufOtlpTagWriter.WriteKeyValue(ref state, 1, "key", this.dateTimeValue);
        return state.WritePosition;
    }

    [Benchmark]
    public int WriteDateTimeOffset()
    {
        var state = new ProtobufOtlpTagWriter.OtlpTagWriterState { Buffer = this.buffer };
        ProtobufOtlpTagWriter.WriteKeyValue(ref state, 1, "key", this.dateTimeOffsetValue);
        return state.WritePosition;
    }

    [Benchmark]
    public int WriteTimeSpan()
    {
        var state = new ProtobufOtlpTagWriter.OtlpTagWriterState { Buffer = this.buffer };
        ProtobufOtlpTagWriter.WriteKeyValue(ref state, 1, "key", this.timeSpanValue);
        return state.WritePosition;
    }

    [Benchmark]
    public int WriteGuid()
    {
        var state = new ProtobufOtlpTagWriter.OtlpTagWriterState { Buffer = this.buffer };
        ProtobufOtlpTagWriter.WriteKeyValue(ref state, 1, "key", this.guidValue);
        return state.WritePosition;
    }

    [Benchmark]
    public int WriteDecimal()
    {
        var state = new ProtobufOtlpTagWriter.OtlpTagWriterState { Buffer = this.buffer };
        ProtobufOtlpTagWriter.WriteKeyValue(ref state, 1, "key", this.decimalValue);
        return state.WritePosition;
    }
}
```

</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
