### PR TITLE
[Exporter.Prometheus] Reduce allocations

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
@@ -515,6 +515,12 @@ internal abstract class TextFormatSerializer
     internal static int WriteLabelValue(byte[] buffer, int cursor, string value)
         => WriteEscapedString(buffer, cursor, value, escapeQuotationMarks: true);
 
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int WriteLabelValue(byte[] buffer, int cursor, ReadOnlySpan<char> value)
+        => WriteEscapedUtf8String(buffer, cursor, value, LabelValueEscapeChars);
+#endif
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int WriteLabelValue(byte[] buffer, int cursor, object? value)
     {
@@ -565,6 +571,20 @@ internal abstract class TextFormatSerializer
                 return AdvanceCursorOrThrow(result, cursor, bytesWritten);
 #else
                 return WriteLabelValue(buffer, cursor, decimalValue.ToString(CultureInfo.InvariantCulture));
+#endif
+
+#if NET
+            case DateTime dateTimeValue:
+                return WriteSpanFormattableLabelValue(buffer, cursor, dateTimeValue, stackalloc char[64]);
+
+            case DateTimeOffset dateTimeOffsetValue:
+                return WriteSpanFormattableLabelValue(buffer, cursor, dateTimeOffsetValue, stackalloc char[64]);
+
+            case TimeSpan timeSpanValue:
+                return WriteSpanFormattableLabelValue(buffer, cursor, timeSpanValue, stackalloc char[32]);
+
+            case Guid guidValue:
+                return WriteSpanFormattableLabelValue(buffer, cursor, guidValue, stackalloc char[36]);
 #endif
 
             case IFormattable formattableValue:
@@ -1995,6 +2015,17 @@ internal abstract class TextFormatSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int AdvanceCursorOrThrow(bool result, int cursor, int bytesWritten) =>
         result ? cursor + bytesWritten : throw new ArgumentException("Destination buffer too small.");
+
+    private static int WriteSpanFormattableLabelValue<T>(byte[] buffer, int cursor, T value, Span<char> destination)
+        where T : ISpanFormattable
+    {
+        if (value.TryFormat(destination, out var charsWritten, format: default, CultureInfo.InvariantCulture))
+        {
+            return WriteLabelValue(buffer, cursor, destination[..charsWritten]);
+        }
+
+        return WriteLabelValue(buffer, cursor, value.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty);
+    }
 #endif
 
     private static string GetCanonicalLabelValueString(double value)

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -98,6 +98,9 @@ public sealed partial class PrometheusSerializerTests
         { 1.5d, "1.5" },
         { new Guid("12345678-1234-1234-1234-1234567890ab"), "12345678-1234-1234-1234-1234567890ab" },
         { new Version(1, 2, 3), "1.2.3" },
+        { new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc), "05/06/2024 07:08:09" },
+        { new DateTimeOffset(2024, 5, 6, 7, 8, 9, TimeSpan.FromHours(2)), "05/06/2024 07:08:09 +02:00" },
+        { TimeSpan.FromTicks(1234567890), "00:02:03.4567890" },
     };
 
     [Fact]


### PR DESCRIPTION
## Changes

Reduce allocations when writing tags when targeting .NET for some common types that implement `ISpanFormattable`, similar to #7682.

Results from some throw-away benchmarks of the changes:

| Method | Alloc Before | Alloc After | Alloc Δ | Mean Before | Mean After |
|---|---:|---:|---:|---:|---:|
| WriteDateTime | 88 B | 24 B | -73% | 32.6 ns | 26.9 ns |
| WriteDateTimeOffset | 112 B | 32 B | -71% | 35.6 ns | 30.4 ns |
| WriteTimeSpan | 56 B | 24 B | -57% | 28.4 ns | 27.1 ns |
| WriteGuid | 128 B | 32 B | -75% | 29.0 ns | 42.6 ns (noisy) |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
