### PR TITLE
[OTLP] Fix instrumentation scope grouping

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -11,6 +11,11 @@ Notes](../../RELEASENOTES.md).
   now be dropped.
   ([#7688](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7688))
 
+* Fixed traces and metrics with the same instrumentation scope name but
+  different versions, schema URLs, or attributes being exported under the same
+  OTLP scope.
+  ([#7687](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7687))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
@@ -24,7 +24,7 @@ internal static class ProtobufOtlpMetricSerializer
     [ThreadStatic]
     private static Stack<List<Metric>>? metricListPool;
     [ThreadStatic]
-    private static Dictionary<InstrumentationScopeMetric, List<Metric>>? scopeMetricsList;
+    private static Dictionary<InstrumentationScope, List<Metric>>? scopeMetricsList;
 
     private delegate int WriteExemplarFunc(byte[] buffer, int writePosition, in Exemplar exemplar);
 
@@ -36,7 +36,7 @@ internal static class ProtobufOtlpMetricSerializer
         int maxBufferSize = ProtobufSerializer.MaxBufferSize)
     {
         metricListPool ??= [];
-        scopeMetricsList ??= new(InstrumentationScopeMetricComparer.Instance);
+        scopeMetricsList ??= [];
 
         // Note: The grouped batch is held in thread-static state, so it has to be
         // released even when serialization fails. TryWriteResourceMetrics rethrows
@@ -46,7 +46,7 @@ internal static class ProtobufOtlpMetricSerializer
         {
             foreach (var metric in batch)
             {
-                var instrumentationScope = new InstrumentationScopeMetric(metric);
+                var instrumentationScope = new InstrumentationScope(metric);
                 if (!scopeMetricsList.TryGetValue(instrumentationScope, out var metrics))
                 {
                     metrics = metricListPool.Count > 0 ? metricListPool.Pop() : [];
@@ -70,7 +70,7 @@ internal static class ProtobufOtlpMetricSerializer
         ref byte[] buffer,
         int writePosition,
         Resources.Resource? resource,
-        Dictionary<InstrumentationScopeMetric, List<Metric>> scopeMetrics,
+        Dictionary<InstrumentationScope, List<Metric>> scopeMetrics,
         int maxBufferSize = ProtobufSerializer.MaxBufferSize)
     {
         while (true)
@@ -117,7 +117,7 @@ internal static class ProtobufOtlpMetricSerializer
         }
     }
 
-    private static int WriteResourceMetrics(byte[] buffer, int writePosition, Resources.Resource? resource, Dictionary<InstrumentationScopeMetric, List<Metric>> scopeMetrics)
+    private static int WriteResourceMetrics(byte[] buffer, int writePosition, Resources.Resource? resource, Dictionary<InstrumentationScope, List<Metric>> scopeMetrics)
     {
         writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, writePosition, resource);
         writePosition = WriteScopeMetrics(buffer, writePosition, scopeMetrics);
@@ -130,7 +130,7 @@ internal static class ProtobufOtlpMetricSerializer
         return writePosition;
     }
 
-    private static int WriteScopeMetrics(byte[] buffer, int writePosition, Dictionary<InstrumentationScopeMetric, List<Metric>> scopeMetrics)
+    private static int WriteScopeMetrics(byte[] buffer, int writePosition, Dictionary<InstrumentationScope, List<Metric>> scopeMetrics)
     {
         if (scopeMetrics != null)
         {
@@ -140,7 +140,7 @@ internal static class ProtobufOtlpMetricSerializer
                 var resourceMetricsScopeMetricsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
-                writePosition = WriteScopeMetric(buffer, writePosition, entry.Key.Metric, entry.Value);
+                writePosition = WriteScopeMetric(buffer, writePosition, entry.Key, entry.Value);
 
                 ProtobufSerializer.WriteReservedLength(buffer, resourceMetricsScopeMetricsLengthPosition, writePosition - (resourceMetricsScopeMetricsLengthPosition + ReserveSizeForLength));
             }
@@ -149,18 +149,18 @@ internal static class ProtobufOtlpMetricSerializer
         return writePosition;
     }
 
-    private static int WriteScopeMetric(byte[] buffer, int writePosition, Metric scopeMetric, List<Metric> metrics)
+    private static int WriteScopeMetric(byte[] buffer, int writePosition, InstrumentationScope instrumentationScope, List<Metric> metrics)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Scope, ProtobufWireType.LEN);
         var instrumentationScopeLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         Debug.Assert(metrics.Count > 0, "Metrics collection is not expected to be empty.");
-        var meterVersion = scopeMetric.MeterVersion;
-        var meterTags = scopeMetric.MeterTags;
-        var meterSchemaUrl = scopeMetric.MeterSchemaUrl;
+        var meterVersion = instrumentationScope.Version;
+        var meterTags = instrumentationScope.Tags?.KeyValuePairs;
+        var meterSchemaUrl = instrumentationScope.SchemaUrl;
 
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, scopeMetric.MeterName);
+        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, instrumentationScope.Name);
         if (meterVersion != null)
         {
             writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, meterVersion);
@@ -685,83 +685,55 @@ internal static class ProtobufOtlpMetricSerializer
         ProtobufSerializer.ComputeVarInt32Size((uint)numberOfUtf8Chars) +
         numberOfUtf8Chars;
 
-    private readonly struct InstrumentationScopeMetric
+    private readonly struct InstrumentationScope : IEquatable<InstrumentationScope>
     {
-        public InstrumentationScopeMetric(Metric metric)
+        private readonly int hashCode;
+
+        public InstrumentationScope(Metric metric)
         {
-            this.Metric = metric;
-        }
+            var identity = metric.InstrumentIdentity;
+            this.Name = identity.MeterName;
+            this.Version = identity.MeterVersion;
+            this.SchemaUrl = identity.MeterSchemaUrl;
+            this.Tags = identity.MeterTags;
 
-        public Metric Metric { get; }
-    }
-
-    private sealed class InstrumentationScopeMetricComparer : IEqualityComparer<InstrumentationScopeMetric>
-    {
-        public static readonly InstrumentationScopeMetricComparer Instance = new();
-
-        public bool Equals(InstrumentationScopeMetric x, InstrumentationScopeMetric y)
-        {
-            if (ReferenceEquals(x.Metric, y.Metric))
-            {
-                return true;
-            }
-
-            if (!string.Equals(x.Metric.MeterName, y.Metric.MeterName, StringComparison.Ordinal)
-                || !string.Equals(x.Metric.MeterVersion, y.Metric.MeterVersion, StringComparison.Ordinal)
-                || !string.Equals(x.Metric.MeterSchemaUrl, y.Metric.MeterSchemaUrl, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return TagsEqual(x.Metric.MeterTags, y.Metric.MeterTags);
-        }
-
-        public int GetHashCode(InstrumentationScopeMetric obj)
-        {
-            var hash = 17;
+#if NET || NETSTANDARD2_1_OR_GREATER
+            HashCode hashCode = default;
+            hashCode.Add(this.Name, StringComparer.Ordinal);
+            hashCode.Add(this.Version, StringComparer.Ordinal);
+            hashCode.Add(this.SchemaUrl, StringComparer.Ordinal);
+            hashCode.Add(this.Tags);
+            this.hashCode = hashCode.ToHashCode();
+#else
             unchecked
             {
-                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Metric.MeterName);
-                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Metric.MeterVersion);
-                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Metric.MeterSchemaUrl);
-
-                if (obj.Metric.MeterTags != null)
-                {
-                    foreach (var tag in obj.Metric.MeterTags)
-                    {
-                        hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(tag.Key);
-                        hash = (hash * 31) + (tag.Value?.GetHashCode() ?? 0);
-                    }
-                }
+                var hash = 17;
+                hash = (hash * 31) + this.Name.GetHashCode();
+                hash = (hash * 31) + this.Version.GetHashCode();
+                hash = (hash * 31) + this.SchemaUrl.GetHashCode();
+                hash = (hash * 31) + (this.Tags?.GetHashCode() ?? 0);
+                this.hashCode = hash;
             }
-
-            return hash;
+#endif
         }
 
-        private static bool TagsEqual(
-            IEnumerable<KeyValuePair<string, object?>>? x,
-            IEnumerable<KeyValuePair<string, object?>>? y)
-        {
-            if (x is null || y is null)
-            {
-                return x is null && y is null;
-            }
+        public string Name { get; }
 
-            using var xEnumerator = x.GetEnumerator();
-            using var yEnumerator = y.GetEnumerator();
+        public string Version { get; }
 
-            while (xEnumerator.MoveNext())
-            {
-                if (!yEnumerator.MoveNext()
-                    || !string.Equals(xEnumerator.Current.Key, yEnumerator.Current.Key, StringComparison.Ordinal)
-                    || !EqualityComparer<object?>.Default.Equals(xEnumerator.Current.Value, yEnumerator.Current.Value))
-                {
-                    return false;
-                }
-            }
+        public string SchemaUrl { get; }
 
-            return !yEnumerator.MoveNext();
-        }
+        public Tags? Tags { get; }
+
+        public bool Equals(InstrumentationScope other)
+            => string.Equals(this.Name, other.Name, StringComparison.Ordinal)
+            && string.Equals(this.Version, other.Version, StringComparison.Ordinal)
+            && string.Equals(this.SchemaUrl, other.SchemaUrl, StringComparison.Ordinal)
+            && Nullable.Equals(this.Tags, other.Tags);
+
+        public override bool Equals(object? obj) => obj is InstrumentationScope other && this.Equals(other);
+
+        public override int GetHashCode() => this.hashCode;
     }
 
     private sealed class CachedAttributes(int fieldNumber, byte[] bytes)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
@@ -44,9 +44,18 @@ internal static class ProtobufOtlpMetricSerializer
         // would merge it into the next export on this thread.
         try
         {
+            InstrumentationScope previousInstrumentationScope = default;
+            List<Metric>? previousMetrics = null;
+
             foreach (var metric in batch)
             {
                 var instrumentationScope = new InstrumentationScope(metric);
+                if (previousMetrics != null && instrumentationScope.Equals(previousInstrumentationScope))
+                {
+                    previousMetrics.Add(metric);
+                    continue;
+                }
+
                 if (!scopeMetricsList.TryGetValue(instrumentationScope, out var metrics))
                 {
                     metrics = metricListPool.Count > 0 ? metricListPool.Pop() : [];
@@ -54,6 +63,8 @@ internal static class ProtobufOtlpMetricSerializer
                 }
 
                 metrics.Add(metric);
+                previousInstrumentationScope = instrumentationScope;
+                previousMetrics = metrics;
             }
 
             writePosition = TryWriteResourceMetrics(ref buffer, writePosition, resource, scopeMetricsList, maxBufferSize);
@@ -696,25 +707,7 @@ internal static class ProtobufOtlpMetricSerializer
             this.Version = identity.MeterVersion;
             this.SchemaUrl = identity.MeterSchemaUrl;
             this.Tags = identity.MeterTags;
-
-#if NET || NETSTANDARD2_1_OR_GREATER
-            HashCode hashCode = default;
-            hashCode.Add(this.Name, StringComparer.Ordinal);
-            hashCode.Add(this.Version, StringComparer.Ordinal);
-            hashCode.Add(this.SchemaUrl, StringComparer.Ordinal);
-            hashCode.Add(this.Tags);
-            this.hashCode = hashCode.ToHashCode();
-#else
-            unchecked
-            {
-                var hash = 17;
-                hash = (hash * 31) + this.Name.GetHashCode();
-                hash = (hash * 31) + this.Version.GetHashCode();
-                hash = (hash * 31) + this.SchemaUrl.GetHashCode();
-                hash = (hash * 31) + (this.Tags?.GetHashCode() ?? 0);
-                this.hashCode = hash;
-            }
-#endif
+            this.hashCode = identity.MeterIdentityHashCode;
         }
 
         public string Name { get; }
@@ -726,7 +719,8 @@ internal static class ProtobufOtlpMetricSerializer
         public Tags? Tags { get; }
 
         public bool Equals(InstrumentationScope other)
-            => string.Equals(this.Name, other.Name, StringComparison.Ordinal)
+            => this.hashCode == other.hashCode
+            && string.Equals(this.Name, other.Name, StringComparison.Ordinal)
             && string.Equals(this.Version, other.Version, StringComparison.Ordinal)
             && string.Equals(this.SchemaUrl, other.SchemaUrl, StringComparison.Ordinal)
             && Nullable.Equals(this.Tags, other.Tags);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
@@ -24,7 +24,7 @@ internal static class ProtobufOtlpMetricSerializer
     [ThreadStatic]
     private static Stack<List<Metric>>? metricListPool;
     [ThreadStatic]
-    private static Dictionary<string, List<Metric>>? scopeMetricsList;
+    private static Dictionary<InstrumentationScopeMetric, List<Metric>>? scopeMetricsList;
 
     private delegate int WriteExemplarFunc(byte[] buffer, int writePosition, in Exemplar exemplar);
 
@@ -36,7 +36,7 @@ internal static class ProtobufOtlpMetricSerializer
         int maxBufferSize = ProtobufSerializer.MaxBufferSize)
     {
         metricListPool ??= [];
-        scopeMetricsList ??= [];
+        scopeMetricsList ??= new(InstrumentationScopeMetricComparer.Instance);
 
         // Note: The grouped batch is held in thread-static state, so it has to be
         // released even when serialization fails. TryWriteResourceMetrics rethrows
@@ -46,11 +46,11 @@ internal static class ProtobufOtlpMetricSerializer
         {
             foreach (var metric in batch)
             {
-                var metricName = metric.MeterName;
-                if (!scopeMetricsList.TryGetValue(metricName, out var metrics))
+                var instrumentationScope = new InstrumentationScopeMetric(metric);
+                if (!scopeMetricsList.TryGetValue(instrumentationScope, out var metrics))
                 {
                     metrics = metricListPool.Count > 0 ? metricListPool.Pop() : [];
-                    scopeMetricsList[metricName] = metrics;
+                    scopeMetricsList[instrumentationScope] = metrics;
                 }
 
                 metrics.Add(metric);
@@ -66,11 +66,11 @@ internal static class ProtobufOtlpMetricSerializer
         return writePosition;
     }
 
-    internal static int TryWriteResourceMetrics(
+    private static int TryWriteResourceMetrics(
         ref byte[] buffer,
         int writePosition,
         Resources.Resource? resource,
-        Dictionary<string, List<Metric>> scopeMetrics,
+        Dictionary<InstrumentationScopeMetric, List<Metric>> scopeMetrics,
         int maxBufferSize = ProtobufSerializer.MaxBufferSize)
     {
         while (true)
@@ -117,7 +117,7 @@ internal static class ProtobufOtlpMetricSerializer
         }
     }
 
-    private static int WriteResourceMetrics(byte[] buffer, int writePosition, Resources.Resource? resource, Dictionary<string, List<Metric>> scopeMetrics)
+    private static int WriteResourceMetrics(byte[] buffer, int writePosition, Resources.Resource? resource, Dictionary<InstrumentationScopeMetric, List<Metric>> scopeMetrics)
     {
         writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, writePosition, resource);
         writePosition = WriteScopeMetrics(buffer, writePosition, scopeMetrics);
@@ -130,7 +130,7 @@ internal static class ProtobufOtlpMetricSerializer
         return writePosition;
     }
 
-    private static int WriteScopeMetrics(byte[] buffer, int writePosition, Dictionary<string, List<Metric>> scopeMetrics)
+    private static int WriteScopeMetrics(byte[] buffer, int writePosition, Dictionary<InstrumentationScopeMetric, List<Metric>> scopeMetrics)
     {
         if (scopeMetrics != null)
         {
@@ -140,7 +140,7 @@ internal static class ProtobufOtlpMetricSerializer
                 var resourceMetricsScopeMetricsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
-                writePosition = WriteScopeMetric(buffer, writePosition, entry.Key, entry.Value);
+                writePosition = WriteScopeMetric(buffer, writePosition, entry.Key.Metric, entry.Value);
 
                 ProtobufSerializer.WriteReservedLength(buffer, resourceMetricsScopeMetricsLengthPosition, writePosition - (resourceMetricsScopeMetricsLengthPosition + ReserveSizeForLength));
             }
@@ -149,19 +149,18 @@ internal static class ProtobufOtlpMetricSerializer
         return writePosition;
     }
 
-    private static int WriteScopeMetric(byte[] buffer, int writePosition, string meterName, List<Metric> metrics)
+    private static int WriteScopeMetric(byte[] buffer, int writePosition, Metric scopeMetric, List<Metric> metrics)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Scope, ProtobufWireType.LEN);
         var instrumentationScopeLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         Debug.Assert(metrics.Count > 0, "Metrics collection is not expected to be empty.");
-        var metric = metrics[0];
-        var meterVersion = metric.MeterVersion;
-        var meterTags = metric.MeterTags;
-        var meterSchemaUrl = metric.MeterSchemaUrl;
+        var meterVersion = scopeMetric.MeterVersion;
+        var meterTags = scopeMetric.MeterTags;
+        var meterSchemaUrl = scopeMetric.MeterSchemaUrl;
 
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, meterName);
+        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, scopeMetric.MeterName);
         if (meterVersion != null)
         {
             writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, meterVersion);
@@ -685,6 +684,85 @@ internal static class ProtobufOtlpMetricSerializer
         ProtobufSerializer.ComputeVarInt32Size(ProtobufSerializer.GetTagValue(fieldNumber, ProtobufWireType.LEN)) +
         ProtobufSerializer.ComputeVarInt32Size((uint)numberOfUtf8Chars) +
         numberOfUtf8Chars;
+
+    private readonly struct InstrumentationScopeMetric
+    {
+        public InstrumentationScopeMetric(Metric metric)
+        {
+            this.Metric = metric;
+        }
+
+        public Metric Metric { get; }
+    }
+
+    private sealed class InstrumentationScopeMetricComparer : IEqualityComparer<InstrumentationScopeMetric>
+    {
+        public static readonly InstrumentationScopeMetricComparer Instance = new();
+
+        public bool Equals(InstrumentationScopeMetric x, InstrumentationScopeMetric y)
+        {
+            if (ReferenceEquals(x.Metric, y.Metric))
+            {
+                return true;
+            }
+
+            if (!string.Equals(x.Metric.MeterName, y.Metric.MeterName, StringComparison.Ordinal)
+                || !string.Equals(x.Metric.MeterVersion, y.Metric.MeterVersion, StringComparison.Ordinal)
+                || !string.Equals(x.Metric.MeterSchemaUrl, y.Metric.MeterSchemaUrl, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return TagsEqual(x.Metric.MeterTags, y.Metric.MeterTags);
+        }
+
+        public int GetHashCode(InstrumentationScopeMetric obj)
+        {
+            var hash = 17;
+            unchecked
+            {
+                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Metric.MeterName);
+                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Metric.MeterVersion);
+                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Metric.MeterSchemaUrl);
+
+                if (obj.Metric.MeterTags != null)
+                {
+                    foreach (var tag in obj.Metric.MeterTags)
+                    {
+                        hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(tag.Key);
+                        hash = (hash * 31) + (tag.Value?.GetHashCode() ?? 0);
+                    }
+                }
+            }
+
+            return hash;
+        }
+
+        private static bool TagsEqual(
+            IEnumerable<KeyValuePair<string, object?>>? x,
+            IEnumerable<KeyValuePair<string, object?>>? y)
+        {
+            if (x is null || y is null)
+            {
+                return x is null && y is null;
+            }
+
+            using var xEnumerator = x.GetEnumerator();
+            using var yEnumerator = y.GetEnumerator();
+
+            while (xEnumerator.MoveNext())
+            {
+                if (!yEnumerator.MoveNext()
+                    || !string.Equals(xEnumerator.Current.Key, yEnumerator.Current.Key, StringComparison.Ordinal)
+                    || !EqualityComparer<object?>.Default.Equals(xEnumerator.Current.Value, yEnumerator.Current.Value))
+                {
+                    return false;
+                }
+            }
+
+            return !yEnumerator.MoveNext();
+        }
+    }
 
     private sealed class CachedAttributes(int fieldNumber, byte[] bytes)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -18,7 +18,7 @@ internal static class ProtobufOtlpTraceSerializer
     [ThreadStatic]
     private static Stack<List<Activity>>? activityListPool;
     [ThreadStatic]
-    private static Dictionary<string, List<Activity>>? scopeTracesList;
+    private static Dictionary<ActivitySource, List<Activity>>? scopeTracesList;
 
     internal static int WriteTraceData(
         ref byte[] buffer,
@@ -29,7 +29,7 @@ internal static class ProtobufOtlpTraceSerializer
         int maxBufferSize = ProtobufSerializer.MaxBufferSize)
     {
         activityListPool ??= [];
-        scopeTracesList ??= [];
+        scopeTracesList ??= new(InstrumentationScopeActivitySourceComparer.Instance);
 
         // Note: The grouped batch is held in thread-static state, so it has to be
         // released even when serialization fails. TryWriteResourceSpans rethrows
@@ -39,11 +39,11 @@ internal static class ProtobufOtlpTraceSerializer
         {
             foreach (var activity in batch)
             {
-                var sourceName = activity.Source.Name;
-                if (!scopeTracesList.TryGetValue(sourceName, out var activities))
+                var source = activity.Source;
+                if (!scopeTracesList.TryGetValue(source, out var activities))
                 {
                     activities = activityListPool.Count > 0 ? activityListPool.Pop() : [];
-                    scopeTracesList[sourceName] = activities;
+                    scopeTracesList[source] = activities;
                 }
 
                 activities.Add(activity);
@@ -137,7 +137,7 @@ internal static class ProtobufOtlpTraceSerializer
                 var resourceSpansScopeSpansLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
-                writePosition = WriteScopeSpan(buffer, writePosition, sdkLimitOptions, entry.Value[0].Source, entry.Value);
+                writePosition = WriteScopeSpan(buffer, writePosition, sdkLimitOptions, entry.Key, entry.Value);
                 ProtobufSerializer.WriteReservedLength(buffer, resourceSpansScopeSpansLengthPosition, writePosition - (resourceSpansScopeSpansLengthPosition + ReserveSizeForLength));
             }
         }
@@ -586,5 +586,75 @@ internal static class ProtobufOtlpTraceSerializer
         position = ProtobufSerializer.WriteEnumWithTag(buffer, position, ProtobufOtlpTraceFieldNumberConstants.Status_Code, finalStatusCode);
 
         return position;
+    }
+
+    private sealed class InstrumentationScopeActivitySourceComparer : IEqualityComparer<ActivitySource>
+    {
+        public static readonly InstrumentationScopeActivitySourceComparer Instance = new();
+
+        public bool Equals(ActivitySource? x, ActivitySource? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null
+                || !string.Equals(x.Name, y.Name, StringComparison.Ordinal)
+                || !string.Equals(x.Version, y.Version, StringComparison.Ordinal)
+                || !string.Equals(x.TelemetrySchemaUrl, y.TelemetrySchemaUrl, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return TagsEqual(x.Tags, y.Tags);
+        }
+
+        public int GetHashCode(ActivitySource obj)
+        {
+            var hash = 17;
+            unchecked
+            {
+                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Name);
+                hash = (hash * 31) + (obj.Version == null ? 0 : StringComparer.Ordinal.GetHashCode(obj.Version));
+                hash = (hash * 31) + (obj.TelemetrySchemaUrl == null ? 0 : StringComparer.Ordinal.GetHashCode(obj.TelemetrySchemaUrl));
+
+                if (obj.Tags != null)
+                {
+                    foreach (var tag in obj.Tags)
+                    {
+                        hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(tag.Key);
+                        hash = (hash * 31) + (tag.Value?.GetHashCode() ?? 0);
+                    }
+                }
+            }
+
+            return hash;
+        }
+
+        private static bool TagsEqual(
+            IEnumerable<KeyValuePair<string, object?>>? x,
+            IEnumerable<KeyValuePair<string, object?>>? y)
+        {
+            if (x is null || y is null)
+            {
+                return x is null && y is null;
+            }
+
+            using var xEnumerator = x.GetEnumerator();
+            using var yEnumerator = y.GetEnumerator();
+
+            while (xEnumerator.MoveNext())
+            {
+                if (!yEnumerator.MoveNext()
+                    || !string.Equals(xEnumerator.Current.Key, yEnumerator.Current.Key, StringComparison.Ordinal)
+                    || !EqualityComparer<object?>.Default.Equals(xEnumerator.Current.Value, yEnumerator.Current.Value))
+                {
+                    return false;
+                }
+            }
+
+            return !yEnumerator.MoveNext();
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
@@ -15,10 +16,18 @@ internal static class ProtobufOtlpTraceSerializer
     private const int TraceIdSize = 16;
     private const int SpanIdSize = 8;
 
+    // A source's scope identity is fixed at construction, so the hash is computed once per
+    // source rather than once per span.
+#if NETFRAMEWORK || NETSTANDARD2_0
+    private static readonly ConditionalWeakTable<ActivitySource, StrongBox<int>> CachedScopeHashCodes = new();
+#else
+    private static readonly ConditionalWeakTable<ActivitySource, StrongBox<int>> CachedScopeHashCodes = [];
+#endif
+
     [ThreadStatic]
     private static Stack<List<Activity>>? activityListPool;
     [ThreadStatic]
-    private static Dictionary<ActivitySource, List<Activity>>? scopeTracesList;
+    private static Dictionary<InstrumentationScope, List<Activity>>? scopeTracesList;
 
     internal static int WriteTraceData(
         ref byte[] buffer,
@@ -29,7 +38,7 @@ internal static class ProtobufOtlpTraceSerializer
         int maxBufferSize = ProtobufSerializer.MaxBufferSize)
     {
         activityListPool ??= [];
-        scopeTracesList ??= new(InstrumentationScopeActivitySourceComparer.Instance);
+        scopeTracesList ??= [];
 
         // Note: The grouped batch is held in thread-static state, so it has to be
         // released even when serialization fails. TryWriteResourceSpans rethrows
@@ -39,11 +48,11 @@ internal static class ProtobufOtlpTraceSerializer
         {
             foreach (var activity in batch)
             {
-                var source = activity.Source;
-                if (!scopeTracesList.TryGetValue(source, out var activities))
+                var instrumentationScope = new InstrumentationScope(activity.Source);
+                if (!scopeTracesList.TryGetValue(instrumentationScope, out var activities))
                 {
                     activities = activityListPool.Count > 0 ? activityListPool.Pop() : [];
-                    scopeTracesList[source] = activities;
+                    scopeTracesList[instrumentationScope] = activities;
                 }
 
                 activities.Add(activity);
@@ -137,7 +146,7 @@ internal static class ProtobufOtlpTraceSerializer
                 var resourceSpansScopeSpansLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
-                writePosition = WriteScopeSpan(buffer, writePosition, sdkLimitOptions, entry.Key, entry.Value);
+                writePosition = WriteScopeSpan(buffer, writePosition, sdkLimitOptions, entry.Key.Source, entry.Value);
                 ProtobufSerializer.WriteReservedLength(buffer, resourceSpansScopeSpansLengthPosition, writePosition - (resourceSpansScopeSpansLengthPosition + ReserveSizeForLength));
             }
         }
@@ -588,73 +597,103 @@ internal static class ProtobufOtlpTraceSerializer
         return position;
     }
 
-    private sealed class InstrumentationScopeActivitySourceComparer : IEqualityComparer<ActivitySource>
+    /// <summary>
+    /// Identifies the instrumentation scope spans are grouped by. Sources sharing a name but
+    /// reporting a different version, schema URL, or tags are distinct scopes and must be
+    /// emitted as separate ScopeSpans entries.
+    /// </summary>
+    private readonly struct InstrumentationScope : IEquatable<InstrumentationScope>
     {
-        public static readonly InstrumentationScopeActivitySourceComparer Instance = new();
+        private readonly int hashCode;
 
-        public bool Equals(ActivitySource? x, ActivitySource? y)
+        public InstrumentationScope(ActivitySource source)
         {
-            if (ReferenceEquals(x, y))
-            {
-                return true;
-            }
-
-            if (x is null || y is null
-                || !string.Equals(x.Name, y.Name, StringComparison.Ordinal)
-                || !string.Equals(x.Version, y.Version, StringComparison.Ordinal)
-                || !string.Equals(x.TelemetrySchemaUrl, y.TelemetrySchemaUrl, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return TagsEqual(x.Tags, y.Tags);
+            this.Source = source;
+            this.hashCode = CachedScopeHashCodes.GetValue(source, static s => new StrongBox<int>(ComputeHashCode(s))).Value;
         }
 
-        public int GetHashCode(ActivitySource obj)
-        {
-            var hash = 17;
-            unchecked
-            {
-                hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(obj.Name);
-                hash = (hash * 31) + (obj.Version == null ? 0 : StringComparer.Ordinal.GetHashCode(obj.Version));
-                hash = (hash * 31) + (obj.TelemetrySchemaUrl == null ? 0 : StringComparer.Ordinal.GetHashCode(obj.TelemetrySchemaUrl));
+        public ActivitySource Source { get; }
 
-                if (obj.Tags != null)
+        public bool Equals(InstrumentationScope other)
+        {
+            var ours = this.Source;
+            var theirs = other.Source;
+
+            return ReferenceEquals(ours, theirs)
+                || (this.hashCode == other.hashCode
+                    && string.Equals(ours.Name, theirs.Name, StringComparison.Ordinal)
+                    && string.Equals(ours.Version, theirs.Version, StringComparison.Ordinal)
+                    && string.Equals(ours.TelemetrySchemaUrl, theirs.TelemetrySchemaUrl, StringComparison.Ordinal)
+                    && TagsEqual(ours.Tags, theirs.Tags));
+        }
+
+        public override bool Equals(object? obj) => obj is InstrumentationScope other && this.Equals(other);
+
+        public override int GetHashCode() => this.hashCode;
+
+        private static int ComputeHashCode(ActivitySource source)
+        {
+#if NET || NETSTANDARD2_1_OR_GREATER
+            HashCode hashCode = default;
+            hashCode.Add(source.Name, StringComparer.Ordinal);
+            hashCode.Add(source.Version, StringComparer.Ordinal);
+            hashCode.Add(source.TelemetrySchemaUrl, StringComparer.Ordinal);
+
+            if (source.Tags != null)
+            {
+                foreach (var tag in source.Tags)
                 {
-                    foreach (var tag in obj.Tags)
-                    {
-                        hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(tag.Key);
-                        hash = (hash * 31) + (tag.Value?.GetHashCode() ?? 0);
-                    }
+                    hashCode.Add(tag.Key, StringComparer.Ordinal);
+                    hashCode.Add(tag.Value);
                 }
             }
 
-            return hash;
+            return hashCode.ToHashCode();
+#else
+            unchecked
+            {
+                var hash = 17;
+                hash = (hash * 31) + source.Name.GetHashCode();
+                hash = (hash * 31) + (source.Version?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (source.TelemetrySchemaUrl?.GetHashCode() ?? 0);
+
+                if (source.Tags != null)
+                {
+                    foreach (var tag in source.Tags)
+                    {
+                        hash = (hash * 31) + tag.Key.GetHashCode();
+                        hash = (hash * 31) + (tag.Value?.GetHashCode() ?? 0);
+                    }
+                }
+
+                return hash;
+            }
+#endif
         }
 
         private static bool TagsEqual(
-            IEnumerable<KeyValuePair<string, object?>>? x,
-            IEnumerable<KeyValuePair<string, object?>>? y)
+            IEnumerable<KeyValuePair<string, object?>>? left,
+            IEnumerable<KeyValuePair<string, object?>>? right)
         {
-            if (x is null || y is null)
+            if (left is null || right is null)
             {
-                return x is null && y is null;
+                return left is null && right is null;
             }
 
-            using var xEnumerator = x.GetEnumerator();
-            using var yEnumerator = y.GetEnumerator();
+            using var leftEnumerator = left.GetEnumerator();
+            using var rightEnumerator = right.GetEnumerator();
 
-            while (xEnumerator.MoveNext())
+            while (leftEnumerator.MoveNext())
             {
-                if (!yEnumerator.MoveNext()
-                    || !string.Equals(xEnumerator.Current.Key, yEnumerator.Current.Key, StringComparison.Ordinal)
-                    || !EqualityComparer<object?>.Default.Equals(xEnumerator.Current.Value, yEnumerator.Current.Value))
+                if (!rightEnumerator.MoveNext()
+                    || !string.Equals(leftEnumerator.Current.Key, rightEnumerator.Current.Key, StringComparison.Ordinal)
+                    || !EqualityComparer<object?>.Default.Equals(leftEnumerator.Current.Value, rightEnumerator.Current.Value))
                 {
                     return false;
                 }
             }
 
-            return !yEnumerator.MoveNext();
+            return !rightEnumerator.MoveNext();
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -31,6 +31,16 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
         this.ExponentialHistogramMaxScale = (metricStreamConfiguration as Base2ExponentialBucketHistogramConfiguration)?.MaxScale ?? 0;
         this.HistogramRecordMinMax = (metricStreamConfiguration as HistogramConfiguration)?.RecordMinMax ?? true;
 
+        unchecked
+        {
+            var meterHash = 17;
+            meterHash = (meterHash * 31) + StringComparer.Ordinal.GetHashCode(this.MeterName);
+            meterHash = (meterHash * 31) + StringComparer.Ordinal.GetHashCode(this.MeterVersion);
+            meterHash = (meterHash * 31) + StringComparer.Ordinal.GetHashCode(this.MeterSchemaUrl);
+            meterHash = (meterHash * 31) + (this.MeterTags?.GetHashCode() ?? 0);
+            this.MeterIdentityHashCode = meterHash;
+        }
+
 #if NET || NETSTANDARD2_1_OR_GREATER
         HashCode hashCode = default;
         hashCode.Add(this.InstrumentType);
@@ -163,6 +173,8 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
         || this.InstrumentType == typeof(ObservableGauge<byte>)
         || this.InstrumentType == typeof(ObservableGauge<float>)
         || this.InstrumentType == typeof(ObservableGauge<double>);
+
+    internal int MeterIdentityHashCode { get; }
 
     public static bool operator ==(MetricStreamIdentity metricIdentity1, MetricStreamIdentity metricIdentity2) => metricIdentity1.Equals(metricIdentity2);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -300,6 +300,39 @@ public sealed class OtlpMetricsExporterTests : IDisposable
         VerifyExemplars(longValue, doubleValue, enableExemplars, d => d.Exemplars.FirstOrDefault(), dataPoint);
     }
 
+    [Fact]
+    public void MetricsAreGroupedByFullInstrumentationScope()
+    {
+        var metrics = new List<Metric>();
+        var meterName = nameof(this.MetricsAreGroupedByFullInstrumentationScope);
+        using var meterV1 = new Meter(meterName, "1.0");
+        using var equivalentMeterV1 = new Meter(meterName, "1.0");
+        using var meterV2 = new Meter(meterName, "2.0");
+        using var meterWithSchema = new Meter(new MeterOptions(meterName) { Version = "1.0", TelemetrySchemaUrl = "https://opentelemetry.io/schemas/1.0.0" });
+        using var meterWithTags = new Meter(new MeterOptions(meterName) { Version = "1.0", Tags = [new("scope-key", "scope-value")] });
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meterName)
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+        meterV1.CreateCounter<int>("counter-v1").Add(1);
+        equivalentMeterV1.CreateCounter<int>("counter-v1-equivalent").Add(1);
+        meterV2.CreateCounter<int>("counter-v2").Add(1);
+        meterWithSchema.CreateCounter<int>("counter-schema").Add(1);
+        meterWithTags.CreateCounter<int>("counter-tags").Add(1);
+        provider.ForceFlush();
+
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
+        var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
+
+        var scopeMetrics = Assert.Single(request.ResourceMetrics).ScopeMetrics;
+        Assert.Equal(4, scopeMetrics.Count);
+        Assert.Contains(scopeMetrics, scope => scope.Scope.Version == "1.0" && scope.SchemaUrl.Length == 0 && scope.Scope.Attributes.Count == 0 && scope.Metrics.Count == 2);
+        Assert.Contains(scopeMetrics, scope => scope.Scope.Version == "2.0" && Assert.Single(scope.Metrics).Name == "counter-v2");
+        Assert.Contains(scopeMetrics, scope => scope.SchemaUrl == "https://opentelemetry.io/schemas/1.0.0" && Assert.Single(scope.Metrics).Name == "counter-schema");
+        Assert.Contains(scopeMetrics, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Key == "scope-key" && Assert.Single(scope.Metrics).Name == "counter-tags");
+    }
+
     [Theory]
     [InlineData("test_counter", null, null, 123L, null, MetricReaderTemporalityPreference.Cumulative)]
     [InlineData("test_counter", null, null, null, 123.45, MetricReaderTemporalityPreference.Cumulative)]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -310,27 +310,32 @@ public sealed class OtlpMetricsExporterTests : IDisposable
         using var meterV2 = new Meter(meterName, "2.0");
         using var meterWithSchema = new Meter(new MeterOptions(meterName) { Version = "1.0", TelemetrySchemaUrl = "https://opentelemetry.io/schemas/1.0.0" });
         using var meterWithTags = new Meter(new MeterOptions(meterName) { Version = "1.0", Tags = [new("scope-key", "scope-value")] });
+        using var equivalentMeterWithTags = new Meter(new MeterOptions(meterName) { Version = "1.0", Tags = [new("scope-key", "scope-value")] });
+        using var meterWithDifferentTags = new Meter(new MeterOptions(meterName) { Version = "1.0", Tags = [new("scope-key", "different-value")] });
         using var provider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(meterName)
             .AddInMemoryExporter(metrics)
             .Build();
 
         meterV1.CreateCounter<int>("counter-v1").Add(1);
-        equivalentMeterV1.CreateCounter<int>("counter-v1-equivalent").Add(1);
         meterV2.CreateCounter<int>("counter-v2").Add(1);
-        meterWithSchema.CreateCounter<int>("counter-schema").Add(1);
+        equivalentMeterV1.CreateCounter<int>("counter-v1-equivalent").Add(1);
         meterWithTags.CreateCounter<int>("counter-tags").Add(1);
+        meterWithDifferentTags.CreateCounter<int>("counter-tags-different").Add(1);
+        equivalentMeterWithTags.CreateCounter<int>("counter-tags-equivalent").Add(1);
+        meterWithSchema.CreateCounter<int>("counter-schema").Add(1);
         provider.ForceFlush();
 
         var batch = new Batch<Metric>([.. metrics], metrics.Count);
         var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
 
         var scopeMetrics = Assert.Single(request.ResourceMetrics).ScopeMetrics;
-        Assert.Equal(4, scopeMetrics.Count);
+        Assert.Equal(5, scopeMetrics.Count);
         Assert.Contains(scopeMetrics, scope => scope.Scope.Version == "1.0" && scope.SchemaUrl.Length == 0 && scope.Scope.Attributes.Count == 0 && scope.Metrics.Count == 2);
         Assert.Contains(scopeMetrics, scope => scope.Scope.Version == "2.0" && Assert.Single(scope.Metrics).Name == "counter-v2");
         Assert.Contains(scopeMetrics, scope => scope.SchemaUrl == "https://opentelemetry.io/schemas/1.0.0" && Assert.Single(scope.Metrics).Name == "counter-schema");
-        Assert.Contains(scopeMetrics, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Key == "scope-key" && Assert.Single(scope.Metrics).Name == "counter-tags");
+        Assert.Contains(scopeMetrics, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Value.StringValue == "scope-value" && scope.Metrics.Count == 2);
+        Assert.Contains(scopeMetrics, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Value.StringValue == "different-value" && Assert.Single(scope.Metrics).Name == "counter-tags-different");
     }
 
     [Theory]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -239,28 +239,35 @@ public sealed class OtlpTraceExporterTests : IDisposable
         using var sourceV2 = new ActivitySource(sourceName, "2.0");
         using var sourceWithSchema = new ActivitySource(new ActivitySourceOptions(sourceName) { Version = "1.0", TelemetrySchemaUrl = "https://opentelemetry.io/schemas/1.0.0" });
         using var sourceWithTags = new ActivitySource(new ActivitySourceOptions(sourceName) { Version = "1.0", Tags = [new("scope-key", "scope-value")] });
+        using var equivalentSourceWithTags = new ActivitySource(new ActivitySourceOptions(sourceName) { Version = "1.0", Tags = [new("scope-key", "scope-value")] });
+        using var sourceWithDifferentTags = new ActivitySource(new ActivitySourceOptions(sourceName) { Version = "1.0", Tags = [new("scope-key", "different-value")] });
         using var activityV1 = sourceV1.StartActivity("span-v1-a");
         using var equivalentActivityV1 = equivalentSourceV1.StartActivity("span-v1-b");
         using var activityV2 = sourceV2.StartActivity("span-v2");
         using var activityWithSchema = sourceWithSchema.StartActivity("span-schema");
         using var activityWithTags = sourceWithTags.StartActivity("span-tags");
+        using var equivalentActivityWithTags = equivalentSourceWithTags.StartActivity("span-tags-equivalent");
+        using var activityWithDifferentTags = sourceWithDifferentTags.StartActivity("span-tags-different");
 
         Assert.NotNull(activityV1);
         Assert.NotNull(equivalentActivityV1);
         Assert.NotNull(activityV2);
         Assert.NotNull(activityWithSchema);
         Assert.NotNull(activityWithTags);
+        Assert.NotNull(equivalentActivityWithTags);
+        Assert.NotNull(activityWithDifferentTags);
 
-        var activities = new[] { activityV1, equivalentActivityV1, activityV2, activityWithSchema, activityWithTags };
+        var activities = new[] { activityV1, equivalentActivityV1, activityV2, activityWithSchema, activityWithTags, equivalentActivityWithTags, activityWithDifferentTags };
         var batch = new Batch<Activity>(activities, activities.Length);
         var request = CreateTraceExportRequest(DefaultSdkLimitOptions, batch, ResourceBuilder.CreateEmpty().Build());
 
         var scopeSpans = Assert.Single(request.ResourceSpans).ScopeSpans;
-        Assert.Equal(4, scopeSpans.Count);
+        Assert.Equal(5, scopeSpans.Count);
         Assert.Contains(scopeSpans, scope => scope.Scope.Version == "1.0" && scope.SchemaUrl.Length == 0 && scope.Scope.Attributes.Count == 0 && scope.Spans.Count == 2);
         Assert.Contains(scopeSpans, scope => scope.Scope.Version == "2.0" && Assert.Single(scope.Spans).Name == "span-v2");
         Assert.Contains(scopeSpans, scope => scope.SchemaUrl == "https://opentelemetry.io/schemas/1.0.0" && Assert.Single(scope.Spans).Name == "span-schema");
-        Assert.Contains(scopeSpans, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Key == "scope-key" && Assert.Single(scope.Spans).Name == "span-tags");
+        Assert.Contains(scopeSpans, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Value.StringValue == "scope-value" && scope.Spans.Count == 2);
+        Assert.Contains(scopeSpans, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Value.StringValue == "different-value" && Assert.Single(scope.Spans).Name == "span-tags-different");
     }
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -231,6 +231,39 @@ public sealed class OtlpTraceExporterTests : IDisposable
     }
 
     [Fact]
+    public void TracesAreGroupedByFullInstrumentationScope()
+    {
+        var sourceName = nameof(this.TracesAreGroupedByFullInstrumentationScope);
+        using var sourceV1 = new ActivitySource(sourceName, "1.0");
+        using var equivalentSourceV1 = new ActivitySource(sourceName, "1.0");
+        using var sourceV2 = new ActivitySource(sourceName, "2.0");
+        using var sourceWithSchema = new ActivitySource(new ActivitySourceOptions(sourceName) { Version = "1.0", TelemetrySchemaUrl = "https://opentelemetry.io/schemas/1.0.0" });
+        using var sourceWithTags = new ActivitySource(new ActivitySourceOptions(sourceName) { Version = "1.0", Tags = [new("scope-key", "scope-value")] });
+        using var activityV1 = sourceV1.StartActivity("span-v1-a");
+        using var equivalentActivityV1 = equivalentSourceV1.StartActivity("span-v1-b");
+        using var activityV2 = sourceV2.StartActivity("span-v2");
+        using var activityWithSchema = sourceWithSchema.StartActivity("span-schema");
+        using var activityWithTags = sourceWithTags.StartActivity("span-tags");
+
+        Assert.NotNull(activityV1);
+        Assert.NotNull(equivalentActivityV1);
+        Assert.NotNull(activityV2);
+        Assert.NotNull(activityWithSchema);
+        Assert.NotNull(activityWithTags);
+
+        var activities = new[] { activityV1, equivalentActivityV1, activityV2, activityWithSchema, activityWithTags };
+        var batch = new Batch<Activity>(activities, activities.Length);
+        var request = CreateTraceExportRequest(DefaultSdkLimitOptions, batch, ResourceBuilder.CreateEmpty().Build());
+
+        var scopeSpans = Assert.Single(request.ResourceSpans).ScopeSpans;
+        Assert.Equal(4, scopeSpans.Count);
+        Assert.Contains(scopeSpans, scope => scope.Scope.Version == "1.0" && scope.SchemaUrl.Length == 0 && scope.Scope.Attributes.Count == 0 && scope.Spans.Count == 2);
+        Assert.Contains(scopeSpans, scope => scope.Scope.Version == "2.0" && Assert.Single(scope.Spans).Name == "span-v2");
+        Assert.Contains(scopeSpans, scope => scope.SchemaUrl == "https://opentelemetry.io/schemas/1.0.0" && Assert.Single(scope.Spans).Name == "span-schema");
+        Assert.Contains(scopeSpans, scope => scope.Scope.Attributes.Count == 1 && Assert.Single(scope.Scope.Attributes).Key == "scope-key" && Assert.Single(scope.Spans).Name == "span-tags");
+    }
+
+    [Fact]
     public void ScopeAttributesRemainConsistentAcrossMultipleBatches()
     {
         var activitySourceTags = new TagList


### PR DESCRIPTION
Fixes #7643.

## Changes

* Group traces by the complete `ActivitySource` instrumentation scope instead of source name only.
* Group metrics by meter name, version, schema URL, and scope tags instead of meter name only.
* Preserve grouping for equivalent scopes.
* Add regression coverage for version, schema URL, tags, and equivalent-scope grouping for both traces and metrics.

## Validation

* `dotnet build OpenTelemetry.slnx --configuration Release --no-restore` (0 warnings, 0 errors)
* `dotnet test test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj --framework net10.0 --configuration Release --no-restore` (825 passed, 3 integration tests skipped)
* `dotnet format OpenTelemetry.slnx --no-restore --verify-no-changes --include <changed files>`
* `ProtobufOtlpMetricSerializerBenchmarks` completed for batches containing 1, 4, 16, 64, and 256 metrics.

## Generative AI disclosure

OpenAI Codex (GPT-5) assisted with the investigation, implementation, regression tests, validation, and PR preparation. The resulting changes were validated with the full multi-target Release build, the OTLP exporter test suite, formatting checks, and the existing serializer benchmark.