### PR TITLE
[Declarative config] Phase 4: Document retention

### DIFF
--- a/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
+++ b/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
@@ -18,7 +18,7 @@ Notes](../../RELEASENOTES.md).
   sequences).
   ([#7657](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7657))
 
-* Introduced `DeclarativeConfigurationDocument` and 
+* Introduced `DeclarativeConfigurationDocument` and
   `DeclarativeConfigurationDocumentAccessor`. Each file is parsed at most once
   per application lifetime.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#7690](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7690))

--- a/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
+++ b/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
@@ -17,3 +17,8 @@ Notes](../../RELEASENOTES.md).
   for reading parsed YAML configuration values (scalars, nested mappings, and
   sequences).
   ([#7657](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7657))
+
+* Introduced `DeclarativeConfigurationDocument` and 
+  `DeclarativeConfigurationDocumentAccessor`. Each file is parsed at most once
+  per application lifetime.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))

--- a/src/OpenTelemetry.Configuration.Declarative/Extensions/DeclarativeConfigurationBuilderExtensions.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Extensions/DeclarativeConfigurationBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class DeclarativeConfigurationBuilderExtensions
     /// <remarks>
     /// Appends the source after existing ones (YAML overrides earlier sources; sources added
     /// later override YAML). No-op when <c>OTEL_CONFIG_FILE</c> is unset, empty, or whitespace,
-    /// or when the same file is already registered.
+    /// or when a declarative configuration file is already registered. The first file wins.
     /// </remarks>
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
     /// <returns>The original <see cref="IConfigurationBuilder"/> for chaining.</returns>
@@ -60,18 +60,40 @@ public static class DeclarativeConfigurationBuilderExtensions
     // so callers that already hold a FilePath (e.g. overlay registration) can pass it directly.
     internal static IConfigurationBuilder AddOpenTelemetryDeclarativeConfiguration(
         this IConfigurationBuilder builder,
-        FilePath path)
+        FilePath path) =>
+        builder.AddOpenTelemetryDeclarativeConfiguration(new DeclarativeConfigurationDocumentAccessor(path));
+
+    // Overload accepting an already-created accessor, so UseDeclarativeConfiguration can register
+    // the same accessor instance in both DI and the configuration source.
+    internal static IConfigurationBuilder AddOpenTelemetryDeclarativeConfiguration(
+        this IConfigurationBuilder builder,
+        DeclarativeConfigurationDocumentAccessor accessor)
     {
         Guard.ThrowIfNull(builder);
 
-        if (builder.Sources.OfType<DeclarativeConfigurationSource>().Any(s => s.FilePath == path))
+        var existingSource = builder.Sources
+            .OfType<DeclarativeConfigurationSource>()
+            .FirstOrDefault();
+
+        if (existingSource != null)
         {
-            OpenTelemetryDeclarativeConfigurationEventSource.Log.SourceAlreadyRegisteredInBuilder(path.DisplayPath);
+            if (existingSource.FilePath == accessor.FilePath)
+            {
+                OpenTelemetryDeclarativeConfigurationEventSource.Log.SourceAlreadyRegisteredInBuilder(
+                    accessor.FilePath.DisplayPath);
+            }
+            else
+            {
+                OpenTelemetryDeclarativeConfigurationEventSource.Log.DifferentSourceAlreadyRegistered(
+                    existingSource.FilePath.DisplayPath,
+                    accessor.FilePath.DisplayPath);
+            }
+
             return builder;
         }
 
-        builder.Sources.Add(new DeclarativeConfigurationSource(path));
-        OpenTelemetryDeclarativeConfigurationEventSource.Log.SourceRegistered(path.DisplayPath);
+        builder.Sources.Add(new DeclarativeConfigurationSource(accessor));
+        OpenTelemetryDeclarativeConfigurationEventSource.Log.SourceRegistered(accessor.FilePath.DisplayPath);
         return builder;
     }
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Extensions/OpenTelemetryBuilderDeclarativeConfigurationExtensions.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Extensions/OpenTelemetryBuilderDeclarativeConfigurationExtensions.cs
@@ -74,20 +74,35 @@ public static class OpenTelemetryBuilderDeclarativeConfigurationExtensions
             return;
         }
 
+        // Last registered IConfiguration wins in DI.
+        var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(IConfiguration));
+
+        // The accessor this call contributes if no declarative source is registered already. When one
+        // is, the existing accessor wins and this instance is discarded unused.
+        var candidateAccessor = new DeclarativeConfigurationDocumentAccessor(filePath);
+
         services.AddSingleton(new DeclarativeConfigurationOverlayMarker(filePath));
+
         OpenTelemetryDeclarativeConfigurationEventSource.Log.OverlayRegistrationStarted(filePath.DisplayPath);
 
         // TODO(strict-mode): branch here on a future DeclarativeConfigurationMode (Default vs Strict). See https://github.com/open-telemetry/opentelemetry-dotnet/issues/6380.
 
-        // Last registered IConfiguration wins in DI.
-        var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(IConfiguration));
-
         if (descriptor?.ImplementationInstance is IConfigurationBuilder liveBuilder)
         {
             // ConfigurationManager registered as instance: mutate in-place, preserve reload.
-            liveBuilder.AddOpenTelemetryDeclarativeConfiguration(filePath);
+            liveBuilder.AddOpenTelemetryDeclarativeConfiguration(candidateAccessor);
+            services.TryAddSingleton(
+                DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(liveBuilder)
+                    ?? candidateAccessor);
             return;
         }
+
+        // Explicit singleton registration. Resolving IConfiguration first is what makes the scan
+        // meaningful: the source below is only inserted while the configuration is being built, so
+        // until that has happened there is nothing to find.
+        services.TryAddSingleton(sp =>
+            DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(sp)
+                ?? candidateAccessor);
 
         // Factory/type registration: replace descriptor, wrap or insert on first resolve.
         var existingFactory = descriptor?.ImplementationFactory;
@@ -120,15 +135,14 @@ public static class OpenTelemetryBuilderDeclarativeConfigurationExtensions
                 if (existing is IConfigurationBuilder existingAsBuilder)
                 {
                     // Resolved config is a live builder (HostApplicationBuilder): insert in-place.
-                    existingAsBuilder.AddOpenTelemetryDeclarativeConfiguration(filePath);
+                    existingAsBuilder.AddOpenTelemetryDeclarativeConfiguration(candidateAccessor);
                     return existing;
                 }
 
                 // ConfigurationRoot: chain existing, append YAML last. alreadyRegistered is deferred to
                 // resolve time because HostBuilder's factory-built root is not available until then.
-                var alreadyRegistered = existing is IConfigurationRoot existingRoot &&
-                    existingRoot.Providers.OfType<DeclarativeConfigurationProvider>().Any(p =>
-                        p.FilePath == filePath);
+                var existingAccessor = DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(existing);
+                var alreadyRegistered = existingAccessor != null;
 
 #pragma warning disable CA2000 // Ownership transferred to DI container via factory return value; lifetime matches the replaced descriptor's lifetime
                 var manager = new ConfigurationManager();
@@ -141,11 +155,21 @@ public static class OpenTelemetryBuilderDeclarativeConfigurationExtensions
 
                 if (alreadyRegistered)
                 {
-                    OpenTelemetryDeclarativeConfigurationEventSource.Log.SourceAlreadyPresentInExistingConfiguration(filePath.DisplayPath);
+                    if (existingAccessor!.FilePath == filePath)
+                    {
+                        OpenTelemetryDeclarativeConfigurationEventSource.Log.SourceAlreadyPresentInExistingConfiguration(
+                            filePath.DisplayPath);
+                    }
+                    else
+                    {
+                        OpenTelemetryDeclarativeConfigurationEventSource.Log.DifferentSourceAlreadyRegistered(
+                            existingAccessor.FilePath.DisplayPath,
+                            filePath.DisplayPath);
+                    }
                 }
                 else
                 {
-                    manager.AddOpenTelemetryDeclarativeConfiguration(filePath);
+                    manager.AddOpenTelemetryDeclarativeConfiguration(candidateAccessor);
                 }
 
                 return manager;

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/DeclarativeConfigurationDocumentAccessorResolver.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/DeclarativeConfigurationDocumentAccessorResolver.cs
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpenTelemetry.Configuration.Declarative;
+
+/// <summary>
+/// Locates the <see cref="DeclarativeConfigurationDocumentAccessor"/> for an application, whether it
+/// was registered explicitly by <c>UseDeclarativeConfiguration</c> or reached the application only as
+/// an <see cref="IConfigurationSource"/> added through <c>IConfigurationBuilder</c>.
+/// </summary>
+internal static class DeclarativeConfigurationDocumentAccessorResolver
+{
+    // This type exists for situations when IConfigurationSource is added through IConfigurationBuilder.
+    // IConfigurationBuilder</c> carries no IServiceCollection, so a source added that way cannot register
+    // anything into DI. Scanning the resolved IConfiguration recovers the accessor the configuration
+    // provider is already using, so a typed consumer reads the same document rather than parsing the
+    // file a second time.
+
+    /// <summary>
+    /// Finds the accessor for <paramref name="serviceProvider"/>, preferring an explicit
+    /// registration and falling back to a scan of the registered <see cref="IConfiguration"/>.
+    /// </summary>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to resolve from.</param>
+    /// <returns>
+    /// The accessor, or <see langword="null"/> when the application has no declarative
+    /// configuration.
+    /// </returns>
+    internal static DeclarativeConfigurationDocumentAccessor? Find(IServiceProvider serviceProvider)
+    {
+        var accessor = serviceProvider.GetService<DeclarativeConfigurationDocumentAccessor>()
+            ?? FindInConfiguration(serviceProvider);
+
+        if (accessor == null)
+        {
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.DocumentAccessorNotAvailable();
+        }
+
+        return accessor;
+    }
+
+    /// <summary>
+    /// Resolves <see cref="IConfiguration"/> from <paramref name="serviceProvider"/> and scans it for
+    /// an accessor, without consulting an explicit registration.
+    /// </summary>
+    /// <remarks>
+    /// Resolving <see cref="IConfiguration"/> is what makes the result stable: the declarative source
+    /// may only be inserted while the configuration is being built, so the scan has to run after
+    /// that has happened. It does not matter whether <c>Load()</c> has run, because the accessor
+    /// parses on demand.
+    /// </remarks>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to resolve from.</param>
+    /// <returns>The accessor, or <see langword="null"/> when none is present.</returns>
+    internal static DeclarativeConfigurationDocumentAccessor? FindInConfiguration(IServiceProvider serviceProvider) =>
+        FindInConfiguration(serviceProvider.GetService<IConfiguration>());
+
+    /// <summary>
+    /// Scans a configuration builder's pending sources for a declarative accessor.
+    /// </summary>
+    /// <param name="builder">The builder whose sources are searched.</param>
+    /// <returns>The accessor, or <see langword="null"/> when none is present.</returns>
+    internal static DeclarativeConfigurationDocumentAccessor? FindInConfiguration(IConfigurationBuilder builder) =>
+        FindInConfigurationCore(builder);
+
+    /// <summary>
+    /// Scans a configuration for a declarative accessor.
+    /// </summary>
+    /// <param name="configuration">
+    /// An <see cref="IConfigurationRoot"/> whose providers are searched, or a
+    /// <see cref="ConfigurationManager"/> whose sources are searched in preference to its providers
+    /// because a source added to it is visible before its provider is built.
+    /// </param>
+    /// <remarks>
+    /// Registering a declarative source twice on one builder is refused, so a single builder cannot
+    /// hold two documents. Two can still become reachable when one arrives through
+    /// <c>AddConfiguration</c>, because a chained configuration is opaque to that guard. Flat values
+    /// then follow standard <see cref="IConfiguration"/> ordering, where the last provider to supply
+    /// a key wins, so the last document reachable here is the one whose values an application
+    /// observes and therefore the one returned. The others are reported and ignored: the typed
+    /// document cannot be merged the way flat keys can, so one has to be chosen.
+    /// </remarks>
+    /// <returns>The accessor, or <see langword="null"/> when none is present.</returns>
+    internal static DeclarativeConfigurationDocumentAccessor? FindInConfiguration(IConfiguration? configuration) =>
+        FindInConfigurationCore(configuration);
+
+    private static DeclarativeConfigurationDocumentAccessor? FindInConfigurationCore(object? configuration)
+    {
+        var accessors = new List<DeclarativeConfigurationDocumentAccessor>(capacity: 1);
+
+        Collect(configuration, accessors);
+
+        if (accessors.Count == 0)
+        {
+            return null;
+        }
+
+        var selected = accessors[accessors.Count - 1];
+
+        for (var i = 0; i < accessors.Count - 1; i++)
+        {
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.MultipleConfigurationDocumentsReachable(
+                selected.FilePath.DisplayPath,
+                accessors[i].FilePath.DisplayPath);
+        }
+
+        return selected;
+    }
+
+    /// <summary>
+    /// Appends every accessor reachable from <paramref name="configuration"/> to
+    /// <paramref name="accessors"/>, in ascending order of configuration precedence.
+    /// </summary>
+    private static void Collect(
+        object? configuration,
+        List<DeclarativeConfigurationDocumentAccessor> accessors)
+    {
+        if (configuration is IConfigurationBuilder builder)
+        {
+            // A builder's source list is the complete and authoritative view: every provider is
+            // built from a source, and a source added to a ConfigurationManager is visible before
+            // its provider exists. Walking its providers as well would count each document twice.
+            foreach (var source in builder.Sources)
+            {
+                switch (source)
+                {
+                    case DeclarativeConfigurationSource declarative:
+                        Add(declarative.Accessor, accessors);
+                        break;
+
+                    case ChainedConfigurationSource chained:
+                        Collect(chained.Configuration, accessors);
+                        break;
+                }
+            }
+
+            return;
+        }
+
+        if (configuration is not IConfigurationRoot root)
+        {
+            return;
+        }
+
+        foreach (var provider in root.Providers)
+        {
+            switch (provider)
+            {
+                case DeclarativeConfigurationProvider declarative:
+                    Add(declarative.Accessor, accessors);
+                    break;
+
+                // A configuration chained in via AddConfiguration is reachable only through the
+                // chaining provider, so recurse. UseDeclarativeConfiguration builds exactly this
+                // shape when it wraps an existing root, and so does any application that composes
+                // its configuration from another IConfigurationRoot.
+                case ChainedConfigurationProvider chained:
+                    Collect(chained.Configuration, accessors);
+                    break;
+            }
+        }
+    }
+
+    private static void Add(
+        DeclarativeConfigurationDocumentAccessor accessor,
+        List<DeclarativeConfigurationDocumentAccessor> accessors)
+    {
+        // One accessor can be reachable by more than one route, for example a root chained in twice.
+        // That is one document rather than an ambiguous configuration, so it is recorded once, at
+        // the highest precedence position it occupies.
+        accessors.Remove(accessor);
+        accessors.Add(accessor);
+    }
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/DeclarativeConfigurationProvider.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/DeclarativeConfigurationProvider.cs
@@ -6,42 +6,39 @@ using Microsoft.Extensions.Configuration;
 namespace OpenTelemetry.Configuration.Declarative;
 
 /// <summary>
-/// An <see cref="IConfigurationProvider"/> that reads OpenTelemetry configuration from a declarative configuration YAML file.
-/// The file is parsed and loaded into the provider's data dictionary.
+/// An <see cref="IConfigurationProvider"/> that reads OpenTelemetry configuration from a
+/// declarative configuration YAML file. The file is read at most once; subsequent
+/// <see cref="Load"/> calls are ignored.
 /// </summary>
-internal sealed class DeclarativeConfigurationProvider(FilePath filePath) : ConfigurationProvider
+internal sealed class DeclarativeConfigurationProvider(DeclarativeConfigurationDocumentAccessor accessor) : ConfigurationProvider
 {
-    private readonly string fileDisplayPath = filePath.DisplayPath;
+    private bool loaded;
 
-    internal FilePath FilePath { get; } = filePath;
+    internal FilePath FilePath => accessor.FilePath;
+
+    internal DeclarativeConfigurationDocumentAccessor Accessor => accessor;
 
     /// <inheritdoc/>
     public override void Load()
     {
-        try
+        if (this.loaded)
         {
-            var data = DeclarativeConfigurationReader.Read(this.FilePath);
-
-            this.Data = data;
-
-            OpenTelemetryDeclarativeConfigurationEventSource.Log.ConfigurationLoadSucceeded(this.fileDisplayPath, data.Count);
-
-            if (data.TryGetValue(DeclarativeConfigurationConverter.DisabledKey, out var disabledValue) &&
-                bool.TryParse(disabledValue, out var disabled) && disabled)
-            {
-                OpenTelemetryDeclarativeConfigurationEventSource.Log.SdkDisabledDetected(this.fileDisplayPath);
-            }
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.ConfigurationReloadIgnored(this.FilePath.DisplayPath);
+            return;
         }
-        catch (DeclarativeConfigurationException ex)
+
+        var document = accessor.GetDocumentForProvider(); // may throw; propagates as-is
+
+        this.Data = document.FlatKeys;
+        this.loaded = true;
+
+        OpenTelemetryDeclarativeConfigurationEventSource.Log.ConfigurationLoadSucceeded(
+            this.FilePath.DisplayPath, document.FlatKeys.Count);
+
+        if (document.FlatKeys.TryGetValue(DeclarativeConfigurationConverter.DisabledKey, out var disabledValue) &&
+            bool.TryParse(disabledValue, out var disabled) && disabled)
         {
-            OpenTelemetryDeclarativeConfigurationEventSource.Log.FailedToLoadConfiguration(this.fileDisplayPath, ex);
-            throw;
-        }
-        catch (Exception ex)
-        {
-            OpenTelemetryDeclarativeConfigurationEventSource.Log.FailedToLoadConfiguration(this.fileDisplayPath, ex);
-            throw new DeclarativeConfigurationException(
-                $"Failed to load declarative configuration from '{this.fileDisplayPath}': {ex.Message}", ex);
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.SdkDisabledDetected(this.FilePath.DisplayPath);
         }
     }
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/DeclarativeConfigurationSource.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/DeclarativeConfigurationSource.cs
@@ -6,14 +6,20 @@ using Microsoft.Extensions.Configuration;
 namespace OpenTelemetry.Configuration.Declarative;
 
 /// <summary>
-/// An <see cref="IConfigurationSource"/> that creates <see cref="DeclarativeConfigurationProvider"/> instances to read OpenTelemetry
-/// configuration from a declarative configuration YAML file.
+/// An <see cref="IConfigurationSource"/> that creates <see cref="DeclarativeConfigurationProvider"/> instances
+/// backed by a shared <see cref="DeclarativeConfigurationDocumentAccessor"/>.
 /// </summary>
-internal sealed class DeclarativeConfigurationSource(FilePath filePath) : IConfigurationSource
+internal sealed class DeclarativeConfigurationSource(DeclarativeConfigurationDocumentAccessor accessor) : IConfigurationSource
 {
-    public FilePath FilePath { get; } = filePath;
+    internal FilePath FilePath => this.Accessor.FilePath;
+
+    internal DeclarativeConfigurationDocumentAccessor Accessor { get; } = accessor;
+
+    // Build returns a new provider per call, so a source built into more than one
+    // configuration root yields more than one provider. Sharing the accessor is what keeps them
+    // reading one document produced by one parse.
 
     /// <inheritdoc/>
     public IConfigurationProvider Build(IConfigurationBuilder builder) =>
-        new DeclarativeConfigurationProvider(this.FilePath);
+        new DeclarativeConfigurationProvider(this.Accessor);
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
@@ -96,4 +96,27 @@ internal sealed class OpenTelemetryDeclarativeConfigurationEventSource : EventSo
 
     [Event(25, Message = "Declarative config: property '{0}' is not supported by this declarative configuration implementation. The configuration is invalid; check for a misspelling.", Level = EventLevel.Warning)]
     public void UnknownConfigurationProperty(string propertyPath) => this.WriteEvent(25, propertyPath);
+
+    [Event(26, Message = "Declarative config: '{0}' has already been loaded. Declarative configuration is read once at start-up, so this reload had no effect and the configuration in use is unchanged.", Level = EventLevel.Warning)]
+    public void ConfigurationReloadIgnored(string filePath) => this.WriteEvent(26, filePath);
+
+    [Event(27, Message = "Declarative config: '{0}' was parsed before the configuration provider's Load() ran, indicating a build-time consumer triggered the parse.", Level = EventLevel.Verbose)]
+    public void DocumentParsedOnDemand(string filePath) => this.WriteEvent(27, filePath);
+
+    [Event(28, Message = "Declarative config: no declarative configuration document is available.", Level = EventLevel.Verbose)]
+    public void DocumentAccessorNotAvailable() => this.WriteEvent(28);
+
+    [Event(
+        29,
+        Message = "Declarative config: source for '{0}' is already registered; the source for '{1}' will be ignored. Only the first declarative configuration file applies.",
+        Level = EventLevel.Warning)]
+    public void DifferentSourceAlreadyRegistered(string originalFilePath, string newFilePath) =>
+        this.WriteEvent(29, originalFilePath, newFilePath);
+
+    [Event(
+        30,
+        Message = "Declarative config: more than one declarative configuration file is reachable from the application's IConfiguration. Typed configuration consumers will use the document from '{0}', which is the highest-precedence file, and ignore '{1}'. Flat configuration values still follow standard IConfiguration ordering, so the two views can disagree. Use one declarative configuration file per application.",
+        Level = EventLevel.Warning)]
+    public void MultipleConfigurationDocumentsReachable(string selectedFilePath, string ignoredFilePath) =>
+        this.WriteEvent(30, selectedFilePath, ignoredFilePath);
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
@@ -100,7 +100,7 @@ internal sealed class OpenTelemetryDeclarativeConfigurationEventSource : EventSo
     [Event(26, Message = "Declarative config: '{0}' has already been loaded. Declarative configuration is read once at start-up, so this reload had no effect and the configuration in use is unchanged.", Level = EventLevel.Warning)]
     public void ConfigurationReloadIgnored(string filePath) => this.WriteEvent(26, filePath);
 
-    [Event(27, Message = "Declarative config: '{0}' was parsed before the configuration provider's Load() ran, indicating a build-time consumer triggered the parse.", Level = EventLevel.Verbose)]
+    [Event(27, Message = "Declarative config: '{0}' was parsed on demand by a typed configuration consumer rather than by the configuration provider. The file is still read only once.", Level = EventLevel.Verbose)]
     public void DocumentParsedOnDemand(string filePath) => this.WriteEvent(27, filePath);
 
     [Event(28, Message = "Declarative config: no declarative configuration document is available.", Level = EventLevel.Verbose)]
@@ -115,7 +115,7 @@ internal sealed class OpenTelemetryDeclarativeConfigurationEventSource : EventSo
 
     [Event(
         30,
-        Message = "Declarative config: more than one declarative configuration file is reachable from the application's IConfiguration. Typed configuration consumers will use the document from '{0}', which is the highest-precedence file, and ignore '{1}'. Flat configuration values still follow standard IConfiguration ordering, so the two views can disagree. Use one declarative configuration file per application.",
+        Message = "Declarative config: more than one declarative configuration file is reachable from the application's IConfiguration. Typed configuration consumers will use the document from '{0}', which is the file with the highest precedence, and ignore '{1}'. Individual flat configuration keys still follow standard IConfiguration ordering, so a flat value may come from a file other than '{0}'. Use one declarative configuration file per application.",
         Level = EventLevel.Warning)]
     public void MultipleConfigurationDocumentsReachable(string selectedFilePath, string ignoredFilePath) =>
         this.WriteEvent(30, selectedFilePath, ignoredFilePath);

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Model/DeclarativeConfiguration.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Model/DeclarativeConfiguration.cs
@@ -13,7 +13,10 @@ namespace OpenTelemetry.Configuration.Declarative;
 /// walk that builds it lives in <see cref="DeclarativeConfigurationParser"/>, so a future non-YAML source
 /// (for example a telemetry-policy push) could construct the same model without taking a YAML dependency.
 /// </remarks>
-/// <param name="FileFormat">The validated <c>file_format</c> value.</param>
+/// <param name="FileFormat">
+/// The validated <c>file_format</c> value, or an empty string when the document was empty and there
+/// was no version to validate.
+/// </param>
 internal sealed record DeclarativeConfiguration(string FileFormat)
 {
     /// <summary>

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationDocument.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationDocument.cs
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.ObjectModel;
+
+namespace OpenTelemetry.Configuration.Declarative;
+
+/// <summary>
+/// The parsed result of a declarative configuration document: the typed model and its
+/// flat <c>OTEL_*</c> key projection, produced together from a single file read.
+/// </summary>
+/// <param name="Model">
+/// The typed configuration model. Deeply immutable: collection-valued nodes cannot be modified
+/// through the returned instance.
+/// </param>
+/// <param name="FlatKeys">
+/// The flat <c>OTEL_*</c> key projection derived from <paramref name="Model"/>.
+/// Immutable from first publication.
+/// </param>
+internal sealed record DeclarativeConfigurationDocument(
+    DeclarativeConfiguration Model,
+    ReadOnlyDictionary<string, string?> FlatKeys);

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationDocumentAccessor.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationDocumentAccessor.cs
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration.Declarative;
+
+/// <summary>
+/// Holds the parsed <see cref="DeclarativeConfigurationDocument"/> for a single declarative
+/// configuration file, produced at most once across the lifetime of the application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The document is produced on the first call to <see cref="GetDocument()"/>. Every subsequent
+/// call returns the same instance.
+/// </para>
+/// </remarks>
+internal sealed class DeclarativeConfigurationDocumentAccessor
+{
+    private readonly Lazy<DeclarativeConfigurationDocument> document;
+
+    // Claimed by the first caller to reach a cold accessor, so that DocumentParsedOnDemand is
+    // emitted at most once.
+    private int parseClaimed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeclarativeConfigurationDocumentAccessor"/> class.
+    /// </summary>
+    /// <param name="filePath">The <see cref="FilePath"/> of the declarative configuration file.</param>
+    internal DeclarativeConfigurationDocumentAccessor(FilePath filePath)
+        : this(filePath, DeclarativeConfigurationReader.Read)
+    {
+    }
+
+    internal DeclarativeConfigurationDocumentAccessor(
+        FilePath filePath,
+        Func<FilePath, DeclarativeConfigurationDocument> readDocument)
+    {
+        this.FilePath = filePath;
+        this.document = new Lazy<DeclarativeConfigurationDocument>(
+            () => Parse(filePath, readDocument),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>
+    /// Gets the path of the declarative configuration file.
+    /// </summary>
+    internal FilePath FilePath { get; }
+
+    /// <summary>
+    /// Returns the parsed document, producing it on first call.
+    /// </summary>
+    /// <returns>The parsed <see cref="DeclarativeConfigurationDocument"/>.</returns>
+    /// <exception cref="DeclarativeConfigurationException">
+    /// Thrown when the file cannot be parsed. The exception is cached: subsequent calls
+    /// re-throw the same instance without re-reading the file.
+    /// </exception>
+    internal DeclarativeConfigurationDocument GetDocument() => this.GetDocument(triggeredByProvider: false);
+
+    /// <summary>
+    /// Returns the parsed document for a configuration provider, producing it on first call.
+    /// </summary>
+    /// <returns>The parsed <see cref="DeclarativeConfigurationDocument"/>.</returns>
+    /// <exception cref="DeclarativeConfigurationException">
+    /// Thrown when the file cannot be parsed. The exception is cached: subsequent calls
+    /// re-throw the same instance without re-reading the file.
+    /// </exception>
+    internal DeclarativeConfigurationDocument GetDocumentForProvider() =>
+        this.GetDocument(triggeredByProvider: true);
+
+    private static DeclarativeConfigurationDocument Parse(
+        FilePath filePath,
+        Func<FilePath, DeclarativeConfigurationDocument> readDocument)
+    {
+        try
+        {
+            return readDocument(filePath);
+        }
+        catch (DeclarativeConfigurationException ex)
+        {
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.FailedToLoadConfiguration(filePath.DisplayPath, ex);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.FailedToLoadConfiguration(filePath.DisplayPath, ex);
+            throw new DeclarativeConfigurationException(
+                $"Failed to load declarative configuration from '{filePath.DisplayPath}': {ex.Message}", ex);
+        }
+    }
+
+    private DeclarativeConfigurationDocument GetDocument(bool triggeredByProvider)
+    {
+        if (this.document.IsValueCreated)
+        {
+            return this.document.Value;
+        }
+
+        // The claim identifies the first caller to reach the accessor while it was still cold, not
+        // necessarily the caller that executed the parse. This design avoids a lock purely for diagnostic
+        // purposes, which would be a performance cost for every call to GetDocument().
+        var claimedParse = Interlocked.CompareExchange(ref this.parseClaimed, 1, 0) == 0;
+
+        var parsedDocument = this.document.Value;
+
+        if (claimedParse && !triggeredByProvider)
+        {
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.DocumentParsedOnDemand(this.FilePath.DisplayPath);
+        }
+
+        return parsedDocument;
+    }
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationReader.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Pipeline/DeclarativeConfigurationReader.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
-using Microsoft.Extensions.Configuration;
 using YamlDotNet.RepresentationModel;
 
 namespace OpenTelemetry.Configuration.Declarative;
@@ -20,7 +19,7 @@ internal static class DeclarativeConfigurationReader
 
     /// <summary>
     /// Opens <paramref name="filePath"/>, validates <c>file_format</c>, parses the typed model,
-    /// and converts it into a <see cref="ReadOnlyDictionary{TKey, TValue}"/> as flat declarative configuration keys.
+    /// and returns a <see cref="DeclarativeConfigurationDocument"/>.
     /// </summary>
     /// <param name="filePath">The <see cref="FilePath"/> for the YAML file to be read.</param>
     /// <exception cref="DeclarativeConfigurationException">
@@ -29,11 +28,9 @@ internal static class DeclarativeConfigurationReader
     /// </exception>
     /// <exception cref="YamlDotNet.Core.YamlException">
     /// Thrown when the input is not valid YAML (propagates from <see cref="YamlStream.Load(TextReader)"/>).
-    /// Callers that surface this to end users (e.g. <see cref="IConfigurationProvider.Load"/>)
-    /// should catch and wrap it as a <see cref="DeclarativeConfigurationException"/>.
     /// </exception>
-    /// <returns>A <see cref="ReadOnlyDictionary{TKey, TValue}"/> containing the flat declarative configuration.</returns>
-    internal static ReadOnlyDictionary<string, string?> Read(FilePath filePath)
+    /// <returns>A <see cref="DeclarativeConfigurationDocument"/> containing the typed model and flat keys.</returns>
+    internal static DeclarativeConfigurationDocument Read(FilePath filePath)
     {
         var data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
@@ -47,7 +44,12 @@ internal static class DeclarativeConfigurationReader
         {
             // Empty file is a no-op in overlay mode; informational event for diagnostics.
             OpenTelemetryDeclarativeConfigurationEventSource.Log.EmptyConfigurationFile(filePath.DisplayPath);
-            return new ReadOnlyDictionary<string, string?>(data);
+
+            // A document is returned rather than null so that a consumer never has to handle an
+            // absent model.
+            return new DeclarativeConfigurationDocument(
+                new DeclarativeConfiguration(string.Empty),
+                new ReadOnlyDictionary<string, string?>(data));
         }
 
         if (stream.Documents.Count > 1)
@@ -64,10 +66,9 @@ internal static class DeclarativeConfigurationReader
         root.EnsureCoreCollectionTag("<root>");
         root.EnsureUniqueStringKeys("<root>");
 
-        // Phase 1: validate file_format.
-        // Throw (rather than warn) on a type mismatch: file_format decides how the rest of the
-        // document is interpreted, so `file_format: 1.0` - a YAML 1.2 float - must fail fast rather
-        // than fall through to the generic "missing file_format" message.
+        // Validate file_format. Throw (rather than warn) on a type mismatch: file_format decides
+        // how the rest of the document is interpreted, so `file_format: 1.0` (a YAML 1.2 float)
+        // must fail fast rather than fall through to the generic "missing file_format" message.
         var rawFileFormat = root
             .ReadString(YamlKeys.FileFormat)
             .TryGetValue(out var fmt) ? fmt : null;
@@ -75,15 +76,11 @@ internal static class DeclarativeConfigurationReader
             rawFileFormat,
             OpenTelemetryDeclarativeConfigurationEventSource.Log.FileFormatWarning);
 
-        // Phase 2: walk the AST into the typed model.
         var config = DeclarativeConfigurationParser.Parse(root, fileFormat);
-
         ProcessUnrecognizedTopLevelSections(root);
-
-        // Phase 3: project the typed model into flat keys.
         DeclarativeConfigurationConverter.Convert(config, data);
 
-        return new ReadOnlyDictionary<string, string?>(data);
+        return new DeclarativeConfigurationDocument(config, new ReadOnlyDictionary<string, string?>(data));
     }
 
     // Root additionalProperties=true: unrecognized top-level keys (schema extras or not-yet-

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/DeclarativeConfigurationParser.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/DeclarativeConfigurationParser.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.ObjectModel;
 using YamlDotNet.RepresentationModel;
 
 namespace OpenTelemetry.Configuration.Declarative;
@@ -112,7 +113,10 @@ internal static class DeclarativeConfigurationParser
             entries.Add(ReadAttributeValue(attributeNode, name, type));
         }
 
-        return ModelProperty<IReadOnlyList<ResourceAttributeEntry>>.Create(entries);
+        // Frozen before it leaves the parser. The model outlives the parse, which makes this
+        // reference reachable by callers, and IReadOnlyList<T> over a live List<T> only hides the
+        // mutating members - it does not prevent a cast back to IList<T>.
+        return ModelProperty<IReadOnlyList<ResourceAttributeEntry>>.Create(entries.AsReadOnly());
     }
 
     private static ResourceAttributeType ReadAttributeType(YamlMappingNode node, string entryName)
@@ -219,7 +223,7 @@ internal static class DeclarativeConfigurationParser
         _ => false,
     };
 
-    private static List<ResolvedYamlScalar> ReadAttributeSequence(
+    private static ReadOnlyCollection<ResolvedYamlScalar> ReadAttributeSequence(
         ResourceAttributeType type,
         YamlSequenceNode sequence,
         string entryName)
@@ -265,7 +269,8 @@ internal static class DeclarativeConfigurationParser
             values.Add(resolved);
         }
 
-        return values;
+        // Frozen for the same reason as the attribute list above.
+        return values.AsReadOnly();
     }
 
     private static DeclarativeConfigurationException CreateInvalidResourceAttributeException(string message)

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/DeclarativeConfigurationParser.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Yaml/DeclarativeConfigurationParser.cs
@@ -113,9 +113,10 @@ internal static class DeclarativeConfigurationParser
             entries.Add(ReadAttributeValue(attributeNode, name, type));
         }
 
-        // Frozen before it leaves the parser. The model outlives the parse, which makes this
-        // reference reachable by callers, and IReadOnlyList<T> over a live List<T> only hides the
-        // mutating members - it does not prevent a cast back to IList<T>.
+        // Made read-only before it leaves the parser. The model outlives the parse, which makes
+        // this reference reachable by callers, and IReadOnlyList<T> over a live List<T> only hides
+        // the mutating members - it does not prevent a cast back to IList<T>. AsReadOnly closes
+        // that because ReadOnlyCollection<T> throws from the IList<T> mutators.
         return ModelProperty<IReadOnlyList<ResourceAttributeEntry>>.Create(entries.AsReadOnly());
     }
 
@@ -269,7 +270,7 @@ internal static class DeclarativeConfigurationParser
             values.Add(resolved);
         }
 
-        // Frozen for the same reason as the attribute list above.
+        // Made read-only for the same reason as the attribute list above.
         return values.AsReadOnly();
     }
 

--- a/src/OpenTelemetry.Configuration.Declarative/README.md
+++ b/src/OpenTelemetry.Configuration.Declarative/README.md
@@ -67,6 +67,12 @@ on the same `IServiceCollection` is a no-op - the first file path wins and a
 warning is emitted via EventSource. Calling it with a different path does not
 replace the first registration.
 
+Only one declarative configuration file is supported per
+`IConfigurationBuilder`. Registering the same file again is a no-op. Registering
+a different file leaves the first one in effect. Declarative configuration files
+are not layered against each other: one YAML document is chosen, never a merge
+of two. See [Precedence](#precedence).
+
 ### 3. Write a YAML config file
 
 ```yaml
@@ -141,13 +147,29 @@ declarative configuration **takes precedence over** environment variables,
 Sources you add **after** that call take precedence over YAML values (same as
 standard `IConfiguration` ordering).
 
+This layering applies between YAML and other kinds of configuration source
+(environment variables, `appsettings.json`, in-memory values, etc.). It
+does not apply between two declarative configuration files. Flat keys can be
+merged per key; the typed YAML document cannot, so exactly one document is used.
+
 ## Known limitations
 
 - Only the settings listed above are supported.
 - File watching is not supported; the YAML file is read once at start-up.
+  Calling `IConfigurationRoot.Reload()` does not re-read the YAML file or change
+  the configuration in use. The reload is ignored and a warning is emitted via
+  EventSource.
 - The package uses standard `IConfiguration` source ordering. It does not yet
   provide the specification's strict mode that ignores other SDK environment
   variables when `OTEL_CONFIG_FILE` is set.
+- `UseDeclarativeConfiguration()` applies YAML values by extending the
+  `IConfiguration` registered at the time it is called. An application that
+  replaces its `IConfiguration` registration, or clears its configuration
+  sources, *after* that call detaches the YAML source: flat keys lose the YAML
+  values while typed consumers still read the document. Register declarative
+  configuration after your configuration sources are settled, or use
+  `builder.Configuration.AddOpenTelemetryDeclarativeConfiguration()`, which adds
+  the source directly and is not affected.
 - Only string-valued structured resource attributes are emitted. Unsupported
   typed attributes are skipped and reported.
 - For duplicate structured resource attribute names, the first occurrence wins.

--- a/src/OpenTelemetry.Configuration.Declarative/README.md
+++ b/src/OpenTelemetry.Configuration.Declarative/README.md
@@ -152,7 +152,10 @@ This layering applies between YAML and other kinds of configuration source
 does not apply between two declarative configuration files. Flat keys can be
 merged per key; the typed YAML document cannot, so exactly one document is used.
 
-## Known limitations
+## Known current limitations
+
+_NOTE: These represent limitations of the current implementation. They may be_
+_resolved as this project develops and prior to release._
 
 - Only the settings listed above are supported.
 - File watching is not supported; the YAML file is read once at start-up.

--- a/src/OpenTelemetry.Configuration.Declarative/README.md
+++ b/src/OpenTelemetry.Configuration.Declarative/README.md
@@ -154,8 +154,9 @@ merged per key; the typed YAML document cannot, so exactly one document is used.
 
 ## Known current limitations
 
-_NOTE: These represent limitations of the current implementation. They may be_
-_resolved as this project develops and prior to release._
+> [!NOTE]
+> These represent limitations of the current implementation. They may be
+> resolved as this project develops and prior to release.
 
 - Only the settings listed above are supported.
 - File watching is not supported; the YAML file is read once at start-up.

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationDocumentAccessorTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationDocumentAccessorTests.cs
@@ -11,6 +11,12 @@ namespace OpenTelemetry.Configuration.Declarative.Tests;
 
 public sealed class DeclarativeConfigurationDocumentAccessorTests
 {
+    private const int FailedToLoadConfigurationEventId = 12;
+    private const int DocumentParsedOnDemandEventId = 27;
+    private const int DocumentAccessorNotAvailableEventId = 28;
+    private const int DifferentSourceAlreadyRegisteredEventId = 29;
+    private const int MultipleConfigurationDocumentsReachableEventId = 30;
+
     [Fact]
     public void GetDocument_BeforeAnyLoad_ParsesAndReturnsDocument()
     {
@@ -23,7 +29,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         Assert.NotNull(document);
         Assert.NotNull(document.Model);
         Assert.NotNull(document.FlatKeys);
-        Assert.Single(listener.Messages, e => e.EventId == 27);
+        Assert.Single(listener.Messages, e => e.EventId == DocumentParsedOnDemandEventId);
     }
 
     [Fact]
@@ -32,7 +38,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
         var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
 
-        // Build-time consumer triggers the parse.
+        // A typed consumer triggers the parse.
         var documentFromAccessor = accessor.GetDocument();
 
         // Provider loads after; must not re-parse and must use the same document.
@@ -164,7 +170,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         await Task.WhenAll(consumerTask, providerTask);
 
         Assert.Equal(1, parseCount);
-        Assert.Equal(1, listener.Count(27));
+        Assert.Equal(1, listener.GetEventIdCount(DocumentParsedOnDemandEventId));
     }
 
     [Fact]
@@ -193,7 +199,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         await Task.WhenAll(providerTask, consumerTask);
 
         Assert.Equal(1, parseCount);
-        Assert.Equal(0, listener.Count(27));
+        Assert.Equal(0, listener.GetEventIdCount(DocumentParsedOnDemandEventId));
     }
 
     [Fact]
@@ -239,7 +245,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         Assert.Equal(1, parseCount);
 
         // FailedToLoadConfiguration emitted exactly once, not on each re-throw.
-        Assert.Single(listener.Messages, e => e.EventId == 12);
+        Assert.Single(listener.Messages, e => e.EventId == FailedToLoadConfigurationEventId);
     }
 
     [Fact]
@@ -358,7 +364,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
 
         Assert.Same(providerAccessor, registeredAccessor);
         Assert.Equal("true", resolvedConfiguration[OtelEnvironmentVariables.SdkDisabled]);
-        var warning = Assert.Single(listener.Messages, e => e.EventId == 29);
+        var warning = Assert.Single(listener.Messages, e => e.EventId == DifferentSourceAlreadyRegisteredEventId);
         Assert.Equal(yamlFile1.Path, warning.Payload![0]);
         Assert.Equal(yamlFile2.Path, warning.Payload[1]);
     }
@@ -510,7 +516,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
             expectedFlatValue,
             resolved!.GetDocument().FlatKeys[OtelEnvironmentVariables.SdkDisabled]);
 
-        var warning = Assert.Single(listener.Messages, e => e.EventId == 30);
+        var warning = Assert.Single(listener.Messages, e => e.EventId == MultipleConfigurationDocumentsReachableEventId);
         Assert.Equal(expected.FilePath.DisplayPath, warning.Payload![0]);
         Assert.Equal(ignored.FilePath.DisplayPath, warning.Payload![1]);
     }
@@ -539,7 +545,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         Assert.Same(
             providerAccessor,
             DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(configuration));
-        Assert.DoesNotContain(listener.Messages, e => e.EventId == 30);
+        Assert.DoesNotContain(listener.Messages, e => e.EventId == MultipleConfigurationDocumentsReachableEventId);
     }
 
     [Fact]
@@ -552,7 +558,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         using var sp = services.BuildServiceProvider();
 
         Assert.Null(DeclarativeConfigurationDocumentAccessorResolver.Find(sp));
-        Assert.Single(listener.Messages, e => e.EventId == 28);
+        Assert.Single(listener.Messages, e => e.EventId == DocumentAccessorNotAvailableEventId);
     }
 
     [Fact]
@@ -565,7 +571,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         using var sp = services.BuildServiceProvider();
 
         Assert.Null(DeclarativeConfigurationDocumentAccessorResolver.Find(sp));
-        Assert.Single(listener.Messages, e => e.EventId == 28);
+        Assert.Single(listener.Messages, e => e.EventId == DocumentAccessorNotAvailableEventId);
     }
 
     [Fact]
@@ -689,7 +695,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
 
         Assert.Null(consumer.Accessor);
         Assert.Null(consumer.Document);
-        Assert.Single(listener.Messages, e => e.EventId == 28);
+        Assert.Single(listener.Messages, e => e.EventId == DocumentAccessorNotAvailableEventId);
     }
 
     [Fact]
@@ -698,15 +704,15 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
         var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
 
-        // Build-time consumer queries accessor before Load() runs.
+        // A typed consumer queries the accessor before Load() runs.
         using var listener = CreateVerboseListener();
         _ = accessor.GetDocument();
-        Assert.Single(listener.Messages, e => e.EventId == 27);
+        Assert.Single(listener.Messages, e => e.EventId == DocumentParsedOnDemandEventId);
 
         var provider = new DeclarativeConfigurationProvider(accessor);
         provider.Load();
 
-        Assert.Single(listener.Messages, e => e.EventId == 27);
+        Assert.Single(listener.Messages, e => e.EventId == DocumentParsedOnDemandEventId);
     }
 
     [Fact]
@@ -720,7 +726,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         provider.Load();
         _ = accessor.GetDocument();
 
-        Assert.DoesNotContain(listener.Messages, e => e.EventId == 27);
+        Assert.DoesNotContain(listener.Messages, e => e.EventId == DocumentParsedOnDemandEventId);
     }
 
     [Fact]
@@ -735,7 +741,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
         firstProvider.Load();
         secondProvider.Load();
 
-        Assert.DoesNotContain(listener.Messages, e => e.EventId == 27);
+        Assert.DoesNotContain(listener.Messages, e => e.EventId == DocumentParsedOnDemandEventId);
     }
 
     private static TestEventListener CreateVerboseListener()
@@ -803,7 +809,7 @@ public sealed class DeclarativeConfigurationDocumentAccessorTests
                 EventKeywords.All);
         }
 
-        internal int Count(int eventId) => this.eventIds.Count(id => id == eventId);
+        internal int GetEventIdCount(int eventId) => this.eventIds.Count(id => id == eventId);
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData) =>
             this.eventIds.Enqueue(eventData.EventId);

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationDocumentAccessorTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationDocumentAccessorTests.cs
@@ -1,0 +1,811 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Tests;
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+public sealed class DeclarativeConfigurationDocumentAccessorTests
+{
+    [Fact]
+    public void GetDocument_BeforeAnyLoad_ParsesAndReturnsDocument()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+
+        using var listener = CreateVerboseListener();
+        var document = accessor.GetDocument();
+
+        Assert.NotNull(document);
+        Assert.NotNull(document.Model);
+        Assert.NotNull(document.FlatKeys);
+        Assert.Single(listener.Messages, e => e.EventId == 27);
+    }
+
+    [Fact]
+    public void Load_AfterGetDocument_UsesSameDocument()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+
+        // Build-time consumer triggers the parse.
+        var documentFromAccessor = accessor.GetDocument();
+
+        // Provider loads after; must not re-parse and must use the same document.
+        var provider = new DeclarativeConfigurationProvider(accessor);
+        provider.Load();
+
+        var documentFromProvider = accessor.GetDocument();
+
+        Assert.Same(documentFromAccessor, documentFromProvider);
+        Assert.True(provider.TryGet(OtelEnvironmentVariables.SdkDisabled, out _));
+    }
+
+    [Fact]
+    public void GetDocument_CalledMultipleTimes_ReturnsSameInstance()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+
+        var first = accessor.GetDocument();
+        var second = accessor.GetDocument();
+        var third = accessor.GetDocument();
+
+        Assert.Same(first, second);
+        Assert.Same(first, third);
+    }
+
+    [Fact]
+    public void FlatKeys_IsReadOnly_MutationThrows()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+
+        var document = accessor.GetDocument();
+
+        Assert.Throws<NotSupportedException>(() =>
+            ((IDictionary<string, string?>)document.FlatKeys)["new.key"] = "value");
+    }
+
+    [Fact]
+    public void ModelCollections_AreReadOnly_MutationThrows()
+    {
+        const string yaml = """
+            file_format: "1.1"
+            resource:
+              attributes:
+                - name: scalar
+                  value: value
+                - name: sequence
+                  type: string_array
+                  value: [one, two]
+            """;
+
+        using var yamlFile = DeclarativeYamlTestFile.CreateYamlFile(yaml);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+
+        var model = accessor.GetDocument().Model;
+        var resource = model.Resource.Value;
+        var attributes = resource.Attributes.Value;
+        Assert.True(attributes[1].TryGetSequenceValues(out var sequenceValues));
+
+        Assert.Throws<NotSupportedException>(() =>
+            ((IList<ResourceAttributeEntry>)attributes).Add(attributes[0]));
+        Assert.Throws<NotSupportedException>(() =>
+            ((IList<ResolvedYamlScalar>)sequenceValues).Add(sequenceValues[0]));
+    }
+
+    [Fact]
+    public void GetDocument_ConcurrentAccess_ParsesOnceAndReturnsSameInstance()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var parseCount = 0;
+        var accessor = new DeclarativeConfigurationDocumentAccessor(
+            new FilePath(yamlFile.Path),
+            filePath =>
+            {
+                Interlocked.Increment(ref parseCount);
+                return DeclarativeConfigurationReader.Read(filePath);
+            });
+
+        const int threadCount = 8;
+        var results = new DeclarativeConfigurationDocument?[threadCount];
+        using var barrier = new Barrier(threadCount);
+
+        var threads = Enumerable.Range(0, threadCount).Select(i => new Thread(() =>
+        {
+            barrier.SignalAndWait();
+            results[i] = accessor.GetDocument();
+        })).ToArray();
+
+        foreach (var t in threads)
+        {
+            t.Start();
+        }
+
+        foreach (var t in threads)
+        {
+            t.Join();
+        }
+
+        var first = results[0];
+        Assert.NotNull(first);
+        Assert.All(results, r => Assert.Same(first, r));
+        Assert.Equal(1, parseCount);
+    }
+
+    [Fact]
+    public async Task GetDocument_ConcurrentWithProviderLoad_ConsumerWinnerEmitsOnDemandEventOnce()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var parseStarted = new ManualResetEventSlim();
+        using var releaseParse = new ManualResetEventSlim();
+        var parseCount = 0;
+        var accessor = new DeclarativeConfigurationDocumentAccessor(
+            new FilePath(yamlFile.Path),
+            filePath =>
+            {
+                Interlocked.Increment(ref parseCount);
+                parseStarted.Set();
+                releaseParse.Wait();
+                return DeclarativeConfigurationReader.Read(filePath);
+            });
+        var provider = new DeclarativeConfigurationProvider(accessor);
+
+        using var listener = new ConcurrentEventListener();
+        var consumerTask = Task.Run(() => accessor.GetDocument());
+        Assert.True(parseStarted.Wait(TimeSpan.FromSeconds(10)));
+        var providerTask = Task.Run(provider.Load);
+        releaseParse.Set();
+        await Task.WhenAll(consumerTask, providerTask);
+
+        Assert.Equal(1, parseCount);
+        Assert.Equal(1, listener.Count(27));
+    }
+
+    [Fact]
+    public async Task GetDocument_ConcurrentWithProviderLoad_ProviderWinnerDoesNotEmitOnDemandEvent()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var parseStarted = new ManualResetEventSlim();
+        using var releaseParse = new ManualResetEventSlim();
+        var parseCount = 0;
+        var accessor = new DeclarativeConfigurationDocumentAccessor(
+            new FilePath(yamlFile.Path),
+            filePath =>
+            {
+                Interlocked.Increment(ref parseCount);
+                parseStarted.Set();
+                releaseParse.Wait();
+                return DeclarativeConfigurationReader.Read(filePath);
+            });
+        var provider = new DeclarativeConfigurationProvider(accessor);
+
+        using var listener = new ConcurrentEventListener();
+        var providerTask = Task.Run(provider.Load);
+        Assert.True(parseStarted.Wait(TimeSpan.FromSeconds(10)));
+        var consumerTask = Task.Run(() => accessor.GetDocument());
+        releaseParse.Set();
+        await Task.WhenAll(providerTask, consumerTask);
+
+        Assert.Equal(1, parseCount);
+        Assert.Equal(0, listener.Count(27));
+    }
+
+    [Fact]
+    public void GetDocument_InvalidFileFormat_ThrowsDeclarativeConfigurationException()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(fileFormat: "99.0");
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+
+        Assert.Throws<DeclarativeConfigurationException>(accessor.GetDocument);
+    }
+
+    [Fact]
+    public void Load_InvalidFileFormat_ThrowsDeclarativeConfigurationException()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(fileFormat: "99.0");
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(accessor);
+
+        Assert.Throws<DeclarativeConfigurationException>(provider.Load);
+    }
+
+    [Fact]
+    public void GetDocument_ParseFailure_ExceptionIsCachedAndEventEmittedOnce()
+    {
+        using var factory = new DeclarativeYamlTestFileFactory();
+        var path = factory.CreateYamlFile("file_format: \"99.0\"");
+        var parseCount = 0;
+        var accessor = new DeclarativeConfigurationDocumentAccessor(
+            new FilePath(path),
+            filePath =>
+            {
+                Interlocked.Increment(ref parseCount);
+                return DeclarativeConfigurationReader.Read(filePath);
+            });
+
+        using var listener = CreateErrorListener();
+
+        var ex1 = Assert.Throws<DeclarativeConfigurationException>(accessor.GetDocument);
+        var ex2 = Assert.Throws<DeclarativeConfigurationException>(accessor.GetDocument);
+
+        // Lazy caches the exception; both calls surface the same instance.
+        Assert.Same(ex1, ex2);
+        Assert.Equal(1, parseCount);
+
+        // FailedToLoadConfiguration emitted exactly once, not on each re-throw.
+        Assert.Single(listener.Messages, e => e.EventId == 12);
+    }
+
+    [Fact]
+    public void GetDocument_MissingFile_IsWrappedAsDeclarativeConfigurationException()
+    {
+        using var factory = new DeclarativeYamlTestFileFactory();
+        var accessor = new DeclarativeConfigurationDocumentAccessor(
+            new FilePath(Path.Combine(factory.TempDirectory, "nonexistent.yaml")));
+
+        var ex = Assert.Throws<DeclarativeConfigurationException>(accessor.GetDocument);
+        Assert.IsType<FileNotFoundException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void UseDeclarativeConfiguration_RegistersAccessorAsSingleton()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        var services = new ServiceCollection();
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile.Path);
+
+        using var sp = services.BuildServiceProvider();
+        var accessor1 = sp.GetService<DeclarativeConfigurationDocumentAccessor>();
+        var accessor2 = sp.GetService<DeclarativeConfigurationDocumentAccessor>();
+
+        Assert.NotNull(accessor1);
+        Assert.Same(accessor1, accessor2);
+    }
+
+    [Fact]
+    public void UseDeclarativeConfiguration_AccessorMatchesProviderAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        var services = new ServiceCollection();
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile.Path);
+
+        using var sp = services.BuildServiceProvider();
+        var config = sp.GetRequiredService<IConfiguration>();
+        var root = Assert.IsType<IConfigurationRoot>(config, exactMatch: false);
+        var provider = root.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single();
+
+        var registeredAccessor = sp.GetRequiredService<DeclarativeConfigurationDocumentAccessor>();
+
+        Assert.Same(provider.Accessor, registeredAccessor);
+    }
+
+    [Fact]
+    public void UseDeclarativeConfiguration_SourceAlreadyOnConfigurationManager_ReusesAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var configuration = new ConfigurationManager();
+        configuration.AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path);
+
+        var providerAccessor = configuration.Sources
+            .OfType<DeclarativeConfigurationSource>()
+            .Single()
+            .Accessor;
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile.Path);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var registeredAccessor =
+            serviceProvider.GetRequiredService<DeclarativeConfigurationDocumentAccessor>();
+
+        Assert.Same(providerAccessor, registeredAccessor);
+        Assert.Single(configuration.Sources.OfType<DeclarativeConfigurationSource>());
+    }
+
+    [Fact]
+    public void UseDeclarativeConfiguration_SourceAlreadyOnConfigurationRoot_ReusesAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var configuration = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile.Path);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var registeredAccessor =
+            serviceProvider.GetRequiredService<DeclarativeConfigurationDocumentAccessor>();
+
+        Assert.Same(providerAccessor, registeredAccessor);
+    }
+
+    [Fact]
+    public void UseDeclarativeConfiguration_DifferentSourceAlreadyOnConfigurationRoot_FirstAccessorWins()
+    {
+        using var yamlFile1 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var yamlFile2 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+        var configuration = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile1.Path)
+            .Build();
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile2.Path);
+
+        using var listener = CreateWarningListener();
+        using var serviceProvider = services.BuildServiceProvider();
+        var resolvedConfiguration = serviceProvider.GetRequiredService<IConfiguration>();
+        var registeredAccessor =
+            serviceProvider.GetRequiredService<DeclarativeConfigurationDocumentAccessor>();
+
+        Assert.Same(providerAccessor, registeredAccessor);
+        Assert.Equal("true", resolvedConfiguration[OtelEnvironmentVariables.SdkDisabled]);
+        var warning = Assert.Single(listener.Messages, e => e.EventId == 29);
+        Assert.Equal(yamlFile1.Path, warning.Payload![0]);
+        Assert.Equal(yamlFile2.Path, warning.Payload[1]);
+    }
+
+    [Fact]
+    public void UseDeclarativeConfiguration_SourceReturnedByConfigurationFactory_ReusesAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var configuration = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(_ => configuration);
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile.Path);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        // Resolve the accessor first. Its registration must force IConfiguration construction
+        // before choosing between the new candidate and the provider's existing accessor.
+        var registeredAccessor =
+            serviceProvider.GetRequiredService<DeclarativeConfigurationDocumentAccessor>();
+
+        Assert.Same(providerAccessor, registeredAccessor);
+    }
+
+    [Fact]
+    public void UseDeclarativeConfiguration_SecondCall_IsNoOpAndFirstAccessorWins()
+    {
+        using var yamlFile1 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var yamlFile2 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+
+        var services = new ServiceCollection();
+        var builder = new TestOpenTelemetryBuilder(services);
+        builder.UseDeclarativeConfiguration(yamlFile1.Path);
+        builder.UseDeclarativeConfiguration(yamlFile2.Path); // no-op
+
+        using var sp = services.BuildServiceProvider();
+        var accessor = sp.GetRequiredService<DeclarativeConfigurationDocumentAccessor>();
+
+        Assert.Equal(yamlFile1.Path, accessor.FilePath.DisplayPath);
+    }
+
+    [Fact]
+    public void Resolver_SourceAddedViaBuilderExtension_FindsProviderAccessor()
+    {
+        // The scan fallback recovers the accessor when UseDeclarativeConfiguration was never called,
+        // which is the only route available to IConfigurationBuilder - it has no IServiceCollection.
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        var configRoot = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+        var providerAccessor = configRoot.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configRoot);
+
+        using var sp = services.BuildServiceProvider();
+        var accessor = DeclarativeConfigurationDocumentAccessorResolver.Find(sp);
+
+        Assert.Same(providerAccessor, accessor);
+    }
+
+    [Fact]
+    public void Resolver_SourceBehindChainedConfiguration_FindsProviderAccessor()
+    {
+        // A configuration composed from another root exposes the YAML keys but reaches the
+        // declarative provider only through ChainedConfigurationProvider, so the scan recurses.
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        var yamlRoot = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+        var providerAccessor = yamlRoot.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var chained = new ConfigurationBuilder().AddConfiguration(yamlRoot).Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(chained);
+        services.AddRepresentativeDeclarativeConfigurationConsumer();
+
+        using var sp = services.BuildServiceProvider();
+        var consumer = sp.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+
+        Assert.Equal("true", chained[OtelEnvironmentVariables.SdkDisabled]);
+        Assert.Same(providerAccessor, consumer.Accessor);
+        Assert.Same(providerAccessor.GetDocument(), consumer.Document);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Resolver_ChainedAndDirectSources_SelectsHighestPrecedenceDocumentAndWarns(bool chainedFirst)
+    {
+        // The single-source guard cannot see a declarative source that arrives through
+        // AddConfiguration, so two documents can coexist. Flat keys then resolve from the last
+        // provider that supplies them, so the resolver must select the same document, whichever
+        // order the two were registered in. Otherwise flat and typed consumers disagree.
+        using var chainedFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var directFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+
+        var chainedRoot = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(chainedFile.Path)
+            .Build();
+
+        var builder = new ConfigurationBuilder();
+        if (chainedFirst)
+        {
+            builder.AddConfiguration(chainedRoot).AddOpenTelemetryDeclarativeConfiguration(directFile.Path);
+        }
+        else
+        {
+            builder.AddOpenTelemetryDeclarativeConfiguration(directFile.Path).AddConfiguration(chainedRoot);
+        }
+
+        var configuration = builder.Build();
+
+        var chainedAccessor = chainedRoot.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var directAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+
+        var expected = chainedFirst ? directAccessor : chainedAccessor;
+        var ignored = chainedFirst ? chainedAccessor : directAccessor;
+
+        using var listener = CreateWarningListener();
+
+        var resolved = DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(configuration);
+
+        Assert.Same(expected, resolved);
+
+        // The selected document is the one whose flat value the application observes.
+        var expectedFlatValue = chainedFirst ? "false" : "true";
+        Assert.Equal(expectedFlatValue, configuration[OtelEnvironmentVariables.SdkDisabled]);
+        Assert.Equal(
+            expectedFlatValue,
+            resolved!.GetDocument().FlatKeys[OtelEnvironmentVariables.SdkDisabled]);
+
+        var warning = Assert.Single(listener.Messages, e => e.EventId == 30);
+        Assert.Equal(expected.FilePath.DisplayPath, warning.Payload![0]);
+        Assert.Equal(ignored.FilePath.DisplayPath, warning.Payload![1]);
+    }
+
+    [Fact]
+    public void Resolver_SameConfigurationChainedTwice_IsOneDocumentAndDoesNotWarn()
+    {
+        // One document reachable by two routes is not an ambiguous configuration.
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        var yamlRoot = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+        var providerAccessor = yamlRoot.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+
+        var configuration = new ConfigurationBuilder()
+            .AddConfiguration(yamlRoot)
+            .AddConfiguration(yamlRoot)
+            .Build();
+
+        using var listener = CreateWarningListener();
+
+        Assert.Same(
+            providerAccessor,
+            DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(configuration));
+        Assert.DoesNotContain(listener.Messages, e => e.EventId == 30);
+    }
+
+    [Fact]
+    public void Resolver_NoDeclarativeProviderInConfigRoot_ReturnsNullAndLogs()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+
+        using var listener = CreateVerboseListener();
+        using var sp = services.BuildServiceProvider();
+
+        Assert.Null(DeclarativeConfigurationDocumentAccessorResolver.Find(sp));
+        Assert.Single(listener.Messages, e => e.EventId == 28);
+    }
+
+    [Fact]
+    public void Resolver_NonRootConfiguration_ReturnsNullAndLogs()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new NonRootConfiguration());
+
+        using var listener = CreateVerboseListener();
+        using var sp = services.BuildServiceProvider();
+
+        Assert.Null(DeclarativeConfigurationDocumentAccessorResolver.Find(sp));
+        Assert.Single(listener.Messages, e => e.EventId == 28);
+    }
+
+    [Fact]
+    public void Resolver_NoConfigurationRegisteredAtAll_ReturnsNullAndDoesNotThrow()
+    {
+        using var sp = new ServiceCollection().BuildServiceProvider();
+
+        Assert.Null(DeclarativeConfigurationDocumentAccessorResolver.Find(sp));
+    }
+
+    [Fact]
+    public void Resolver_ExplicitRegistrationTakesPrecedenceOverScan()
+    {
+        // An accessor registered by UseDeclarativeConfiguration wins over whatever a scan of the
+        // configuration would turn up. The two views can still disagree, as they do here: nothing
+        // stops an application replacing its IConfiguration registration, or clearing its sources,
+        // after the accessor was registered. Explicit registration wins by design because it is the
+        // caller's stated intent; the flat overlay is what is lost in that case.
+        using var yamlFile1 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var yamlFile2 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+
+        var scannableRoot = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile1.Path)
+            .Build();
+        var explicitAccessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile2.Path));
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(scannableRoot);
+        services.AddSingleton(explicitAccessor);
+
+        using var sp = services.BuildServiceProvider();
+
+        Assert.Same(explicitAccessor, DeclarativeConfigurationDocumentAccessorResolver.Find(sp));
+    }
+
+    [Fact]
+    public void RepresentativeConsumer_BuilderSource_UsesProviderAccessorAndDocument()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var configuration = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddRepresentativeDeclarativeConfigurationConsumer();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var consumer =
+            serviceProvider.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+
+        Assert.Same(providerAccessor, consumer.Accessor);
+        Assert.Same(providerAccessor.GetDocument(), consumer.Document);
+    }
+
+    [Fact]
+    public void RepresentativeConsumer_SecondBuilderSourceAttempt_UsesFirstProviderAccessorAndDocument()
+    {
+        using var yamlFile1 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var yamlFile2 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+        var configuration = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile1.Path)
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile2.Path)
+            .Build();
+        var provider = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddRepresentativeDeclarativeConfigurationConsumer();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var consumer =
+            serviceProvider.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+
+        Assert.Equal(yamlFile1.Path, provider.FilePath.DisplayPath);
+        Assert.Same(provider.Accessor, consumer.Accessor);
+        Assert.Same(provider.Accessor.GetDocument(), consumer.Document);
+        var document = Assert.IsType<DeclarativeConfigurationDocument>(consumer.Document);
+        Assert.Equal(
+            "true",
+            document.FlatKeys[OtelEnvironmentVariables.SdkDisabled]);
+    }
+
+    [Fact]
+    public void RepresentativeConsumer_ExplicitRegistration_UsesSingleProviderAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var services = new ServiceCollection();
+        services.AddRepresentativeDeclarativeConfigurationConsumer();
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile.Path);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var configuration = Assert.IsType<IConfigurationRoot>(
+            serviceProvider.GetRequiredService<IConfiguration>(), exactMatch: false);
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var consumer =
+            serviceProvider.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+
+        Assert.Same(providerAccessor, consumer.Accessor);
+        Assert.Same(providerAccessor.GetDocument(), consumer.Document);
+    }
+
+    [Fact]
+    public void RepresentativeConsumer_MissingProvider_HasNoDocumentAndDoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddRepresentativeDeclarativeConfigurationConsumer();
+
+        using var listener = CreateVerboseListener();
+        using var serviceProvider = services.BuildServiceProvider();
+        var consumer =
+            serviceProvider.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+
+        Assert.Null(consumer.Accessor);
+        Assert.Null(consumer.Document);
+        Assert.Single(listener.Messages, e => e.EventId == 28);
+    }
+
+    [Fact]
+    public void Load_DoesNotEmitDocumentParsedOnDemand_WhenAccessorWasAlreadyQueried()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+
+        // Build-time consumer queries accessor before Load() runs.
+        using var listener = CreateVerboseListener();
+        _ = accessor.GetDocument();
+        Assert.Single(listener.Messages, e => e.EventId == 27);
+
+        var provider = new DeclarativeConfigurationProvider(accessor);
+        provider.Load();
+
+        Assert.Single(listener.Messages, e => e.EventId == 27);
+    }
+
+    [Fact]
+    public void GetDocument_DoesNotEmitDocumentParsedOnDemand_WhenLoadRanFirst()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(accessor);
+
+        using var listener = CreateVerboseListener();
+        provider.Load();
+        _ = accessor.GetDocument();
+
+        Assert.DoesNotContain(listener.Messages, e => e.EventId == 27);
+    }
+
+    [Fact]
+    public void Load_OnSecondProviderSharingAccessor_DoesNotEmitDocumentParsedOnDemand()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+        var firstProvider = new DeclarativeConfigurationProvider(accessor);
+        var secondProvider = new DeclarativeConfigurationProvider(accessor);
+
+        using var listener = CreateVerboseListener();
+        firstProvider.Load();
+        secondProvider.Load();
+
+        Assert.DoesNotContain(listener.Messages, e => e.EventId == 27);
+    }
+
+    private static TestEventListener CreateVerboseListener()
+    {
+        var listener = new TestEventListener();
+        listener.EnableEvents(
+            OpenTelemetryDeclarativeConfigurationEventSource.Log,
+            EventLevel.Verbose,
+            EventKeywords.All);
+        return listener;
+    }
+
+    private static TestEventListener CreateWarningListener()
+    {
+        var listener = new TestEventListener();
+        listener.EnableEvents(
+            OpenTelemetryDeclarativeConfigurationEventSource.Log,
+            EventLevel.Warning,
+            EventKeywords.All);
+        return listener;
+    }
+
+    private static TestEventListener CreateErrorListener()
+    {
+        var listener = new TestEventListener();
+        listener.EnableEvents(
+            OpenTelemetryDeclarativeConfigurationEventSource.Log,
+            EventLevel.Error,
+            EventKeywords.All);
+        return listener;
+    }
+
+    private sealed class TestOpenTelemetryBuilder(IServiceCollection services) : IOpenTelemetryBuilder
+    {
+        public IServiceCollection Services { get; } = services;
+    }
+
+    private sealed class NonRootConfiguration : IConfiguration
+    {
+        private readonly IConfiguration inner = new ConfigurationBuilder().Build();
+
+        public string? this[string key]
+        {
+            get => this.inner[key];
+            set => this.inner[key] = value;
+        }
+
+        public IEnumerable<IConfigurationSection> GetChildren() => this.inner.GetChildren();
+
+        public Microsoft.Extensions.Primitives.IChangeToken GetReloadToken() =>
+            this.inner.GetReloadToken();
+
+        public IConfigurationSection GetSection(string key) => this.inner.GetSection(key);
+    }
+
+    private sealed class ConcurrentEventListener : EventListener
+    {
+        private readonly ConcurrentQueue<int> eventIds = new();
+
+        internal ConcurrentEventListener()
+        {
+            this.EnableEvents(
+                OpenTelemetryDeclarativeConfigurationEventSource.Log,
+                EventLevel.Verbose,
+                EventKeywords.All);
+        }
+
+        internal int Count(int eventId) => this.eventIds.Count(id => id == eventId);
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData) =>
+            this.eventIds.Enqueue(eventData.EventId);
+    }
+}

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationEventSourceTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationEventSourceTests.cs
@@ -703,7 +703,7 @@ public sealed class DeclarativeConfigurationEventSourceTests
     private static ReadOnlyDictionary<string, string?> ReadConfiguration(string yaml)
     {
         using var factory = new DeclarativeYamlTestFileFactory();
-        return DeclarativeConfigurationReader.Read(new FilePath(factory.CreateYamlFile(yaml)));
+        return DeclarativeConfigurationReader.Read(new FilePath(factory.CreateYamlFile(yaml))).FlatKeys;
     }
 
     private sealed class TestEventSourceBuilder : IOpenTelemetryBuilder

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationExtensionTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationExtensionTests.cs
@@ -1,9 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Tests;
 
 namespace OpenTelemetry.Configuration.Declarative.Tests;
 
@@ -249,6 +251,30 @@ public sealed class DeclarativeConfigurationExtensionTests
     }
 
     [Fact]
+    public void AddOpenTelemetryDeclarativeConfiguration_DifferentPaths_FirstSourceWinsAndSecondIsNotLoaded()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var yamlFileFactory = new DeclarativeYamlTestFileFactory();
+        var missingSecondPath = Path.Combine(yamlFileFactory.TempDirectory, "missing.yaml");
+        using var listener = new TestEventListener();
+        listener.EnableEvents(
+            OpenTelemetryDeclarativeConfigurationEventSource.Log,
+            EventLevel.Warning,
+            EventKeywords.All);
+        using var configuration = new ConfigurationManager();
+
+        configuration.AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path);
+        configuration.AddOpenTelemetryDeclarativeConfiguration(missingSecondPath);
+
+        Assert.Equal("true", configuration[OtelEnvironmentVariables.SdkDisabled]);
+        var source = Assert.Single(configuration.Sources.OfType<DeclarativeConfigurationSource>());
+        Assert.Equal(yamlFile.Path, source.FilePath.DisplayPath);
+        var warning = Assert.Single(listener.Messages, e => e.EventId == 29);
+        Assert.Equal(yamlFile.Path, warning.Payload![0]);
+        Assert.Equal(missingSecondPath, warning.Payload[1]);
+    }
+
+    [Fact]
     public void AddOpenTelemetryDeclarativeConfiguration_AndUseDeclarativeConfiguration_DoesNotDoubleSource()
     {
         // Verify that calling the IConfigurationBuilder extension directly and then
@@ -268,6 +294,24 @@ public sealed class DeclarativeConfigurationExtensionTests
         _ = ResolveConfiguration(services);
 
         Assert.Single(configManager.Sources, s => s is DeclarativeConfigurationSource);
+    }
+
+    [Fact]
+    public void AddOpenTelemetryDeclarativeConfiguration_ThenUseDifferentPath_FirstSourceWins()
+    {
+        using var yamlFile1 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        using var yamlFile2 = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+        using var configManager = new ConfigurationManager();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configManager);
+        configManager.AddOpenTelemetryDeclarativeConfiguration(yamlFile1.Path);
+
+        new TestOpenTelemetryBuilder(services).UseDeclarativeConfiguration(yamlFile2.Path);
+
+        var configuration = ResolveConfiguration(services);
+        Assert.Equal("true", configuration[OtelEnvironmentVariables.SdkDisabled]);
+        var source = Assert.Single(configManager.Sources.OfType<DeclarativeConfigurationSource>());
+        Assert.Equal(yamlFile1.Path, source.FilePath.DisplayPath);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationExtensionTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationExtensionTests.cs
@@ -267,8 +267,10 @@ public sealed class DeclarativeConfigurationExtensionTests
         configuration.AddOpenTelemetryDeclarativeConfiguration(missingSecondPath);
 
         Assert.Equal("true", configuration[OtelEnvironmentVariables.SdkDisabled]);
+
         var source = Assert.Single(configuration.Sources.OfType<DeclarativeConfigurationSource>());
         Assert.Equal(yamlFile.Path, source.FilePath.DisplayPath);
+
         var warning = Assert.Single(listener.Messages, e => e.EventId == 29);
         Assert.Equal(yamlFile.Path, warning.Payload![0]);
         Assert.Equal(missingSecondPath, warning.Payload[1]);
@@ -310,6 +312,7 @@ public sealed class DeclarativeConfigurationExtensionTests
 
         var configuration = ResolveConfiguration(services);
         Assert.Equal("true", configuration[OtelEnvironmentVariables.SdkDisabled]);
+
         var source = Assert.Single(configManager.Sources.OfType<DeclarativeConfigurationSource>());
         Assert.Equal(yamlFile1.Path, source.FilePath.DisplayPath);
     }

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationHostIntegrationTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationHostIntegrationTests.cs
@@ -60,6 +60,28 @@ public sealed class DeclarativeConfigurationHostIntegrationTests
     }
 
     [Fact]
+    public void ModernHost_BuilderConfiguration_RepresentativeConsumerUsesProviderAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path);
+        builder.Services.AddRepresentativeDeclarativeConfigurationConsumer();
+
+        using var host = builder.Build();
+        var configuration = Assert.IsType<IConfigurationRoot>(
+            host.Services.GetRequiredService<IConfiguration>(), exactMatch: false);
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var consumer =
+            host.Services.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+
+        Assert.Same(providerAccessor, consumer.Accessor);
+        Assert.Same(providerAccessor.GetDocument(), consumer.Document);
+    }
+
+    [Fact]
     public void ModernHost_DisabledTrue_ProducesNoopTracerProvider()
     {
         using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
@@ -200,6 +222,30 @@ public sealed class DeclarativeConfigurationHostIntegrationTests
         Assert.Contains(
             resource.Attributes,
             a => a.Key == "service.name" && (string)a.Value == "classic-host-svc-via-otel");
+    }
+
+    [Fact]
+    public void ClassicHost_BuilderConfiguration_RepresentativeConsumerUsesProviderAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        using var host = new HostBuilder()
+            .ConfigureAppConfiguration(builder =>
+                builder.AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path))
+            .ConfigureServices(services =>
+                services.AddRepresentativeDeclarativeConfigurationConsumer())
+            .Build();
+        var configuration = Assert.IsType<IConfigurationRoot>(
+            host.Services.GetRequiredService<IConfiguration>(), exactMatch: false);
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        var consumer =
+            host.Services.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+
+        Assert.Same(providerAccessor, consumer.Accessor);
+        Assert.Same(providerAccessor.GetDocument(), consumer.Document);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationProviderTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationProviderTests.cs
@@ -1,6 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics.Tracing;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using OpenTelemetry.Tests;
+
 namespace OpenTelemetry.Configuration.Declarative.Tests;
 
 public sealed class DeclarativeConfigurationProviderTests
@@ -9,7 +15,7 @@ public sealed class DeclarativeConfigurationProviderTests
     public void Load_MissingFile_ThrowsDeclarativeConfigurationException()
     {
         using var yamlFile = new DeclarativeYamlTestFileFactory();
-        var provider = new DeclarativeConfigurationProvider(new FilePath(Path.Combine(yamlFile.TempDirectory, "nonexistent.yaml")));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(Path.Combine(yamlFile.TempDirectory, "nonexistent.yaml"))));
 
         var ex = Assert.Throws<DeclarativeConfigurationException>(provider.Load);
         Assert.IsType<FileNotFoundException>(ex.InnerException);
@@ -22,7 +28,7 @@ public sealed class DeclarativeConfigurationProviderTests
             disabled: true,
             resourceAttributes: new Dictionary<string, string> { ["service.name"] = "my-service" });
 
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path)));
         provider.Load();
 
         Assert.True(provider.TryGet(OtelEnvironmentVariables.SdkDisabled, out var disabled));
@@ -36,7 +42,7 @@ public sealed class DeclarativeConfigurationProviderTests
     public void Load_EmptyFile_LeavesDataEmpty()
     {
         using var yamlFile = DeclarativeYamlTestFile.CreateYamlFile(string.Empty);
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path)));
         provider.Load();
 
         Assert.False(provider.TryGet(OtelEnvironmentVariables.SdkDisabled, out _));
@@ -44,28 +50,126 @@ public sealed class DeclarativeConfigurationProviderTests
     }
 
     [Fact]
-    public void Load_SecondLoad_ReplacesDataSoRemovedYamlKeysDoNotPersist()
+    public void Load_SecondLoad_LeavesDataUnchangedAndLogs()
     {
         using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
         var yamlWithoutDisabled = """
             file_format: "1.0"
             """;
 
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        using var listener = new TestEventListener();
+        listener.EnableEvents(
+            OpenTelemetryDeclarativeConfigurationEventSource.Log,
+            EventLevel.Warning,
+            EventKeywords.All);
+
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(accessor);
         provider.Load();
         Assert.True(provider.TryGet(OtelEnvironmentVariables.SdkDisabled, out _));
 
+        // Rewrite the file; the second Load() must ignore the change.
         File.WriteAllText(yamlFile.Path, yamlWithoutDisabled);
         provider.Load();
 
-        Assert.False(provider.TryGet(OtelEnvironmentVariables.SdkDisabled, out _));
+        // Key still present - second load was a no-op.
+        Assert.True(provider.TryGet(OtelEnvironmentVariables.SdkDisabled, out _));
+        Assert.Single(listener.Messages, e => e.EventId == 26);
+    }
+
+    [Fact]
+    public void Load_SecondLoad_DoesNotReparse()
+    {
+        var parseCount = 0;
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        var accessor = new DeclarativeConfigurationDocumentAccessor(
+            new FilePath(yamlFile.Path),
+            filePath =>
+            {
+                Interlocked.Increment(ref parseCount);
+                return DeclarativeConfigurationReader.Read(filePath);
+            });
+        var provider = new DeclarativeConfigurationProvider(accessor);
+
+        provider.Load();
+        provider.Load();
+
+        Assert.Equal(1, parseCount);
+    }
+
+    [Fact]
+    public void Load_SetsDataToTheDocumentsFlatKeysWithoutCopying()
+    {
+        // Identity, not equivalence: the provider must publish the document's own dictionary, so that
+        // every provider sharing an accessor exposes one projection rather than a copy per provider.
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var accessor = new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(accessor);
+
+        provider.Load();
+
+        // Data is protected on ConfigurationProvider and the provider is sealed, so there is no
+        // subclass seam; reflection is the only way to assert on the instance itself.
+        var data = typeof(ConfigurationProvider)
+            .GetProperty("Data", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(provider);
+
+        Assert.Same(accessor.GetDocument().FlatKeys, data);
+    }
+
+    [Fact]
+    public void Load_ProviderRebuiltFromSameSource_ReusesDocumentWithoutReparsing()
+    {
+        // ConfigurationManager rebuilds its providers when the sources collection is mutated other
+        // than by appending. The rebuilt provider shares the accessor, so the file is not re-read.
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+        var parseCount = 0;
+        var accessor = new DeclarativeConfigurationDocumentAccessor(
+            new FilePath(yamlFile.Path),
+            filePath =>
+            {
+                Interlocked.Increment(ref parseCount);
+                return DeclarativeConfigurationReader.Read(filePath);
+            });
+
+        using var manager = new ConfigurationManager();
+        manager.AddOpenTelemetryDeclarativeConfiguration(accessor);
+        var originalProvider = ((IConfigurationRoot)manager).Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single();
+
+        manager.Sources.Insert(0, new MemoryConfigurationSource());
+
+        var rebuiltProvider = ((IConfigurationRoot)manager).Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single();
+
+        Assert.NotSame(originalProvider, rebuiltProvider);
+        Assert.Same(accessor, rebuiltProvider.Accessor);
+        Assert.Equal("true", manager[OtelEnvironmentVariables.SdkDisabled]);
+        Assert.Equal(1, parseCount);
+    }
+
+    [Fact]
+    public void Reload_OnConfigurationRoot_DoesNotThrow()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: true);
+
+        var root = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+
+        // IConfigurationRoot.Reload() must not throw even though the provider ignores it.
+        var ex = Record.Exception(root.Reload);
+        Assert.Null(ex);
     }
 
     [Fact]
     public void Load_InvalidFileFormat_ThrowsDeclarativeConfigurationException()
     {
         using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(fileFormat: "99.0");
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path)));
 
         Assert.Throws<DeclarativeConfigurationException>(provider.Load);
     }
@@ -82,7 +186,7 @@ public sealed class DeclarativeConfigurationProviderTests
             """;
 
         using var yamlFile = DeclarativeYamlTestFile.CreateYamlFile(yaml);
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path)));
         provider.Load();
 
         Assert.True(provider.TryGet(OtelEnvironmentVariables.ResourceAttributes, out var attrs));
@@ -101,7 +205,7 @@ public sealed class DeclarativeConfigurationProviderTests
             """;
 
         using var yamlFile = DeclarativeYamlTestFile.CreateYamlFile(yaml);
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path)));
 
         Assert.Throws<DeclarativeConfigurationException>(provider.Load);
     }
@@ -114,7 +218,7 @@ public sealed class DeclarativeConfigurationProviderTests
             """;
 
         using var yamlFile = DeclarativeYamlTestFile.CreateYamlFile(yaml);
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path)));
 
         Assert.Throws<DeclarativeConfigurationException>(provider.Load);
     }
@@ -125,7 +229,7 @@ public sealed class DeclarativeConfigurationProviderTests
         const string yaml = "{ unclosed: [bracket";
 
         using var yamlFile = DeclarativeYamlTestFile.CreateYamlFile(yaml);
-        var provider = new DeclarativeConfigurationProvider(new FilePath(yamlFile.Path));
+        var provider = new DeclarativeConfigurationProvider(new DeclarativeConfigurationDocumentAccessor(new FilePath(yamlFile.Path)));
 
         var ex = Assert.Throws<DeclarativeConfigurationException>(provider.Load);
         Assert.NotNull(ex.InnerException);

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationReaderTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationReaderTests.cs
@@ -2048,6 +2048,6 @@ public sealed class DeclarativeConfigurationReaderTests
     private static ReadOnlyDictionary<string, string?> ReadConfiguration(string yaml)
     {
         using var factory = new DeclarativeYamlTestFileFactory();
-        return DeclarativeConfigurationReader.Read(new FilePath(factory.CreateYamlFile(yaml)));
+        return DeclarativeConfigurationReader.Read(new FilePath(factory.CreateYamlFile(yaml))).FlatKeys;
     }
 }

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationSchemaTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationSchemaTests.cs
@@ -363,7 +363,7 @@ public sealed class DeclarativeConfigurationSchemaTests
     private static ReadOnlyDictionary<string, string?> ReadConfiguration(string yaml)
     {
         using var factory = new DeclarativeYamlTestFileFactory();
-        return DeclarativeConfigurationReader.Read(new FilePath(factory.CreateYamlFile(yaml)));
+        return DeclarativeConfigurationReader.Read(new FilePath(factory.CreateYamlFile(yaml))).FlatKeys;
     }
 
     private static DeclarativeConfiguration ParseConfiguration(string yaml)

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationSdkIntegrationTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationSdkIntegrationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Configuration.Declarative.Tests;
@@ -251,6 +252,58 @@ public sealed class DeclarativeConfigurationSdkIntegrationTests
             a => a.Key == "service.name" && (string)a.Value == "from-yaml");
     }
 
+    [Fact]
+    public void PlainSdk_SharedConfigurationRoot_RepresentativeConsumersShareProviderAccessor()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+        var configuration = new ConfigurationBuilder()
+            .AddOpenTelemetryDeclarativeConfiguration(yamlFile.Path)
+            .Build();
+        var providerAccessor = configuration.Providers
+            .OfType<DeclarativeConfigurationProvider>()
+            .Single()
+            .Accessor;
+        RepresentativeDeclarativeConfigurationConsumer? tracerConsumer = null;
+        RepresentativeDeclarativeConfigurationConsumer? meterConsumer = null;
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IConfiguration>(configuration);
+                services.AddRepresentativeDeclarativeConfigurationConsumer();
+            })
+            .ConfigureResource(resource => resource.AddDetector(serviceProvider =>
+            {
+                tracerConsumer =
+                    serviceProvider.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+                return new EmptyResourceDetector();
+            }))
+            .Build();
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IConfiguration>(configuration);
+                services.AddRepresentativeDeclarativeConfigurationConsumer();
+            })
+            .ConfigureResource(resource => resource.AddDetector(serviceProvider =>
+            {
+                meterConsumer =
+                    serviceProvider.GetRequiredService<RepresentativeDeclarativeConfigurationConsumer>();
+                return new EmptyResourceDetector();
+            }))
+            .Build();
+
+        var resolvedTracerConsumer =
+            Assert.IsType<RepresentativeDeclarativeConfigurationConsumer>(tracerConsumer);
+        var resolvedMeterConsumer =
+            Assert.IsType<RepresentativeDeclarativeConfigurationConsumer>(meterConsumer);
+
+        Assert.Same(providerAccessor, resolvedTracerConsumer.Accessor);
+        Assert.Same(providerAccessor, resolvedMeterConsumer.Accessor);
+        Assert.Same(resolvedTracerConsumer.Document, resolvedMeterConsumer.Document);
+    }
+
     private static TracerProvider BuildTracerProvider(string yamlPath, string? sourceName = null)
     {
         var config = new ConfigurationBuilder()
@@ -291,4 +344,9 @@ public sealed class DeclarativeConfigurationSdkIntegrationTests
             .Build()!;
     }
 #endif
+
+    private sealed class EmptyResourceDetector : IResourceDetector
+    {
+        public Resource Detect() => Resource.Empty;
+    }
 }

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/RepresentativeDeclarativeConfigurationConsumer.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/RepresentativeDeclarativeConfigurationConsumer.cs
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+internal sealed class RepresentativeDeclarativeConfigurationConsumer(
+    DeclarativeConfigurationDocumentAccessor? accessor)
+{
+    internal DeclarativeConfigurationDocumentAccessor? Accessor { get; } = accessor;
+
+    internal DeclarativeConfigurationDocument? Document => this.Accessor?.GetDocument();
+}

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/RepresentativeDeclarativeConfigurationConsumerExtensions.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/RepresentativeDeclarativeConfigurationConsumerExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+internal static class RepresentativeDeclarativeConfigurationConsumerExtensions
+{
+    // Stands in for how a real typed consumer acquires the document: resolve the
+    // accessor at construction time, tolerate its absence, and contribute nothing when absent.
+    internal static IServiceCollection AddRepresentativeDeclarativeConfigurationConsumer(
+        this IServiceCollection services)
+    {
+        services.AddSingleton(sp =>
+            new RepresentativeDeclarativeConfigurationConsumer(
+                DeclarativeConfigurationDocumentAccessorResolver.Find(sp)));
+        return services;
+    }
+}


### PR DESCRIPTION
Contibutes to #7658

## Changes

Introduces `DeclarativeConfigurationDocument` and `DeclarativeConfigurationDocumentAccessor` so the parsed YAML document is retained for the application lifetime. A second Load() returns the frozen result and logs a warning. When multiple declarative documents are reachable simultaneously, the resolver picks the highest-precedence one and warns for each ignored file.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~