### PR TITLE
[OTLP] Fix CA certificate loading

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -13,7 +13,7 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed CA certificate loading (e.g. using `OTEL_EXPORTER_OTLP_CERTIFICATE`)
   for PEM-encoded certificates that only contain a public key.
-  ([#7691](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7691))
+  ([#7693](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7693))
 
 ## 1.18.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -11,6 +11,10 @@ Notes](../../RELEASENOTES.md).
   now be dropped.
   ([#7688](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7688))
 
+* Fixed CA certificate loading (e.g. using `OTEL_EXPORTER_OTLP_CERTIFICATE`)
+  for PEM-encoded certificates that only contain a public key.
+  ([#7691](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7691))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
@@ -35,7 +35,12 @@ internal static class OtlpCertificateManager
 
         try
         {
-            var caCertificate = X509Certificate2.CreateFromPemFile(caCertificatePath);
+#if NET9_0_OR_GREATER
+            var caCertificate = X509CertificateLoader.LoadCertificateFromFile(caCertificatePath);
+#else
+            var pemContents = File.ReadAllText(caCertificatePath);
+            var caCertificate = X509Certificate2.CreateFromPem(pemContents);
+#endif
 
             OpenTelemetryProtocolExporterEventSource.Log.MtlsCertificateLoaded(
                 CaCertificateType,

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpCertificateManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpCertificateManagerTests.cs
@@ -105,6 +105,28 @@ INVALID CERTIFICATE DATA
     }
 
     [Fact]
+    public void LoadCaCertificate_LoadsCertificate_WhenPemFileHasNoPrivateKey()
+    {
+        using var selfSignedCertificate = CreateSelfSignedCertificate();
+        var certificateOnlyPem = selfSignedCertificate.ExportCertificatePem();
+
+        var tempCertFile = Path.GetTempFileName();
+        File.WriteAllText(tempCertFile, certificateOnlyPem);
+
+        try
+        {
+            using var caCertificate = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadCaCertificate(tempCertFile);
+
+            Assert.Equal(selfSignedCertificate.Thumbprint, caCertificate.Thumbprint);
+            Assert.False(caCertificate.HasPrivateKey);
+        }
+        finally
+        {
+            File.Delete(tempCertFile);
+        }
+    }
+
+    [Fact]
     public void LoadCaCertificate_ThrowsInvalidOperationException_WhenTrustStoreFileIsEmpty()
     {
         var tempTrustStoreFile = Path.GetTempFileName();


### PR DESCRIPTION
Fixes #7692

## Changes

Fix being unable to use a CA certificate that does not contain a private key (e.g. a self-signed collector certificate configured via `OTEL_EXPORTER_OTLP_CERTIFICATE`).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
