### PR TITLE
[Exporters] Encode maps and arrays as JSON

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
+  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
   (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
 
 ## 1.18.0
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -12,7 +12,7 @@ Notes](../../RELEASENOTES.md).
   ([#7679](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7679))
 
 * Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
-  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
+  (e.g. `[1,2,3]`) instead of being Base64-encoded as per the specification.
   ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
 
 ## 1.18.0

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -11,7 +11,7 @@ Notes](../../RELEASENOTES.md).
   (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
   Other array- and map-valued attributes are now also JSON-encoded instead
   of falling back to the .NET type name (e.g. `System.Int32[]`).
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
 
 ## 1.18.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -7,6 +7,12 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
+  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
+  Other array- and map-valued attributes are now also JSON-encoded instead
+  of falling back to the .NET type name (e.g. `System.Int32[]`).
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -7,10 +7,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
-  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
-  Other array- and map-valued attributes are now also JSON-encoded instead
-  of falling back to the .NET type name (e.g. `System.Int32[]`).
+* Fixed array- and map-valued attributes being serialized as the .NET type
+  name (e.g. `System.Byte[]`, `System.Int32[]`) instead of being JSON-encoded
+  as per the specification. `byte[]`-valued attributes are now
+  Base64-encoded, and other array- and map-valued attributes are now
+  JSON-encoded.
   ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
 
 ## 1.18.0-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/OpenTelemetry.Exporter.Prometheus.AspNetCore.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/OpenTelemetry.Exporter.Prometheus.AspNetCore.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Shims\Lock.cs" Link="Includes\Shims\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\TagWriter\*.cs" Link="Includes\TagWriter\%(Filename).cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -11,7 +11,7 @@ Notes](../../RELEASENOTES.md).
   (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
   Other array- and map-valued attributes are now also JSON-encoded instead
   of falling back to the .NET type name (e.g. `System.Int32[]`).
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
 
 ## 1.18.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -7,6 +7,12 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
+  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
+  Other array- and map-valued attributes are now also JSON-encoded instead
+  of falling back to the .NET type name (e.g. `System.Int32[]`).
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.18.0-beta.1
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -7,10 +7,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
-  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
-  Other array- and map-valued attributes are now also JSON-encoded instead
-  of falling back to the .NET type name (e.g. `System.Int32[]`).
+* Fixed array- and map-valued attributes being serialized as the .NET type
+  name (e.g. `System.Byte[]`, `System.Int32[]`) instead of being JSON-encoded
+  as per the specification. `byte[]`-valued attributes are now
+  Base64-encoded, and other array- and map-valued attributes are now
+  JSON-encoded.
   ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
 
 ## 1.18.0-beta.1

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusExporterEventSource.cs
@@ -111,4 +111,8 @@ internal sealed class PrometheusExporterEventSource : EventSource, IConfiguratio
     [Event(12, Message = "Failed to collect metrics for a scrape request; the scrape endpoint may be under heavy load.", Level = EventLevel.Error)]
     public void CollectFailed()
         => this.WriteEvent(12);
+
+    [Event(13, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
+    public void UnsupportedAttributeType(string type, string key)
+        => this.WriteEvent(13, type, key);
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/PrometheusAnyValueWriter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/PrometheusAnyValueWriter.cs
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Exporter.Prometheus.Serialization;
+
+// Computes the string representation of an array- or map-valued attribute for use as a
+// Prometheus label value. As described by
+// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/common/README.md#anyvalue-representation-for-non-otlp-protocols.
+// This JSON-encodes the value (numbers/booleans/nested arrays/maps keep their native JSON
+// typing, byte arrays are Base64-encoded). Scalar values never reach this writer;
+// TextFormatSerializer.GetLabelValueString formats those directly.
+internal sealed class PrometheusAnyValueWriter : JsonStringArrayTagWriter<PrometheusAnyValueWriter.AnyValue>
+{
+    public static readonly PrometheusAnyValueWriter Instance = new();
+
+    private PrometheusAnyValueWriter()
+    {
+    }
+
+    public string ToLabelValueString(string key, object? value)
+    {
+        AnyValue state = default;
+        return this.TryWriteTag(ref state, key, value) ? state.Value ?? string.Empty : string.Empty;
+    }
+
+    protected override void WriteIntegralTag(ref AnyValue state, string key, long value)
+    {
+        state.Value = value.ToString(CultureInfo.InvariantCulture);
+        state.IsJsonLiteral = true;
+    }
+
+    protected override void WriteFloatingPointTag(ref AnyValue state, string key, double value)
+    {
+        state.Value = value.ToString(CultureInfo.InvariantCulture);
+
+        // JSON has no representation for NaN or infinity, so those are emitted as strings.
+        state.IsJsonLiteral = !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
+    protected override void WriteBooleanTag(ref AnyValue state, string key, bool value)
+    {
+        state.Value = value ? "true" : "false";
+        state.IsJsonLiteral = true;
+    }
+
+    protected override void WriteStringTag(ref AnyValue state, string key, ReadOnlySpan<char> value)
+    {
+        state.Value = value.ToString();
+        state.IsJsonLiteral = false;
+    }
+
+    protected override void WriteArrayTag(ref AnyValue state, string key, ArraySegment<byte> arrayUtf8JsonBytes)
+    {
+#if NET
+        state.Value = Encoding.UTF8.GetString(arrayUtf8JsonBytes.Array!, arrayUtf8JsonBytes.Offset, arrayUtf8JsonBytes.Count);
+#else
+        state.Value = Encoding.UTF8.GetString(arrayUtf8JsonBytes.Array, arrayUtf8JsonBytes.Offset, arrayUtf8JsonBytes.Count);
+#endif
+        state.IsJsonLiteral = true;
+    }
+
+    protected override void OnUnsupportedTagDropped(string tagKey, string tagValueTypeFullName)
+        => PrometheusExporterEventSource.Log.UnsupportedAttributeType(tagValueTypeFullName, tagKey);
+
+    protected override bool TryWriteEmptyTag(ref AnyValue state, string key, object? value)
+    {
+        // Empty values are represented as JSON null when nested (as an array element or map
+        // value); this writer is only reached for the array/map case, so this is always the
+        // nested rule, never the top-level "empty string" rule.
+        state.Value = null;
+        state.IsJsonLiteral = true;
+        return true;
+    }
+
+    protected override void WriteKvListTag(
+        ref AnyValue state,
+        string key,
+        IEnumerable<KeyValuePair<string, object?>> kvList,
+        int? tagValueMaxLength)
+    {
+        using var stream = new MemoryStream();
+        var writer = new Utf8JsonWriter(stream);
+
+        try
+        {
+            writer.WriteStartObject();
+
+            foreach (var kvp in kvList)
+            {
+                AnyValue nestedValue = default;
+                if (this.TryWriteTag(ref nestedValue, kvp.Key, kvp.Value, tagValueMaxLength))
+                {
+                    writer.WritePropertyName(kvp.Key);
+
+                    if (nestedValue.Value == null)
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else if (nestedValue.IsJsonLiteral)
+                    {
+                        // The nested write produced JSON (a number, a boolean, an array or an
+                        // object), so it is embedded as-is rather than being quoted as a string.
+#if NET
+                        writer.WriteRawValue(nestedValue.Value);
+#else
+                        using var doc = JsonDocument.Parse(nestedValue.Value);
+                        doc.RootElement.WriteTo(writer);
+#endif
+                    }
+                    else
+                    {
+                        writer.WriteStringValue(nestedValue.Value);
+                    }
+                }
+            }
+
+            writer.WriteEndObject();
+            writer.Flush();
+        }
+        finally
+        {
+            writer.Dispose();
+        }
+
+        var success = stream.TryGetBuffer(out var buffer);
+        Debug.Assert(success, "success was false");
+
+#if NET
+        state.Value = Encoding.UTF8.GetString(buffer.Array!, buffer.Offset, buffer.Count);
+#else
+        state.Value = Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
+#endif
+        state.IsJsonLiteral = true;
+    }
+
+    internal struct AnyValue
+    {
+        public string? Value;
+
+        public bool IsJsonLiteral;
+    }
+}

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
@@ -522,7 +522,7 @@ internal abstract class TextFormatSerializer
 #endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static int WriteLabelValue(byte[] buffer, int cursor, object? value)
+    internal static int WriteLabelValue(byte[] buffer, int cursor, object? value, string key = "")
     {
         switch (value)
         {
@@ -586,6 +586,16 @@ internal abstract class TextFormatSerializer
             case Guid guidValue:
                 return WriteSpanFormattableLabelValue(buffer, cursor, guidValue, stackalloc char[36]);
 #endif
+
+            // See https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/common/README.md#byte-arrays;
+            // byte arrays are Base64-encoded rather than falling through to the array handling below.
+            case byte[] byteArrayValue:
+                return WriteLabelValue(buffer, cursor, Convert.ToBase64String(byteArrayValue));
+
+            // Arrays and maps are JSON-encoded, per
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/common/README.md#anyvalue-representation-for-non-otlp-protocols.
+            case Array or IEnumerable<KeyValuePair<string, object?>>:
+                return WriteLabelValue(buffer, cursor, PrometheusAnyValueWriter.Instance.ToLabelValueString(key, value));
 
             case IFormattable formattableValue:
                 return WriteLabelValue(buffer, cursor, formattableValue.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty);
@@ -1004,7 +1014,7 @@ internal abstract class TextFormatSerializer
 
             writtenKeyRanges[writtenKeyRangeCount++] = (keyStart, writtenKey.Length);
 
-            cursor = WriteSanitizedLabel(buffer, cursor, value);
+            cursor = WriteSanitizedLabel(buffer, cursor, value, key);
             wroteLabel = true;
 
             return true;
@@ -1387,7 +1397,7 @@ internal abstract class TextFormatSerializer
         in MetricPoint metricPoint,
         in TextFormatSerializerOptions options);
 
-    private static string GetLabelValueString(object? labelValue) => labelValue switch
+    private static string GetLabelValueString(string key, object? labelValue) => labelValue switch
     {
         null => string.Empty,
         string stringValue => stringValue,
@@ -1403,6 +1413,8 @@ internal abstract class TextFormatSerializer
         float floatValue => GetCanonicalLabelValueString(floatValue),
         double doubleValue => GetCanonicalLabelValueString(doubleValue),
         decimal decimalValue => decimalValue.ToString(CultureInfo.InvariantCulture),
+        byte[] byteArrayValue => Convert.ToBase64String(byteArrayValue),
+        Array or IEnumerable<KeyValuePair<string, object?>> => PrometheusAnyValueWriter.Instance.ToLabelValueString(key, labelValue),
         IFormattable formattableValue => formattableValue.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty,
         _ => labelValue.ToString() ?? string.Empty,
     };
@@ -1470,19 +1482,23 @@ internal abstract class TextFormatSerializer
 
     private static List<LabelData> CreateScopeLabelData(Metric metric)
     {
+        const string OTelScopeNameKey = "otel_scope_name";
+        const string OTelScopeVersionKey = "otel_scope_version";
+        const string OTelScopeSchemaUrlKey = "otel_scope_schema_url";
+
         var scopeLabels = new List<LabelData>(3)
         {
-            new("otel_scope_name", "otel_scope_name", GetLabelValueString(metric.MeterName)),
+            new(OTelScopeNameKey, OTelScopeNameKey, GetLabelValueString(OTelScopeNameKey, metric.MeterName)),
         };
 
         if (!string.IsNullOrEmpty(metric.MeterVersion))
         {
-            scopeLabels.Add(new("otel_scope_version", "otel_scope_version", GetLabelValueString(metric.MeterVersion)));
+            scopeLabels.Add(new(OTelScopeVersionKey, OTelScopeVersionKey, GetLabelValueString(OTelScopeVersionKey, metric.MeterVersion)));
         }
 
         if (!string.IsNullOrEmpty(metric.MeterSchemaUrl))
         {
-            scopeLabels.Add(new("otel_scope_schema_url", "otel_scope_schema_url", GetLabelValueString(metric.MeterSchemaUrl)));
+            scopeLabels.Add(new(OTelScopeSchemaUrlKey, OTelScopeSchemaUrlKey, GetLabelValueString(OTelScopeSchemaUrlKey, metric.MeterSchemaUrl)));
         }
 
         if (metric.MeterTags == null)
@@ -1499,7 +1515,7 @@ internal abstract class TextFormatSerializer
                 continue;
             }
 
-            scopeLabels.Add(new(tag.Key, labelKey, GetLabelValueString(tag.Value)));
+            scopeLabels.Add(new(tag.Key, labelKey, GetLabelValueString(tag.Key, tag.Value)));
         }
 
         return scopeLabels;
@@ -1699,13 +1715,13 @@ internal abstract class TextFormatSerializer
 #endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int WriteSanitizedLabel(byte[] buffer, int cursor, object? labelValue)
+    private static int WriteSanitizedLabel(byte[] buffer, int cursor, object? labelValue, string key = "")
     {
         buffer[cursor++] = unchecked((byte)'=');
         buffer[cursor++] = unchecked((byte)'"');
 
         // In Prometheus, a label with an empty label value is considered equivalent to a label that does not exist.
-        cursor = WriteLabelValue(buffer, cursor, labelValue);
+        cursor = WriteLabelValue(buffer, cursor, labelValue, key);
         buffer[cursor++] = unchecked((byte)'"');
 
         return cursor;
@@ -1724,7 +1740,7 @@ internal abstract class TextFormatSerializer
         }
 
         labels ??= [];
-        labels.Add(new LabelData(originalKey, outputKey, GetLabelValueString(value)));
+        labels.Add(new LabelData(originalKey, outputKey, GetLabelValueString(originalKey, value)));
     }
 
     private static bool IsValidLabelKey(string value)
@@ -1943,7 +1959,7 @@ internal abstract class TextFormatSerializer
                 // The grouped key is already the final output key; it is written verbatim, or
                 // quoted when the allow-utf-8 scheme produced a non-legacy label name.
                 cursor = WriteLabelName(buffer, cursor, key);
-                cursor = WriteSanitizedLabel(buffer, cursor, value);
+                cursor = WriteSanitizedLabel(buffer, cursor, value, key);
                 buffer[cursor++] = unchecked((byte)',');
                 wroteLabel = true;
             }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/Serialization/TextFormatSerializer.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 #endif
 #endif
 using System.Buffers;
+using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -594,7 +595,7 @@ internal abstract class TextFormatSerializer
 
             // Arrays and maps are JSON-encoded, per
             // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/common/README.md#anyvalue-representation-for-non-otlp-protocols.
-            case Array or IEnumerable<KeyValuePair<string, object?>>:
+            case Array or IEnumerable<KeyValuePair<string, object?>> or IEnumerable<KeyValuePair<string, string?>> or IDictionary:
                 return WriteLabelValue(buffer, cursor, PrometheusAnyValueWriter.Instance.ToLabelValueString(key, value));
 
             case IFormattable formattableValue:
@@ -1414,7 +1415,7 @@ internal abstract class TextFormatSerializer
         double doubleValue => GetCanonicalLabelValueString(doubleValue),
         decimal decimalValue => decimalValue.ToString(CultureInfo.InvariantCulture),
         byte[] byteArrayValue => Convert.ToBase64String(byteArrayValue),
-        Array or IEnumerable<KeyValuePair<string, object?>> => PrometheusAnyValueWriter.Instance.ToLabelValueString(key, labelValue),
+        Array or IEnumerable<KeyValuePair<string, object?>> or IEnumerable<KeyValuePair<string, string?>> or IDictionary => PrometheusAnyValueWriter.Instance.ToLabelValueString(key, labelValue),
         IFormattable formattableValue => formattableValue.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty,
         _ => labelValue.ToString() ?? string.Empty,
     };

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/OpenTelemetry.Exporter.Prometheus.HttpListener.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/OpenTelemetry.Exporter.Prometheus.HttpListener.csproj
@@ -5,6 +5,7 @@
     <Description>Stand-alone HttpListener for hosting OpenTelemetry .NET Prometheus Exporter</Description>
     <PackageTags>$(PackageTags);prometheus;metrics</PackageTags>
     <MinVerTagPrefix>coreunstable-</MinVerTagPrefix>
+    <ReferenceSystemTextJsonPackages>true</ReferenceSystemTextJsonPackages>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' != 'true'">
@@ -28,6 +29,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\Shims\Lock.cs" Link="Includes\Shims\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\StopwatchExtensions.cs" Link="Includes\StopwatchExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\TagWriter\*.cs" Link="Includes\TagWriter\%(Filename).cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
+  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes](../../RELEASENOTES.md).
 
 * Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
   (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
 
 ## 1.18.0
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -12,10 +12,6 @@ Notes](../../RELEASENOTES.md).
   (`IEnumerable<KeyValuePair<string, string?>>` and `IDictionary`).
   ([#7679](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7679))
 
-* Fixed `byte[]`-valued tags being serialized as a JSON array of numbers
-  (e.g. `[1,2,3]`) instead of being Base64-encoded as-per the specification.
-  ([#7694](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7694))
-
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
@@ -67,6 +67,8 @@ internal sealed class ZipkinTagWriter : JsonStringArrayTagWriter<Utf8JsonWriter>
 
     protected override bool TryWriteEmptyTag(ref Utf8JsonWriter state, string key, object? value) => false;
 
+    protected override bool TryWriteByteArrayTag(ref Utf8JsonWriter state, string key, ReadOnlySpan<byte> value) => false;
+
     protected override void WriteKvListTag(ref Utf8JsonWriter writer, string key, IEnumerable<KeyValuePair<string, object?>> value, int? tagValueMaxLength)
     {
         using var stream = new MemoryStream();

--- a/src/Shared/TagWriter/ArrayTagWriter.cs
+++ b/src/Shared/TagWriter/ArrayTagWriter.cs
@@ -21,6 +21,28 @@ internal abstract class ArrayTagWriter<TArrayState>
 
     public abstract void WriteStringValue(ref TArrayState state, ReadOnlySpan<char> value);
 
+    // Byte arrays and nested arrays/maps are only supported by writers that can embed an
+    // arbitrarily-nested value as an array element (currently the JSON-based writers); the
+    // default implementations report "not supported" so that TagWriter falls back to writing
+    // a string representation of the value instead.
+    public virtual bool TryWriteByteArrayValue(ref TArrayState state, ReadOnlySpan<byte> value) => false;
+
+    public virtual bool TryBeginNestedArrayValue(ref TArrayState state) => false;
+
+    public virtual void EndNestedArrayValue(ref TArrayState state)
+    {
+    }
+
+    public virtual bool TryBeginNestedObjectValue(ref TArrayState state) => false;
+
+    public virtual void WriteNestedObjectPropertyName(ref TArrayState state, string name)
+    {
+    }
+
+    public virtual void EndNestedObjectValue(ref TArrayState state)
+    {
+    }
+
     public abstract void EndWriteArray(ref TArrayState state);
 
     public virtual void AbortWriteArray(ref TArrayState state)

--- a/src/Shared/TagWriter/JsonStringArrayTagWriter.cs
+++ b/src/Shared/TagWriter/JsonStringArrayTagWriter.cs
@@ -25,7 +25,18 @@ internal abstract class JsonStringArrayTagWriter<TTagState> : TagWriter<TTagStat
 
     protected abstract void WriteArrayTag(ref TTagState writer, string key, ArraySegment<byte> arrayUtf8JsonBytes);
 
-    protected override bool TryWriteByteArrayTag(ref TTagState consoleTag, string key, ReadOnlySpan<byte> value) => false;
+    protected override bool TryWriteByteArrayTag(ref TTagState state, string key, ReadOnlySpan<byte> value)
+    {
+        // See https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/common/README.md#byte-arrays;
+        // byte arrays SHOULD be Base64-encoded when represented as a string for non-OTLP protocols.
+#if NET
+        var base64 = Convert.ToBase64String(value);
+#else
+        var base64 = Convert.ToBase64String(value.ToArray());
+#endif
+        this.WriteStringTag(ref state, key, base64.AsSpan());
+        return true;
+    }
 
     internal readonly struct JsonArrayTagWriterState(MemoryStream stream, Utf8JsonWriter writer)
     {
@@ -58,29 +69,19 @@ internal abstract class JsonStringArrayTagWriter<TTagState> : TagWriter<TTagStat
         }
 
         public override void WriteBooleanValue(ref JsonArrayTagWriterState state, bool value)
-        {
-            state.Writer.WriteBooleanValue(value);
-        }
+            => state.Writer.WriteBooleanValue(value);
 
         public override void WriteFloatingPointValue(ref JsonArrayTagWriterState state, double value)
-        {
-            state.Writer.WriteNumberValue(value);
-        }
+            => state.Writer.WriteNumberValue(value);
 
         public override void WriteIntegralValue(ref JsonArrayTagWriterState state, long value)
-        {
-            state.Writer.WriteNumberValue(value);
-        }
+            => state.Writer.WriteNumberValue(value);
 
         public override void WriteNullValue(ref JsonArrayTagWriterState state)
-        {
-            state.Writer.WriteNullValue();
-        }
+            => state.Writer.WriteNullValue();
 
         public override void WriteStringValue(ref JsonArrayTagWriterState state, ReadOnlySpan<char> value)
-        {
-            state.Writer.WriteStringValue(value);
-        }
+            => state.Writer.WriteStringValue(value);
 
         private static JsonArrayTagWriterState EnsureWriter()
         {

--- a/src/Shared/TagWriter/JsonStringArrayTagWriter.cs
+++ b/src/Shared/TagWriter/JsonStringArrayTagWriter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 
 namespace OpenTelemetry.Internal;
@@ -72,7 +73,17 @@ internal abstract class JsonStringArrayTagWriter<TTagState> : TagWriter<TTagStat
             => state.Writer.WriteBooleanValue(value);
 
         public override void WriteFloatingPointValue(ref JsonArrayTagWriterState state, double value)
-            => state.Writer.WriteNumberValue(value);
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                // JSON has no representation for NaN or infinity, so those are emitted as strings.
+                state.Writer.WriteStringValue(value.ToString(CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                state.Writer.WriteNumberValue(value);
+            }
+        }
 
         public override void WriteIntegralValue(ref JsonArrayTagWriterState state, long value)
             => state.Writer.WriteNumberValue(value);
@@ -82,6 +93,36 @@ internal abstract class JsonStringArrayTagWriter<TTagState> : TagWriter<TTagStat
 
         public override void WriteStringValue(ref JsonArrayTagWriterState state, ReadOnlySpan<char> value)
             => state.Writer.WriteStringValue(value);
+
+        public override bool TryWriteByteArrayValue(ref JsonArrayTagWriterState state, ReadOnlySpan<byte> value)
+        {
+            // See https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/common/README.md#byte-arrays;
+            // byte arrays are Base64-encoded when nested inside another array or map, the same
+            // as when they are the top-level attribute value.
+            state.Writer.WriteBase64StringValue(value);
+            return true;
+        }
+
+        public override bool TryBeginNestedArrayValue(ref JsonArrayTagWriterState state)
+        {
+            state.Writer.WriteStartArray();
+            return true;
+        }
+
+        public override void EndNestedArrayValue(ref JsonArrayTagWriterState state)
+            => state.Writer.WriteEndArray();
+
+        public override bool TryBeginNestedObjectValue(ref JsonArrayTagWriterState state)
+        {
+            state.Writer.WriteStartObject();
+            return true;
+        }
+
+        public override void WriteNestedObjectPropertyName(ref JsonArrayTagWriterState state, string name)
+            => state.Writer.WritePropertyName(name);
+
+        public override void EndNestedObjectValue(ref JsonArrayTagWriterState state)
+            => state.Writer.WriteEndObject();
 
         private static JsonArrayTagWriterState EnsureWriter()
         {

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -439,80 +439,151 @@ internal abstract class TagWriter<TTagState, TArrayState>
     {
         for (var i = 0; i < array.Length; ++i)
         {
-            var item = array.GetValue(i);
-            if (item == null)
-            {
-                this.arrayWriter.WriteNullValue(ref arrayState);
-                continue;
-            }
+            this.WriteArrayItem(ref arrayState, array.GetValue(i), tagValueMaxLength);
+        }
+    }
 
-            // Ordered by how often each type is likely to appear for performance
-            switch (item)
-            {
-                case string s:
+    private void WriteArrayItem(ref TArrayState arrayState, object? item, int? tagValueMaxLength)
+    {
+        if (item == null)
+        {
+            this.arrayWriter.WriteNullValue(ref arrayState);
+            return;
+        }
+
+        // Ordered by how often each type is likely to appear for performance
+        switch (item)
+        {
+            case string s:
+                this.WriteStringValue(
+                    ref arrayState,
+                    s,
+                    tagValueMaxLength);
+                break;
+            case int intValue:
+                this.arrayWriter.WriteIntegralValue(ref arrayState, intValue);
+                break;
+            case long l:
+                this.arrayWriter.WriteIntegralValue(ref arrayState, l);
+                break;
+            case bool b:
+                this.arrayWriter.WriteBooleanValue(ref arrayState, b);
+                break;
+            case double d:
+                this.arrayWriter.WriteFloatingPointValue(ref arrayState, d);
+                break;
+            case char c:
+                this.WriteCharValue(ref arrayState, c);
+                break;
+            case byte b:
+                this.arrayWriter.WriteIntegralValue(ref arrayState, b);
+                break;
+            case sbyte sb:
+                this.arrayWriter.WriteIntegralValue(ref arrayState, sb);
+                break;
+            case short s:
+                this.arrayWriter.WriteIntegralValue(ref arrayState, s);
+                break;
+            case ushort us:
+                this.arrayWriter.WriteIntegralValue(ref arrayState, us);
+                break;
+            case uint ui:
+                this.arrayWriter.WriteIntegralValue(ref arrayState, ui);
+                break;
+            case float f:
+                this.arrayWriter.WriteFloatingPointValue(ref arrayState, f);
+                break;
+
+            // A nested byte array, array or map is only written as a native nested value when
+            // the array writer supports embedding one (currently the JSON-based writers); when
+            // it is not supported, or the nesting limit below has been reached, the "when"
+            // clause is false and the switch falls through to the string-converted default.
+            case byte[] byteArray when this.arrayWriter.TryWriteByteArrayValue(ref arrayState, byteArray):
+                break;
+
+            case Array nestedArray when this.TryWriteNestedArrayValue(ref arrayState, nestedArray, tagValueMaxLength):
+                break;
+
+            case IEnumerable<KeyValuePair<string, object?>> nestedKvList when this.TryWriteNestedObjectValue(ref arrayState, nestedKvList, tagValueMaxLength):
+                break;
+
+            case IEnumerable<KeyValuePair<string, string?>> nestedStringKvList when this.TryWriteNestedObjectValue(ref arrayState, AdaptStringKvList(nestedStringKvList), tagValueMaxLength):
+                break;
+
+            case IDictionary nestedDictionary when this.TryWriteNestedObjectValue(ref arrayState, AdaptDictionary(nestedDictionary), tagValueMaxLength):
+                break;
+
+            // All other types are converted to strings including the following
+            // built-in value types:
+            // case nint:    Pointer type.
+            // case nuint:   Pointer type.
+            // case ulong:   May throw an exception on overflow.
+            // case decimal: Converting to double produces rounding errors.
+            default:
+                var stringValue = Convert.ToString(item, CultureInfo.InvariantCulture);
+                if (stringValue == null)
+                {
+                    this.arrayWriter.WriteNullValue(ref arrayState);
+                }
+                else
+                {
                     this.WriteStringValue(
                         ref arrayState,
-                        s,
+                        stringValue,
                         tagValueMaxLength);
-                    break;
-                case int intValue:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, intValue);
-                    break;
-                case long l:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, l);
-                    break;
-                case bool b:
-                    this.arrayWriter.WriteBooleanValue(ref arrayState, b);
-                    break;
-                case double d:
-                    this.arrayWriter.WriteFloatingPointValue(ref arrayState, d);
-                    break;
-                case char c:
-                    this.WriteCharValue(ref arrayState, c);
-                    break;
-                case byte b:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, b);
-                    break;
-                case sbyte sb:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, sb);
-                    break;
-                case short s:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, s);
-                    break;
-                case ushort us:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, us);
-                    break;
-                case uint ui:
-                    this.arrayWriter.WriteIntegralValue(ref arrayState, ui);
-                    break;
-                case float f:
-                    this.arrayWriter.WriteFloatingPointValue(ref arrayState, f);
-                    break;
+                }
 
-                // All other types are converted to strings including the following
-                // built-in value types:
-                // case Array:   Nested array.
-                // case nint:    Pointer type.
-                // case nuint:   Pointer type.
-                // case ulong:   May throw an exception on overflow.
-                // case decimal: Converting to double produces rounding errors.
-                default:
-                    var stringValue = Convert.ToString(item, CultureInfo.InvariantCulture);
-                    if (stringValue == null)
-                    {
-                        this.arrayWriter.WriteNullValue(ref arrayState);
-                    }
-                    else
-                    {
-                        this.WriteStringValue(
-                            ref arrayState,
-                            stringValue,
-                            tagValueMaxLength);
-                    }
+                break;
+        }
+    }
 
-                    break;
+    private bool TryWriteNestedArrayValue(ref TArrayState arrayState, Array nestedArray, int? tagValueMaxLength)
+    {
+        if (recursionDepth >= MaxRecursionDepth || !this.arrayWriter.TryBeginNestedArrayValue(ref arrayState))
+        {
+            return false;
+        }
+
+        recursionDepth++;
+        try
+        {
+            foreach (var element in nestedArray)
+            {
+                this.WriteArrayItem(ref arrayState, element, tagValueMaxLength);
             }
         }
+        finally
+        {
+            recursionDepth--;
+        }
+
+        this.arrayWriter.EndNestedArrayValue(ref arrayState);
+        return true;
+    }
+
+    private bool TryWriteNestedObjectValue(ref TArrayState arrayState, IEnumerable<KeyValuePair<string, object?>> kvList, int? tagValueMaxLength)
+    {
+        if (recursionDepth >= MaxRecursionDepth || !this.arrayWriter.TryBeginNestedObjectValue(ref arrayState))
+        {
+            return false;
+        }
+
+        recursionDepth++;
+        try
+        {
+            foreach (var kvp in kvList)
+            {
+                this.arrayWriter.WriteNestedObjectPropertyName(ref arrayState, kvp.Key);
+                this.WriteArrayItem(ref arrayState, kvp.Value, tagValueMaxLength);
+            }
+        }
+        finally
+        {
+            recursionDepth--;
+        }
+
+        this.arrayWriter.EndNestedObjectValue(ref arrayState);
+        return true;
     }
 
     private void WriteToArrayCovariant<TItem>(ref TArrayState arrayState, TItem[] array)

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleKvListAttributeTests.cs
@@ -135,15 +135,21 @@ public class ConsoleKvListAttributeTests
     [Fact]
     public void KvListWithByteArrayValue()
     {
-        // The console exporter has no byte array representation, so a byte[] is
-        // written as a JSON array of numbers rather than being dropped.
         var kvList = new List<KeyValuePair<string, object?>>
         {
             new("bytes", new byte[] { 1, 2, 3 }),
         };
 
         Assert.True(this.tagWriter.TryTransformTag("key", kvList, out var result));
-        Assert.Equal("""{"bytes":[1,2,3]}""", result.Value);
+        Assert.Equal("""{"bytes":"AQID"}""", result.Value);
+        Assert.Empty(this.droppedTags);
+    }
+
+    [Fact]
+    public void TopLevelByteArrayValueIsBase64Encoded()
+    {
+        Assert.True(this.tagWriter.TryTransformTag("key", new byte[] { 1, 2, 3 }, out var result));
+        Assert.Equal("AQID", result.Value);
         Assert.Empty(this.droppedTags);
     }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -107,6 +107,17 @@ public sealed partial class PrometheusSerializerTests
         { LabelValueArrayCase, "[1,2,3]" },
         { new Dictionary<string, object?> { ["a"] = 1 }, """{\"a\":1}""" },
         { new Dictionary<string, object?> { ["b"] = LabelValueByteArrayCase }, """{\"b\":\"AQID\"}""" },
+        {
+            new Dictionary<string, object?>
+            {
+                ["flag"] = true,
+                ["dbl"] = 1.5,
+                ["nan"] = double.NaN,
+                ["empty"] = null,
+                ["bad"] = new UnsupportedValue(),
+            },
+            """{\"flag\":true,\"dbl\":1.5,\"nan\":\"NaN\",\"empty\":null}"""
+        },
     };
 
     [Fact]
@@ -2462,4 +2473,9 @@ public sealed partial class PrometheusSerializerTests
 
     private static Regex SdkVersion() => new("telemetry_sdk_version=\"[^\"]*\"", RegexOptions.Compiled);
 #endif
+
+    private sealed class UnsupportedValue
+    {
+        public override string? ToString() => null;
+    }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -17,6 +17,8 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests;
 public sealed partial class PrometheusSerializerTests
 {
     internal static readonly VerifySettings VerifySettings = CreateVerifySettings();
+    private static readonly int[] LabelValueArrayCase = [1, 2, 3];
+    private static readonly byte[] LabelValueByteArrayCase = [1, 2, 3];
 
     public static TheoryData<string> EscapingSchemes =>
     [
@@ -101,6 +103,10 @@ public sealed partial class PrometheusSerializerTests
         { new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc), "05/06/2024 07:08:09" },
         { new DateTimeOffset(2024, 5, 6, 7, 8, 9, TimeSpan.FromHours(2)), "05/06/2024 07:08:09 +02:00" },
         { TimeSpan.FromTicks(1234567890), "00:02:03.4567890" },
+        { LabelValueByteArrayCase, "AQID" },
+        { LabelValueArrayCase, "[1,2,3]" },
+        { new Dictionary<string, object?> { ["a"] = 1 }, """{\"a\":1}""" },
+        { new Dictionary<string, object?> { ["b"] = LabelValueByteArrayCase }, """{\"b\":\"AQID\"}""" },
     };
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Globalization;
@@ -118,6 +119,12 @@ public sealed partial class PrometheusSerializerTests
             },
             """{\"flag\":true,\"dbl\":1.5,\"nan\":\"NaN\",\"empty\":null}"""
         },
+        { new Dictionary<string, string?> { ["a"] = "b" }, """{\"a\":\"b\"}""" },
+        { new Hashtable { ["a"] = 1 }, """{\"a\":1}""" },
+        { new double[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity, 1.5 }, """[\"NaN\",\"Infinity\",\"-Infinity\",1.5]""" },
+        { new object[] { LabelValueArrayCase }, "[[1,2,3]]" },
+        { new object[] { LabelValueByteArrayCase }, """[\"AQID\"]""" },
+        { new object[] { new Dictionary<string, object?> { ["a"] = 1 } }, """[{\"a\":1}]""" },
     };
 
     [Fact]

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
 using OpenTelemetry.Exporter.Zipkin.Tests;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
@@ -293,5 +295,29 @@ public class ZipkinActivityConversionTests
 
         // Ensure additional Activity tags were being converted.
         Assert.Contains(zipkinSpan.Tags, t => t.Key == "myCustomTag" && (string?)t.Value == "myCustomTagValue");
+    }
+
+    [Fact]
+    public void ToZipkinSpan_ByteArrayTag_IsBase64Encoded()
+    {
+        // Arrange
+        using var activity = new Activity(ZipkinSpanName);
+        activity.Start();
+        activity.SetTag("bytes", new byte[] { 1, 2, 3 });
+        activity.Stop();
+
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+
+        // Act
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            zipkinSpan.Write(writer);
+        }
+
+        var json = Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+
+        // Assert
+        Assert.Contains(@"""bytes"":""AQID""", json, StringComparison.Ordinal);
     }
 }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
@@ -298,7 +298,7 @@ public class ZipkinActivityConversionTests
     }
 
     [Fact]
-    public void ToZipkinSpan_ByteArrayTag_IsBase64Encoded()
+    public void ToZipkinSpan_ByteArrayTag_IsSerializedAsJsonArray()
     {
         // Arrange
         using var activity = new Activity(ZipkinSpanName);
@@ -318,6 +318,6 @@ public class ZipkinActivityConversionTests
         var json = Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
 
         // Assert
-        Assert.Contains(@"""bytes"":""AQID""", json, StringComparison.Ordinal);
+        Assert.Contains(@"""bytes"":""[1,2,3]""", json, StringComparison.Ordinal);
     }
 }

--- a/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
@@ -115,7 +115,7 @@ public class JsonStringArrayTagWriterTests
 
     [Theory]
     [InlineData([new object?[] { }, "[]"])]
-    [InlineData([new object?[] { null, float.MinValue, float.MaxValue, double.MinValue, double.MaxValue, int.MinValue, int.MaxValue, long.MinValue, long.MaxValue, true, false, "Hello world", new object[] { "inner array" } }, """[null,-3.4028234663852886E+38,3.4028234663852886E+38,-1.7976931348623157E+308,1.7976931348623157E+308,-2147483648,2147483647,-9223372036854775808,9223372036854775807,true,false,"Hello world","System.Object[]"]"""])]
+    [InlineData([new object?[] { null, float.MinValue, float.MaxValue, double.MinValue, double.MaxValue, int.MinValue, int.MaxValue, long.MinValue, long.MaxValue, true, false, "Hello world", new object[] { "inner array" } }, """[null,-3.4028234663852886E+38,3.4028234663852886E+38,-1.7976931348623157E+308,1.7976931348623157E+308,-2147483648,2147483647,-9223372036854775808,9223372036854775807,true,false,"Hello world",["inner array"]]"""])]
     public void ObjectArray(object?[] data, string expectedValue)
         => VerifySerialization(data, expectedValue);
 


### PR DESCRIPTION
## Changes

- Format `byte[]` values for non-OTLP exporters as Base64-encoded strings ([spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/common/README.md#byte-arrays)) except Zipkin.
- Format arrays and map values in the Prometheus exporter as JSON (https://github.com/open-telemetry/opentelemetry-specification/pull/5149).

/cc @pellared

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
