### PR TITLE
[OpenTelemetry] Avoid sampler attribute enumerator allocations

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Reduced allocations when applying sampler attributes backed by arrays or
+  read-only lists.
+  ([#7696](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7696))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -501,9 +501,20 @@ internal sealed class TracerProviderSdk : TracerProvider
         {
             if (samplingResult.AttributesOrNull is { } attributes)
             {
-                foreach (var att in attributes)
+                if (attributes is IReadOnlyList<KeyValuePair<string, object>> attributeList)
                 {
-                    options.SamplingTags[att.Key] = att.Value;
+                    for (var i = 0; i < attributeList.Count; i++)
+                    {
+                        var att = attributeList[i];
+                        options.SamplingTags[att.Key] = att.Value;
+                    }
+                }
+                else
+                {
+                    foreach (var att in attributes)
+                    {
+                        options.SamplingTags[att.Key] = att.Value;
+                    }
                 }
             }
         }
@@ -647,9 +658,20 @@ internal sealed class TracerProviderSdk : TracerProvider
         {
             if (samplingResult.AttributesOrNull is { } attributes)
             {
-                foreach (var att in attributes)
+                if (attributes is IReadOnlyList<KeyValuePair<string, object>> attributeList)
                 {
-                    activity.SetTag(att.Key, att.Value);
+                    for (var i = 0; i < attributeList.Count; i++)
+                    {
+                        var att = attributeList[i];
+                        activity.SetTag(att.Key, att.Value);
+                    }
+                }
+                else
+                {
+                    foreach (var att in attributes)
+                    {
+                        activity.SetTag(att.Key, att.Value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Changes

Avoid allocating boxed enumerators when a sampler returns attributes backed by
an `IReadOnlyList<KeyValuePair<string, object>>`. Arrays and lists now use an
indexed loop; arbitrary `IEnumerable<T>` implementations retain the existing
fallback.

## Benchmark

`SamplingResultBenchmarks` was run before and after this change using
BenchmarkDotNet 0.15.8 on .NET 10.0.11, Windows 11, Intel Core i7-12700K.

| Method | Before | After | Change | Allocated before | Allocated after |
|---|---:|---:|---:|---:|---:|
| NoAttributes | 124.7 ns | 122.2 ns | control | 328 B | 328 B |
| WithAttributeArray | 220.3 ns | 186.3 ns | -15.4% | 672 B | 640 B |
| WithAttributeList | 363.3 ns | 298.3 ns | -17.9% | 752 B | 720 B |
| Drop | 115.1 ns | 114.7 ns | control | 328 B | 328 B |
| ParentBasedSampled | 119.3 ns | 121.0 ns | control | 328 B | 328 B |

The optimized paths remove 32 B per sampled activity while leaving control
path allocations unchanged.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Existing unit tests cover sampler attributes; 7 focused tests pass
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] No public API changes
