### PR TITLE
[OpenTelemetry.Api] Avoid Baggage params enumeration

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -269,7 +269,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
     public Baggage SetBaggage(params KeyValuePair<string, string?>[] baggageItems)
-        => this.SetBaggage((IEnumerable<KeyValuePair<string, string?>>)baggageItems);
+        => this.SetBaggage(baggageItems.AsSpan());
 
     /// <summary>
     /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
@@ -412,6 +412,44 @@ public readonly struct Baggage : IEquatable<Baggage>
         }
 
         return baggageHolder;
+    }
+
+    private Baggage SetBaggage(ReadOnlySpan<KeyValuePair<string, string?>> baggageItems)
+    {
+        Dictionary<string, string>? newBaggage = null;
+        foreach (ref readonly var item in baggageItems)
+        {
+            if (string.IsNullOrEmpty(item.Key))
+            {
+                continue;
+            }
+            else if (item.Value == null)
+            {
+                var currentBaggage = newBaggage ?? this.baggage;
+                if (currentBaggage?.ContainsKey(item.Key) == true)
+                {
+                    newBaggage ??= new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.Ordinal);
+                    newBaggage.Remove(item.Key);
+                }
+            }
+            else
+            {
+                var currentBaggage = newBaggage ?? this.baggage;
+
+                if (currentBaggage != null &&
+                    currentBaggage.TryGetValue(item.Key, out var existingValue) &&
+                    existingValue == item.Value)
+                {
+                    continue;
+                }
+
+                newBaggage ??= new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.Ordinal);
+                newBaggage[item.Key] = item.Value;
+            }
+        }
+
+        // If nothing was changed return the current instance
+        return newBaggage == null ? this : new Baggage(newBaggage);
     }
 
     private sealed class BaggageHolder

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Reduced allocations when setting baggage through the `params` overload.
+  ([#7697](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7697))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -84,6 +84,33 @@ public class BaggageTests
     }
 
     [Fact]
+    public void SetBaggageParamsTest()
+    {
+        var baggage = default(Baggage).SetBaggage(
+            new KeyValuePair<string, string?>(K1, V1),
+            new KeyValuePair<string, string?>(K2, V2));
+
+        var unchanged = baggage.SetBaggage(
+            new KeyValuePair<string, string?>(string.Empty, V3),
+            new KeyValuePair<string, string?>(K3, null),
+            new KeyValuePair<string, string?>(K1, V1));
+
+        Assert.Same(baggage.GetBaggage(), unchanged.GetBaggage());
+
+        var updated = baggage.SetBaggage(
+            new KeyValuePair<string, string?>(K1, null),
+            new KeyValuePair<string, string?>(K3, null),
+            new KeyValuePair<string, string?>(K2, V2),
+            new KeyValuePair<string, string?>(K3, V3));
+
+        Assert.Equal(2, updated.Count);
+        Assert.Null(updated.GetBaggage(K1));
+        Assert.Equal(V2, updated.GetBaggage(K2));
+        Assert.Equal(V3, updated.GetBaggage(K3));
+        Assert.Equal(V1, baggage.GetBaggage(K1));
+    }
+
+    [Fact]
     public void SetEmptyNameTest()
     {
         var baggage = Baggage.Current;

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -90,6 +90,11 @@ public class BaggageTests
             new KeyValuePair<string, string?>(K1, V1),
             new KeyValuePair<string, string?>(K2, V2));
 
+        KeyValuePair<string, string?>[]? nullItems = null;
+        var unchangedFromNull = baggage.SetBaggage(nullItems!);
+
+        Assert.Same(baggage.GetBaggage(), unchangedFromNull.GetBaggage());
+
         var unchanged = baggage.SetBaggage(
             new KeyValuePair<string, string?>(string.Empty, V3),
             new KeyValuePair<string, string?>(K3, null),


### PR DESCRIPTION
## Changes

Route the existing `Baggage.SetBaggage(params KeyValuePair<...>[])` overload
through a private `ReadOnlySpan<T>` implementation. This avoids boxing the
array enumerator while preserving the arbitrary `IEnumerable<T>` overload and
public API.

## Benchmark

`BaggageBenchmarks` was run before and after this change using BenchmarkDotNet
0.15.8 on .NET 10.0.11, Windows 11, Intel Core i7-12700K.

| Method | Items | Before | After | Change | Allocated before | Allocated after |
|---|---:|---:|---:|---:|---:|---:|
| SetBaggageNoOp | 1 | 8.421 ns | 3.425 ns | -59.3% | 32 B | 0 B |
| SetBaggageNoOp | 5 | 26.470 ns | 17.457 ns | -34.1% | 32 B | 0 B |
| SetBaggageNoOp | 20 | 100.349 ns | 73.172 ns | -27.1% | 32 B | 0 B |
| SetBaggageSingleUpdate | 1 | 36.729 ns | 28.870 ns | -21.4% | 248 B | 216 B |
| SetBaggageSingleUpdate | 5 | 78.342 ns | 72.137 ns | -7.9% | 360 B | 328 B |
| SetBaggageSingleUpdate | 20 | 230.981 ns | 209.6 ns | -9.3% | 808 B | 776 B |

The 20-item update case was rerun independently because the first post-change
run was noisy (`250.342 ns`, `33.943 ns` standard deviation). The independent
run measured `209.6 ns` with `5.21 ns` standard deviation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed
* [x] All 17 `BaggageTests` pass
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] No public API changes
