### PR TITLE
[API] Avoid log attribute array enumeration

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Reduced allocations when creating log record attributes from an array.
+  ([#7699](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7699))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
@@ -140,9 +140,19 @@ internal
         Guard.ThrowIfNull(attributes);
 
         LogRecordAttributeList logRecordAttributes = default;
-        foreach (var attribute in attributes)
+        if (attributes is KeyValuePair<string, object?>[] attributeArray)
         {
-            logRecordAttributes.Add(attribute);
+            foreach (ref readonly var attribute in attributeArray.AsSpan())
+            {
+                logRecordAttributes.Add(attribute);
+            }
+        }
+        else
+        {
+            foreach (var attribute in attributes)
+            {
+                logRecordAttributes.Add(attribute);
+            }
         }
 
         return logRecordAttributes;

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
@@ -144,6 +144,26 @@ public sealed class LogRecordAttributeListTests
     [InlineData(1)]
     [InlineData(8)]
     [InlineData(9)]
+    public void CreateFromArrayTest(int numberOfItems)
+    {
+        var sourceAttributes = Enumerable.Range(0, numberOfItems)
+            .Select(i => new KeyValuePair<string, object?>($"key{i}", i))
+            .ToArray();
+
+        var attributes = LogRecordAttributeList.CreateFromEnumerable(sourceAttributes);
+
+        Assert.Equal(sourceAttributes.Length, attributes.Count);
+        for (var i = 0; i < attributes.Count; i++)
+        {
+            Assert.Equal(sourceAttributes[i], attributes[i]);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(9)]
     [InlineData(64)]
     public void ExportTest(int numberOfItems)
     {


### PR DESCRIPTION
## Changes

Use `ReadOnlySpan<T>` enumeration when
`LogRecordAttributeList.CreateFromEnumerable` receives an array. Arbitrary
enumerable inputs retain the existing path, and public API remains unchanged.

## Benchmark

A task-scoped BenchmarkDotNet benchmark called `CreateFromEnumerable` with a
pre-created array containing 1, 8, 9, or 20 attributes. The 8/9 boundary covers
the transition from inline storage to the overflow list.

BenchmarkDotNet 0.15.8, .NET 10.0.11, Windows 11, Intel Core i7-12700K:

| Items | Before | After | Change | Allocated before | Allocated after |
|---:|---:|---:|---:|---:|---:|
| 1 | 107.5 ns | 99.37 ns | -7.6% | 32 B | 0 B |
| 8 | 147.3 ns | 126.55 ns | -14.1% | 32 B | 0 B |
| 9 | 183.5 ns | 164.33 ns | -10.4% | 344 B | 312 B |
| 20 | 354.5 ns | 329.79 ns | -7.0% | 880 B | 848 B |

The array path removes 32 B per call. Calls with up to eight attributes become
allocation-free because `LogRecordAttributeList` stores those attributes inline.

Benchmark method:

```csharp
[Benchmark]
public LogRecordAttributeList FromArray()
    => LogRecordAttributeList.CreateFromEnumerable(this.array);
```

`array` was initialized in `GlobalSetup`; `[MemoryDiagnoser]` was enabled and
`ItemCount` used `[Params(1, 8, 9, 20)]`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed
* [x] All 19 `LogRecordAttributeListTests` pass
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] No public API changes
