### PR TITLE
[OTLP] Disable HttpClientFactory for browser platforms

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -11,6 +11,10 @@ Notes](../../RELEASENOTES.md).
   now be dropped.
   ([#7688](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7688))
 
+* Disable HttpClientFactory integration for Android, Blazor, iOS and tvOS
+  platforms to avoid stalled export requests when async HTTP handlers are used.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -13,7 +13,7 @@ Notes](../../RELEASENOTES.md).
 
 * Disable HttpClientFactory integration for Android, Blazor, iOS and tvOS
   platforms to avoid stalled export requests when async HTTP handlers are used.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#7709](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7709))
 
 ## 1.18.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -11,8 +11,8 @@ Notes](../../RELEASENOTES.md).
   now be dropped.
   ([#7688](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7688))
 
-* Disable HttpClientFactory integration for Android, Blazor, iOS and tvOS
-  platforms to avoid stalled export requests when async HTTP handlers are used.
+* Disable HttpClientFactory integration on browser WebAssembly (e.g. Blazor)
+  environments to avoid stalled export requests when async HTTP handlers are used.
   ([#7709](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7709))
 
 ## 1.18.0

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
@@ -11,15 +11,15 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 
 internal abstract class OtlpExportClient : IExportClient
 {
-    private static readonly Version Http2RequestVersion = new(2, 0);
-
 #if NET
     // See: https://github.com/dotnet/runtime/blob/280f2a0c60ce0378b8db49adc0eecc463d00fe5d/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs#L767
-    private static readonly bool SynchronousSendSupportedByCurrentPlatform = !OperatingSystem.IsAndroid()
+    internal static readonly bool SynchronousSendSupportedByCurrentPlatform = !OperatingSystem.IsAndroid()
             && !OperatingSystem.IsIOS()
             && !OperatingSystem.IsTvOS()
             && !OperatingSystem.IsBrowser();
 #endif
+
+    private static readonly Version Http2RequestVersion = new(2, 0);
 
     protected OtlpExportClient(OtlpExporterOptions options, HttpClient httpClient, string signalPath)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
@@ -11,15 +11,15 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 
 internal abstract class OtlpExportClient : IExportClient
 {
+    private static readonly Version Http2RequestVersion = new(2, 0);
+
 #if NET
     // See: https://github.com/dotnet/runtime/blob/280f2a0c60ce0378b8db49adc0eecc463d00fe5d/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs#L767
-    internal static readonly bool SynchronousSendSupportedByCurrentPlatform = !OperatingSystem.IsAndroid()
+    private static readonly bool SynchronousSendSupportedByCurrentPlatform = !OperatingSystem.IsAndroid()
             && !OperatingSystem.IsIOS()
             && !OperatingSystem.IsTvOS()
             && !OperatingSystem.IsBrowser();
 #endif
-
-    private static readonly Version Http2RequestVersion = new(2, 0);
 
     protected OtlpExportClient(OtlpExporterOptions options, HttpClient httpClient, string signalPath)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -154,13 +154,13 @@ internal static class OtlpExporterOptionsExtensions
 #if NET
             && options.MtlsOptions?.IsEnabled != true
 
-            // On platforms where HttpClient cannot send requests synchronously,
-            // the exporter always sends asynchronously and then blocks on the result.
-            // If the IHttpClientFactory-resolved HttpClient pipeline contains a
-            // delegating handler that yields asynchronously that continuation may
-            // never run on a single-threaded runtime and stall the export indefinitely.
+            // On single-threaded browser WebAssembly environments, the exporter
+            // always sends asynchronously and then blocks on the result. If the
+            // IHttpClientFactory-resolved HttpClient pipeline contains a delegating
+            // handler that yields asynchronously, the continuation can never run
+            // because the only thread is blocked, stalling the export indefinitely.
             // See https://github.com/open-telemetry/opentelemetry-dotnet/issues/7708.
-            && OtlpExportClient.SynchronousSendSupportedByCurrentPlatform
+            && !OperatingSystem.IsBrowser()
 #endif
             && options.HttpClientFactory == options.DefaultHttpClientFactory)
         {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -153,6 +153,14 @@ internal static class OtlpExporterOptionsExtensions
             && options.Protocol == OtlpExportProtocol.HttpProtobuf
 #if NET
             && options.MtlsOptions?.IsEnabled != true
+
+            // On platforms where HttpClient cannot send requests synchronously,
+            // the exporter always sends asynchronously and then blocks on the result.
+            // If the IHttpClientFactory-resolved HttpClient pipeline contains a
+            // delegating handler that yields asynchronously that continuation may
+            // never run on a single-threaded runtime and stall the export indefinitely.
+            // See https://github.com/open-telemetry/opentelemetry-dotnet/issues/7708.
+            && OtlpExportClient.SynchronousSendSupportedByCurrentPlatform
 #endif
             && options.HttpClientFactory == options.DefaultHttpClientFactory)
         {

--- a/test/OpenTelemetry.BlazorWasm.TestApp/AsyncYieldingDelegatingHandler.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/AsyncYieldingDelegatingHandler.cs
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.BlazorWasm.TestApp;
+
+// Simulates a custom async handler that could cause issues with Blazor
+// when using HttpClientFactory. See https://github.com/open-telemetry/opentelemetry-dotnet/issues/7708.
+
+internal sealed class AsyncYieldingDelegatingHandler : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/OpenTelemetry.BlazorWasm.TestApp.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
+++ b/test/OpenTelemetry.BlazorWasm.TestApp/Program.cs
@@ -26,7 +26,12 @@ var baseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 using var instrumentation = new InstrumentationSource();
 builder.Services.AddSingleton(instrumentation);
 
-builder.Services.AddScoped(_ => new HttpClient { BaseAddress = baseAddress });
+builder.Services.AddHttpClient();
+builder.Services.ConfigureHttpClientDefaults((http) =>
+{
+    http.ConfigureHttpClient((client) => client.BaseAddress = baseAddress);
+    http.AddHttpMessageHandler(() => new AsyncYieldingDelegatingHandler());
+});
 
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(resource => resource.AddService(InstrumentationSource.ServiceName))


### PR DESCRIPTION
Contributes to #7708.

## Changes

Disable HttpClientFactory integration for Blazor/browser environments to avoid potential for still when sending telemetry when an async delegating handler is configured due to sync-of-async due to a lack of support for `HttpClient.Send()` on those platforms.

This would avoid the reported issue out-of-the-box, and would require a user who wants to integrate with HttpClientFactory on these platforms to explicitly opt-in and verify their HTTP pipeline configuration.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
