### PR TITLE
[Declarative config] Phase 9: Component provider abstraction and registry

### DIFF
--- a/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
+++ b/src/OpenTelemetry.Configuration.Declarative/CHANGELOG.md
@@ -22,3 +22,8 @@ Notes](../../RELEASENOTES.md).
   `DeclarativeConfigurationDocumentAccessor`. Each file is parsed at most once
   per application lifetime.
   ([#7690](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7690))
+
+* Added a `PluginComponentProvider` abstraction and registry that allows SDK
+  components and plugins to register named factories for declarative-config
+  components which participate in YAML-driven configuration.
+  ([#7710](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7710))

--- a/src/OpenTelemetry.Configuration.Declarative/Extensions/OpenTelemetryBuilderPluginComponentProviderExtensions.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Extensions/OpenTelemetryBuilderPluginComponentProviderExtensions.cs
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Configuration;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry;
+
+/// <summary>
+/// Extension methods for registering declarative configuration plugin component providers.
+/// </summary>
+internal static class OpenTelemetryBuilderPluginComponentProviderExtensions
+{
+    /// <summary>
+    /// Registers <paramref name="provider"/> as the source of <typeparamref name="TComponent"/>
+    /// components under <paramref name="name"/>.
+    /// </summary>
+    /// <typeparam name="TComponent">The type of component the provider creates.</typeparam>
+    /// <param name="builder">The <see cref="IOpenTelemetryBuilder"/> builder.</param>
+    /// <param name="name">
+    /// The case-sensitive name that selects the provider in a configuration document.
+    /// </param>
+    /// <param name="provider">The provider to register.</param>
+    /// <returns>The supplied <see cref="IOpenTelemetryBuilder"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a provider instance for the same component type and name is already registered.
+    /// </exception>
+    public static IOpenTelemetryBuilder AddPluginComponentProvider<TComponent>(
+        this IOpenTelemetryBuilder builder,
+        string name,
+        PluginComponentProvider<TComponent> provider)
+        where TComponent : class
+    {
+        Guard.ThrowIfNull(builder);
+
+        builder.Services.AddPluginComponentProvider(name, provider);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers <typeparamref name="TProvider"/> as the source of <typeparamref name="TComponent"/>
+    /// components under <paramref name="name"/>, constructing it from the container so that it can
+    /// take dependencies.
+    /// </summary>
+    /// <typeparam name="TComponent">The type of component the provider creates.</typeparam>
+    /// <typeparam name="TProvider">The provider type to construct.</typeparam>
+    /// <param name="builder">The <see cref="IOpenTelemetryBuilder"/> builder.</param>
+    /// <param name="name">
+    /// The case-sensitive name that selects the provider in a configuration document.
+    /// </param>
+    /// <returns>The supplied <see cref="IOpenTelemetryBuilder"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a provider for the same component type and name is already registered.
+    /// </exception>
+#if NET
+    public static IOpenTelemetryBuilder AddPluginComponentProvider<TComponent, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TProvider>(
+#else
+    public static IOpenTelemetryBuilder AddPluginComponentProvider<TComponent, TProvider>(
+#endif
+        this IOpenTelemetryBuilder builder,
+        string name)
+        where TComponent : class
+        where TProvider : PluginComponentProvider<TComponent>
+    {
+        Guard.ThrowIfNull(builder);
+
+        builder.Services.AddPluginComponentProvider<TComponent, TProvider>(name);
+        return builder;
+    }
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Extensions/PluginComponentProviderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Extensions/PluginComponentProviderServiceCollectionExtensions.cs
@@ -103,13 +103,13 @@ internal static class PluginComponentProviderServiceCollectionExtensions
 
         registerProvider?.Invoke(services);
 
-        services.Add(ServiceDescriptor.Singleton(registration));
+        services.AddSingleton(registration);
         services.TryAddSingleton<PluginComponentProviderRegistry>();
 
         OpenTelemetryDeclarativeConfigurationEventSource.Log.ComponentProviderRegistered(
+            registration.ProviderType.ToString(),
             registration.ComponentType.ToString(),
-            registration.Name,
-            registration.ProviderType.ToString());
+            registration.Name);
 
         return services;
     }

--- a/src/OpenTelemetry.Configuration.Declarative/Extensions/PluginComponentProviderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Extensions/PluginComponentProviderServiceCollectionExtensions.cs
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OpenTelemetry.Configuration;
+using OpenTelemetry.Configuration.Declarative;
+using OpenTelemetry.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering component providers, which create the components a
+/// declarative configuration document names.
+/// </summary>
+internal static class PluginComponentProviderServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <paramref name="provider"/> as the source of <typeparamref name="TComponent"/>
+    /// components under <paramref name="name"/>.
+    /// </summary>
+    /// <typeparam name="TComponent">The type of component the provider creates.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register into.</param>
+    /// <param name="name">
+    /// The case-sensitive name that selects the provider in a configuration document.
+    /// </param>
+    /// <param name="provider">The provider to register.</param>
+    /// <returns>The supplied <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a provider instance for the same component type and name is already registered.
+    /// </exception>
+    public static IServiceCollection AddPluginComponentProvider<TComponent>(
+        this IServiceCollection services,
+        string name,
+        PluginComponentProvider<TComponent> provider)
+        where TComponent : class
+    {
+        Guard.ThrowIfNull(services);
+        Guard.ThrowIfNullOrWhitespace(name);
+        Guard.ThrowIfNull(provider);
+
+        return AddPluginComponentProvider(
+            services,
+            new PluginComponentProviderRegistration<TComponent>(
+                name,
+                provider.GetType(),
+                _ => provider));
+    }
+
+    /// <summary>
+    /// Registers <typeparamref name="TProvider"/> as the source of <typeparamref name="TComponent"/>
+    /// components under <paramref name="name"/>, constructing it from the container so that it can
+    /// take dependencies.
+    /// </summary>
+    /// <typeparam name="TComponent">The type of component the provider creates.</typeparam>
+    /// <typeparam name="TProvider">The provider type to construct.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to register into.</param>
+    /// <param name="name">
+    /// The case-sensitive name that selects the provider in a configuration document.
+    /// </param>
+    /// <returns>The supplied <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a provider for the same component type and name is already registered.
+    /// </exception>
+#if NET
+    public static IServiceCollection AddPluginComponentProvider<TComponent, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TProvider>(
+#else
+    public static IServiceCollection AddPluginComponentProvider<TComponent, TProvider>(
+#endif
+        this IServiceCollection services,
+        string name)
+        where TComponent : class
+        where TProvider : PluginComponentProvider<TComponent>
+    {
+        Guard.ThrowIfNull(services);
+        Guard.ThrowIfNullOrWhitespace(name);
+
+        return AddPluginComponentProvider(
+            services,
+            new PluginComponentProviderRegistration<TComponent>(
+                name,
+                typeof(TProvider),
+                static sp => sp.GetRequiredService<TProvider>()),
+            static services => services.TryAddSingleton<TProvider>());
+    }
+
+    private static IServiceCollection AddPluginComponentProvider(
+        IServiceCollection services,
+        IPluginComponentProviderRegistration registration,
+        Action<IServiceCollection>? registerProvider = null)
+    {
+        ThrowIfDuplicate(
+            services,
+            registration.ComponentType,
+            registration.Name,
+            registration.ProviderType);
+
+        registerProvider?.Invoke(services);
+
+        services.Add(ServiceDescriptor.Singleton(registration));
+        services.TryAddSingleton<PluginComponentProviderRegistry>();
+
+        OpenTelemetryDeclarativeConfigurationEventSource.Log.ComponentProviderRegistered(
+            registration.ComponentType.ToString(),
+            registration.Name,
+            registration.ProviderType.ToString());
+
+        return services;
+    }
+
+    private static void ThrowIfDuplicate(
+        IServiceCollection services,
+        Type componentType,
+        string name,
+        Type providerType)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType != typeof(IPluginComponentProviderRegistration)
+                || descriptor.ImplementationInstance is not IPluginComponentProviderRegistration existing
+                || existing.ComponentType != componentType
+                || !string.Equals(existing.Name, name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.DuplicateComponentProviderRejected(
+                componentType.ToString(),
+                name,
+                existing.ProviderType.ToString(),
+                providerType.ToString());
+
+            throw new InvalidOperationException(
+                $"A component provider for component type '{componentType}' with name '{name}' is already registered by '{existing.ProviderType}', so '{providerType}' cannot be registered. Each component type and name combination must be unique.");
+        }
+    }
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/IPluginComponentProviderRegistration.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/IPluginComponentProviderRegistration.cs
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// A non-generic component provider registration, used to store registrations for different
+/// component types in a single collection.
+/// </summary>
+internal interface IPluginComponentProviderRegistration
+{
+    /// <summary>
+    /// Gets the type of component the registered provider creates.
+    /// </summary>
+    Type ComponentType { get; }
+
+    /// <summary>
+    /// Gets the name that selects this provider in a configuration document.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the registered concrete provider type.
+    /// </summary>
+    Type ProviderType { get; }
+
+    /// <summary>
+    /// Creates a component from the supplied configuration properties and services.
+    /// </summary>
+    /// <param name="properties">The configuration properties for the component.</param>
+    /// <param name="serviceProvider">The services available to the provider.</param>
+    /// <returns>The created component.</returns>
+    object Create(ConfigProperties properties, IServiceProvider serviceProvider);
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/PluginComponentProvider.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/PluginComponentProvider.cs
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// The base class for a provider that creates <typeparamref name="TComponent"/> instances from a
+/// configuration node.
+/// </summary>
+/// <remarks>
+/// A provider is a stateless factory and must be thread-safe: the same instance can be asked for a
+/// component concurrently. Constructor dependencies must be safe to use from a singleton.
+/// </remarks>
+/// <typeparam name="TComponent">The type of component created.</typeparam>
+internal abstract class PluginComponentProvider<TComponent>
+    where TComponent : class
+{
+    /// <summary>
+    /// Creates a component from the supplied configuration properties and services.
+    /// </summary>
+    /// <remarks>
+    /// Returns a new component on every call; nothing caches the result. Throw a
+    /// <see cref="Declarative.DeclarativeConfigurationException"/> when the supplied properties do
+    /// not satisfy the component's configuration schema.
+    /// </remarks>
+    /// <param name="properties">The configuration properties for the component.</param>
+    /// <param name="serviceProvider">The services available to the provider.</param>
+    /// <returns>The created component.</returns>
+    public abstract TComponent Create(ConfigProperties properties, IServiceProvider serviceProvider);
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/PluginComponentProvider.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/PluginComponentProvider.cs
@@ -19,7 +19,8 @@ internal abstract class PluginComponentProvider<TComponent>
     /// Creates a component from the supplied configuration properties and services.
     /// </summary>
     /// <remarks>
-    /// Returns a new component on every call; nothing caches the result. Throw a
+    /// Called for every component the configuration names; the registry does not cache results,
+    /// and providers should not cache the value they return. Throw a
     /// <see cref="Declarative.DeclarativeConfigurationException"/> when the supplied properties do
     /// not satisfy the component's configuration schema.
     /// </remarks>

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/PluginComponentProviderRegistration.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ComponentProviders/PluginComponentProviderRegistration.cs
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Configuration;
+
+/// <summary>
+/// Represents a named registration for a provider that creates components of a specific type.
+/// </summary>
+/// <typeparam name="TComponent">The type of component created by the provider.</typeparam>
+internal sealed class PluginComponentProviderRegistration<TComponent> : IPluginComponentProviderRegistration
+    where TComponent : class
+{
+    private readonly Func<IServiceProvider, PluginComponentProvider<TComponent>> providerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginComponentProviderRegistration{TComponent}"/> class.
+    /// </summary>
+    /// <param name="name">The name that selects the provider in a configuration document.</param>
+    /// <param name="providerType">The concrete provider type associated with the registration.</param>
+    /// <param name="providerFactory">The function used to obtain the provider from the available services.</param>
+    public PluginComponentProviderRegistration(
+        string name,
+        Type providerType,
+        Func<IServiceProvider, PluginComponentProvider<TComponent>> providerFactory)
+    {
+        this.Name = name;
+        this.ProviderType = providerType;
+        this.providerFactory = providerFactory;
+    }
+
+    /// <inheritdoc />
+    public Type ComponentType => typeof(TComponent);
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public Type ProviderType { get; }
+
+    /// <inheritdoc />
+    public object Create(ConfigProperties properties, IServiceProvider serviceProvider)
+        => this.providerFactory(serviceProvider).Create(properties, serviceProvider)!;
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Components/PluginComponentProviderRegistry.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Components/PluginComponentProviderRegistry.cs
@@ -14,9 +14,7 @@ namespace OpenTelemetry.Configuration.Declarative;
 /// from them.
 /// </summary>
 /// <remarks>
-/// The index is built once during construction and never mutated afterwards, so
-/// <see cref="Create{TComponent}(string, ConfigProperties)"/> is safe to call concurrently and
-/// re-entrantly.
+/// The index is built once and never mutated, so this class is safe for concurrent use.
 /// </remarks>
 internal sealed class PluginComponentProviderRegistry
 {
@@ -112,7 +110,7 @@ internal sealed class PluginComponentProviderRegistry
             if (string.IsNullOrWhiteSpace(registration.Name))
             {
                 throw new InvalidOperationException(
-                    $"Component provider registration '{registration.GetType()}' has no name. Name must return a non-empty value.");
+                    $"Component provider registration '{registration.GetType()}' has no name. {nameof(IPluginComponentProviderRegistration.Name)} must return a non-empty value.");
             }
 
             var key = new ComponentProviderKey(registration.ComponentType, registration.Name);

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Components/PluginComponentProviderRegistry.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Components/PluginComponentProviderRegistry.cs
@@ -1,0 +1,156 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+using System.Collections.Frozen;
+#endif
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Configuration.Declarative;
+
+/// <summary>
+/// Resolves registered component providers by component type and name, and creates components
+/// from them.
+/// </summary>
+/// <remarks>
+/// The index is built once during construction and never mutated afterwards, so
+/// <see cref="Create{TComponent}(string, ConfigProperties)"/> is safe to call concurrently and
+/// re-entrantly.
+/// </remarks>
+internal sealed class PluginComponentProviderRegistry
+{
+#if NET
+    private readonly FrozenDictionary<ComponentProviderKey, IPluginComponentProviderRegistration> registrations;
+#else
+    private readonly Dictionary<ComponentProviderKey, IPluginComponentProviderRegistration> registrations;
+#endif
+    private readonly IServiceProvider serviceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginComponentProviderRegistry"/> class over
+    /// the providers registered in <paramref name="serviceProvider"/>.
+    /// </summary>
+    /// <param name="serviceProvider">
+    /// The services the providers were registered into. Taking the providers from the same
+    /// container that is handed to them guarantees a provider sees its own registrations.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serviceProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a provider has no usable name, or when two providers share a component type and name.
+    /// </exception>
+    public PluginComponentProviderRegistry(IServiceProvider serviceProvider)
+    {
+        Guard.ThrowIfNull(serviceProvider);
+
+        this.serviceProvider = serviceProvider;
+        this.registrations = BuildIndex(serviceProvider.GetServices<IPluginComponentProviderRegistration>());
+    }
+
+    /// <summary>
+    /// Creates the <typeparamref name="TComponent"/> registered under <paramref name="name"/>.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is cached: each call creates a new component, so a component type appearing at two
+    /// configuration nodes yields two instances. Exceptions thrown by the provider propagate
+    /// unchanged.
+    /// </remarks>
+    /// <typeparam name="TComponent">The type of component to create. Matched exactly; a derived type does not resolve a provider registered for its base.</typeparam>
+    /// <param name="name">The name that selects the provider.</param>
+    /// <param name="properties">The configuration node for the component.</param>
+    /// <returns>The created component.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> or <paramref name="properties"/> is <see langword="null"/>.</exception>
+    /// <exception cref="DeclarativeConfigurationException">Thrown when no provider is registered for the component type and name.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the registered provider returns <see langword="null"/> or a component of an incompatible type.
+    /// </exception>
+    public TComponent Create<TComponent>(string name, ConfigProperties properties)
+        where TComponent : class
+    {
+        Guard.ThrowIfNull(name);
+        Guard.ThrowIfNull(properties);
+
+        if (!this.registrations.TryGetValue(new(typeof(TComponent), name), out var registration))
+        {
+            var registered = this.DescribeRegisteredNames(typeof(TComponent));
+
+            OpenTelemetryDeclarativeConfigurationEventSource.Log.ComponentProviderNotFound(
+                typeof(TComponent).ToString(),
+                name,
+                registered);
+
+            throw new DeclarativeConfigurationException(
+                $"No component provider is registered for component type '{typeof(TComponent)}' with name '{name}'. {registered}");
+        }
+
+        var created = registration.Create(properties, this.serviceProvider);
+
+        if (created is not TComponent component)
+        {
+            var actualType = created is null ? "null" : $"component type '{created.GetType()}'";
+
+            throw new InvalidOperationException(
+                $"Component provider '{registration.ProviderType}' registered for component type '{typeof(TComponent)}' with name '{name}' returned {actualType}.");
+        }
+
+        OpenTelemetryDeclarativeConfigurationEventSource.Log.ComponentCreated(typeof(TComponent).ToString(), name);
+
+        return component;
+    }
+
+#if NET
+    private static FrozenDictionary<ComponentProviderKey, IPluginComponentProviderRegistration> BuildIndex(
+#else
+    private static Dictionary<ComponentProviderKey, IPluginComponentProviderRegistration> BuildIndex(
+#endif
+        IEnumerable<IPluginComponentProviderRegistration> registrations)
+    {
+        var index = new Dictionary<ComponentProviderKey, IPluginComponentProviderRegistration>();
+
+        foreach (var registration in registrations)
+        {
+            if (string.IsNullOrWhiteSpace(registration.Name))
+            {
+                throw new InvalidOperationException(
+                    $"Component provider registration '{registration.GetType()}' has no name. Name must return a non-empty value.");
+            }
+
+            var key = new ComponentProviderKey(registration.ComponentType, registration.Name);
+
+            if (index.TryGetValue(key, out var existing))
+            {
+                OpenTelemetryDeclarativeConfigurationEventSource.Log.DuplicateComponentProviderRejected(
+                    key.ComponentType.ToString(),
+                    key.Name,
+                    existing.ProviderType.ToString(),
+                    registration.ProviderType.ToString());
+
+                throw new InvalidOperationException(
+                    $"Two component providers are registered for component type '{key.ComponentType}' with name '{key.Name}': '{existing.ProviderType}' and '{registration.ProviderType}'. Each component type and name combination must be unique.");
+            }
+
+            index.Add(key, registration);
+        }
+
+#if NET
+        return index.ToFrozenDictionary();
+#else
+        return index;
+#endif
+    }
+
+    private string DescribeRegisteredNames(Type componentType)
+    {
+        var names = this.registrations.Keys
+            .Where(key => key.ComponentType == componentType)
+            .Select(key => $"'{key.Name}'")
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        return names.Count == 0
+            ? "No component providers are registered for this component type."
+            : $"Registered names for this component type: {string.Join(", ", names)}.";
+    }
+
+    private readonly record struct ComponentProviderKey(Type ComponentType, string Name);
+}

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigPropertiesBuilder.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/ConfigProperties/ConfigPropertiesBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpenTelemetry.Internal;
+
 namespace OpenTelemetry.Configuration;
 
 /// <summary>
@@ -11,17 +13,112 @@ internal sealed class ConfigPropertiesBuilder
     private readonly Dictionary<string, ConfigValue> values = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// Adds <paramref name="key"/> with <paramref name="value"/>.
+    /// Adds a null value.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <returns>This builder, for chaining.</returns>
+    public ConfigPropertiesBuilder AddNull(string key)
+        => this.AddValue(key, ConfigValue.Null);
+
+    /// <summary>
+    /// Adds a string value.
     /// </summary>
     /// <param name="key">The key to add.</param>
     /// <param name="value">The value to associate with the key.</param>
     /// <returns>This builder, for chaining.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> already exists in this builder.</exception>
-    public ConfigPropertiesBuilder Add(string key, ConfigValue value)
+    public ConfigPropertiesBuilder Add(string key, string value)
+        => this.AddValue(key, ConfigValue.String(value));
+
+    /// <summary>
+    /// Adds a boolean value.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="value">The value to associate with the key.</param>
+    /// <returns>This builder, for chaining.</returns>
+    public ConfigPropertiesBuilder Add(string key, bool value)
+        => this.AddValue(key, ConfigValue.Boolean(value));
+
+    /// <summary>
+    /// Adds a 32-bit integer value.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="value">The value to associate with the key.</param>
+    /// <returns>This builder, for chaining.</returns>
+    public ConfigPropertiesBuilder Add(string key, int value)
+        => this.AddValue(key, ConfigValue.Integer(value));
+
+    /// <summary>
+    /// Adds a 64-bit integer value.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="value">The value to associate with the key.</param>
+    /// <returns>This builder, for chaining.</returns>
+    public ConfigPropertiesBuilder Add(string key, long value)
+        => this.AddValue(key, ConfigValue.Integer(value));
+
+    /// <summary>
+    /// Adds a double-precision floating-point value.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="value">The value to associate with the key.</param>
+    /// <returns>This builder, for chaining.</returns>
+    public ConfigPropertiesBuilder Add(string key, double value)
+        => this.AddValue(key, ConfigValue.Double(value));
+
+    /// <summary>
+    /// Adds a nested mapping.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="value">The value to associate with the key.</param>
+    /// <returns>This builder, for chaining.</returns>
+    public ConfigPropertiesBuilder Add(string key, ConfigProperties value)
+        => this.AddValue(key, ConfigValue.Mapping(value));
+
+    /// <summary>
+    /// Adds a sequence of scalar values.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The scalar element type. Supported types are <see cref="string"/>, <see cref="bool"/>,
+    /// <see cref="long"/>, <see cref="double"/>, and <see cref="int"/>.
+    /// </typeparam>
+    /// <param name="key">The key to add.</param>
+    /// <param name="items">The sequence items.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <typeparamref name="T"/> is not a supported scalar type.
+    /// </exception>
+    public ConfigPropertiesBuilder AddScalarList<T>(string key, IReadOnlyList<T> items)
     {
-        this.values.Add(key, value);
-        return this;
+        Guard.ThrowIfNull(items);
+
+        var values = new ConfigValue[items.Count];
+        for (var i = 0; i < items.Count; i++)
+        {
+            values[i] = ToScalarValue(items[i]);
+        }
+
+        return this.AddValue(key, ConfigValue.Sequence(values));
+    }
+
+    /// <summary>
+    /// Adds a sequence of nested mappings.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="items">The nested mappings.</param>
+    /// <returns>This builder, for chaining.</returns>
+    public ConfigPropertiesBuilder AddPropertiesList(
+        string key,
+        IReadOnlyList<ConfigProperties> items)
+    {
+        Guard.ThrowIfNull(items);
+
+        var values = new ConfigValue[items.Count];
+        for (var i = 0; i < items.Count; i++)
+        {
+            values[i] = ConfigValue.Mapping(items[i]);
+        }
+
+        return this.AddValue(key, ConfigValue.Sequence(values));
     }
 
     /// <summary>
@@ -30,4 +127,33 @@ internal sealed class ConfigPropertiesBuilder
     /// <returns>A new <see cref="ConfigProperties"/> containing the entries added so far.</returns>
     public ConfigProperties Build()
         => ConfigProperties.Create(this.values);
+
+    /// <summary>
+    /// Adds <paramref name="key"/> with an internal configuration value.
+    /// </summary>
+    /// <param name="key">The key to add.</param>
+    /// <param name="value">The value to associate with the key.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> already exists in this builder.</exception>
+    internal ConfigPropertiesBuilder Add(string key, ConfigValue value)
+        => this.AddValue(key, value);
+
+    private static ConfigValue ToScalarValue<T>(T value)
+        => value switch
+        {
+            string stringValue => ConfigValue.String(stringValue),
+            bool booleanValue => ConfigValue.Boolean(booleanValue),
+            int integerValue => ConfigValue.Integer(integerValue),
+            long integerValue => ConfigValue.Integer(integerValue),
+            double doubleValue => ConfigValue.Double(doubleValue),
+            _ => throw new NotSupportedException(
+                $"'{typeof(T).Name}' is not a supported scalar element type. Supported types are string, bool, long, double, and int."),
+        };
+
+    private ConfigPropertiesBuilder AddValue(string key, ConfigValue value)
+    {
+        this.values.Add(key, value);
+        return this;
+    }
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
@@ -119,4 +119,16 @@ internal sealed class OpenTelemetryDeclarativeConfigurationEventSource : EventSo
         Level = EventLevel.Warning)]
     public void MultipleConfigurationDocumentsReachable(string selectedFilePath, string ignoredFilePath) =>
         this.WriteEvent(30, selectedFilePath, ignoredFilePath);
+
+    [Event(31, Message = "Declarative config: component provider '{2}' registered for component type '{0}' with name '{1}'.", Level = EventLevel.Verbose)]
+    public void ComponentProviderRegistered(string componentType, string name, string providerType) => this.WriteEvent(31, componentType, name, providerType);
+
+    [Event(32, Message = "Declarative config: created a component of type '{0}' with name '{1}'.", Level = EventLevel.Verbose)]
+    public void ComponentCreated(string componentType, string name) => this.WriteEvent(32, componentType, name);
+
+    [Event(33, Message = "Declarative config: no component provider is registered for component type '{0}' with name '{1}'. {2}", Level = EventLevel.Error)]
+    public void ComponentProviderNotFound(string componentType, string name, string registeredNames) => this.WriteEvent(33, componentType, name, registeredNames);
+
+    [Event(34, Message = "Declarative config: component type '{0}' with name '{1}' is claimed by both '{2}' and '{3}'. Each component type and name combination must be unique.", Level = EventLevel.Error)]
+    public void DuplicateComponentProviderRejected(string componentType, string name, string existingProviderType, string duplicateProviderType) => this.WriteEvent(34, componentType, name, existingProviderType, duplicateProviderType);
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Internal/Diagnostics/OpenTelemetryDeclarativeConfigurationEventSource.cs
@@ -120,8 +120,8 @@ internal sealed class OpenTelemetryDeclarativeConfigurationEventSource : EventSo
     public void MultipleConfigurationDocumentsReachable(string selectedFilePath, string ignoredFilePath) =>
         this.WriteEvent(30, selectedFilePath, ignoredFilePath);
 
-    [Event(31, Message = "Declarative config: component provider '{2}' registered for component type '{0}' with name '{1}'.", Level = EventLevel.Verbose)]
-    public void ComponentProviderRegistered(string componentType, string name, string providerType) => this.WriteEvent(31, componentType, name, providerType);
+    [Event(31, Message = "Declarative config: component provider '{0}' registered for component type '{1}' with name '{2}'.", Level = EventLevel.Verbose)]
+    public void ComponentProviderRegistered(string providerType, string componentType, string name) => this.WriteEvent(31, providerType, componentType, name);
 
     [Event(32, Message = "Declarative config: created a component of type '{0}' with name '{1}'.", Level = EventLevel.Verbose)]
     public void ComponentCreated(string componentType, string name) => this.WriteEvent(32, componentType, name);

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <TrimmerRootAssembly Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
     <TrimmerRootAssembly Include="OpenTelemetry.Api" />
+    <TrimmerRootAssembly Include="OpenTelemetry.Configuration.Declarative" />
     <TrimmerRootAssembly Include="OpenTelemetry.Exporter.Console" />
     <TrimmerRootAssembly Include="OpenTelemetry.Exporter.InMemory" />
     <TrimmerRootAssembly Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
@@ -757,9 +757,21 @@ public sealed class ConfigPropertiesTests
     public void Builder_AddScalarList_SupportsAllScalarTypes()
     {
         var booleans = new[] { true, false };
-        var ints = new[] { 1, 2 };
-        var longs = new[] { 3L, 4L };
-        var doubles = new[] { 0.25, 0.5 };
+        var ints = new[] { 1, 2, 0, int.MinValue, int.MaxValue };
+        var longs = new[] { 3L, 4L, 0L, long.MinValue, long.MaxValue };
+        var doubles = new[]
+        {
+            0.25,
+            0.5,
+            0.0,
+            -0.0,
+            double.MinValue,
+            double.MaxValue,
+            double.Epsilon,
+            double.NaN,
+            double.PositiveInfinity,
+            double.NegativeInfinity,
+        };
         var properties = new ConfigPropertiesBuilder()
             .AddScalarList("booleans", booleans)
             .AddScalarList("ints", ints)
@@ -771,6 +783,43 @@ public sealed class ConfigPropertiesTests
         Assert.Equal(ints, properties.GetScalarList<int>("ints").Value);
         Assert.Equal(longs, properties.GetScalarList<long>("longs").Value);
         Assert.Equal(doubles, properties.GetScalarList<double>("doubles").Value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public void Builder_Add_Int_RoundTripsBoundaryValues(int value)
+    {
+        var properties = new ConfigPropertiesBuilder().Add("k", value).Build();
+
+        Assert.Equal(value, properties.GetInt("k").Value);
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(long.MinValue)]
+    [InlineData(long.MaxValue)]
+    public void Builder_Add_Long_RoundTripsBoundaryValues(long value)
+    {
+        var properties = new ConfigPropertiesBuilder().Add("k", value).Build();
+
+        Assert.Equal(value, properties.GetLong("k").Value);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(double.MinValue)]
+    [InlineData(double.MaxValue)]
+    [InlineData(double.Epsilon)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Builder_Add_Double_RoundTripsBoundaryValues(double value)
+    {
+        var properties = new ConfigPropertiesBuilder().Add("k", value).Build();
+
+        Assert.Equal(value, properties.GetDouble("k").Value);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
@@ -213,6 +213,26 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
+    public void IntegerNotExactlyRepresentableAsDouble_UsesClrWidening()
+    {
+        var properties = Build("k", ConfigValue.Integer(9007199254740993L));
+        var result = properties.GetDouble("k");
+
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(9007199254740992D, result.Value);
+    }
+
+    [Fact]
+    public void IntegerExactlyRepresentableAsDouble_IsReadable()
+    {
+        var properties = Build("k", ConfigValue.Integer(9007199254740992L));
+        var result = properties.GetDouble("k");
+
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(9007199254740992.0, result.Value);
+    }
+
+    [Fact]
     public void Double_IntegralValue_ReadsAsInt64()
     {
         var properties = Build("k", ConfigValue.Double(5.0));
@@ -631,6 +651,16 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
+    public void ScalarList_DoubleType_InexactIntegerElement_UsesClrWidening()
+    {
+        var seq = ConfigValue.Sequence([ConfigValue.Integer(9007199254740993L)]);
+        var result = Build("k", seq).GetScalarList<double>("k");
+
+        Assert.Equal(ConfigValueOutcome.Present, result.Outcome);
+        Assert.Equal(9007199254740992D, Assert.Single(result.Value!));
+    }
+
+    [Fact]
     public void ScalarList_Int32Type_DoubleElementsWithNoFraction_Readable()
     {
         var seq = ConfigValue.Sequence([ConfigValue.Double(4.0), ConfigValue.Double(9.0)]);
@@ -693,6 +723,35 @@ public sealed class ConfigPropertiesTests
     [Fact]
     public void Builder_Add_NullKey_Throws()
         => Assert.Throws<ArgumentNullException>(() => new ConfigPropertiesBuilder().Add(null!, ConfigValue.String("v")));
+
+    [Fact]
+    public void Builder_PublicTypedMethods_CreateReadableProperties()
+    {
+        var nested = new ConfigPropertiesBuilder().Add("child", "value").Build();
+        var scalarValues = new[] { "one", "two" };
+        var mappingValues = new[] { nested };
+        var properties = new ConfigPropertiesBuilder()
+            .AddNull("null")
+            .Add("string", "value")
+            .Add("boolean", true)
+            .Add("int", 1)
+            .Add("long", 2L)
+            .Add("double", 0.25)
+            .Add("mapping", nested)
+            .AddScalarList("scalars", scalarValues)
+            .AddPropertiesList("mappings", mappingValues)
+            .Build();
+
+        Assert.Equal(ConfigValueOutcome.PresentNull, properties.GetString("null").Outcome);
+        Assert.Equal("value", properties.GetString("string").Value);
+        Assert.True(properties.GetBoolean("boolean").Value);
+        Assert.Equal(1, properties.GetInt("int").Value);
+        Assert.Equal(2L, properties.GetLong("long").Value);
+        Assert.Equal(0.25, properties.GetDouble("double").Value);
+        Assert.Same(nested, properties.GetProperties("mapping").Value);
+        Assert.Equal(scalarValues, properties.GetScalarList<string>("scalars").Value);
+        Assert.Same(nested, Assert.Single(properties.GetPropertiesList("mappings").Value!));
+    }
 
     [Fact]
     public void BuilderMutatedAfterBuild_DoesNotAffectBuiltProperties()

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/ConfigPropertiesTests.cs
@@ -754,6 +754,36 @@ public sealed class ConfigPropertiesTests
     }
 
     [Fact]
+    public void Builder_AddScalarList_SupportsAllScalarTypes()
+    {
+        var booleans = new[] { true, false };
+        var ints = new[] { 1, 2 };
+        var longs = new[] { 3L, 4L };
+        var doubles = new[] { 0.25, 0.5 };
+        var properties = new ConfigPropertiesBuilder()
+            .AddScalarList("booleans", booleans)
+            .AddScalarList("ints", ints)
+            .AddScalarList("longs", longs)
+            .AddScalarList("doubles", doubles)
+            .Build();
+
+        Assert.Equal(booleans, properties.GetScalarList<bool>("booleans").Value);
+        Assert.Equal(ints, properties.GetScalarList<int>("ints").Value);
+        Assert.Equal(longs, properties.GetScalarList<long>("longs").Value);
+        Assert.Equal(doubles, properties.GetScalarList<double>("doubles").Value);
+    }
+
+    [Fact]
+    public void Builder_AddScalarList_UnsupportedType_Throws()
+    {
+        var dates = new[] { default(DateTime) };
+        var exception = Assert.Throws<NotSupportedException>(
+            () => new ConfigPropertiesBuilder().AddScalarList("dates", dates));
+
+        Assert.Contains(nameof(DateTime), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuilderMutatedAfterBuild_DoesNotAffectBuiltProperties()
     {
         var builder = new ConfigPropertiesBuilder()

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationEventSourceTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationEventSourceTests.cs
@@ -730,8 +730,9 @@ public sealed class DeclarativeConfigurationEventSourceTests
         new PluginComponentProviderRegistry(serviceProvider).Create<TestComponent>("always_on", ConfigProperties.Empty);
 
         var registered = Assert.Single(listener.Messages, e => e.EventId == 31);
-        Assert.Equal("always_on", registered.Payload![1]);
-        Assert.Contains(nameof(TestComponentProvider), registered.Payload[2] as string, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponentProvider), registered.Payload![0] as string, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponent), registered.Payload[1] as string, StringComparison.Ordinal);
+        Assert.Equal("always_on", registered.Payload[2]);
 
         var created = Assert.Single(listener.Messages, e => e.EventId == 32);
         Assert.Contains(nameof(TestComponent), created.Payload![0] as string, StringComparison.Ordinal);

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationEventSourceTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationEventSourceTests.cs
@@ -680,6 +680,64 @@ public sealed class DeclarativeConfigurationEventSourceTests
         Assert.Equal("resource.<<", evt.Payload![0]);
     }
 
+    [Fact]
+    public void Create_UnknownName_EmitsComponentProviderNotFoundEvent()
+    {
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider("always_on", new TestComponentProvider());
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var registry = new PluginComponentProviderRegistry(serviceProvider);
+
+        using var listener = CreateWarningListener();
+
+        Assert.Throws<DeclarativeConfigurationException>(
+            () => registry.Create<TestComponent>("always_upside_down", ConfigProperties.Empty));
+
+        var evt = Assert.Single(listener.Messages, e => e.EventId == 33);
+        Assert.Contains(nameof(TestComponent), evt.Payload![0] as string, StringComparison.Ordinal);
+        Assert.Equal("always_upside_down", evt.Payload[1]);
+        Assert.Contains("always_on", evt.Payload[2] as string, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_Duplicate_EmitsDuplicateRejectedEvent()
+    {
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider("always_on", new TestComponentProvider());
+
+        using var listener = CreateWarningListener();
+
+        Assert.Throws<InvalidOperationException>(
+            () => services.AddPluginComponentProvider("always_on", new TestComponentProvider()));
+
+        var evt = Assert.Single(listener.Messages, e => e.EventId == 34);
+        Assert.Contains(nameof(TestComponent), evt.Payload![0] as string, StringComparison.Ordinal);
+        Assert.Equal("always_on", evt.Payload[1]);
+        Assert.Contains(nameof(TestComponentProvider), evt.Payload[2] as string, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponentProvider), evt.Payload[3] as string, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PluginComponentProvider_RegistrationAndCreation_EmitVerboseEvents()
+    {
+        using var listener = CreateVerboseListener();
+
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider("always_on", new TestComponentProvider());
+
+        using var serviceProvider = services.BuildServiceProvider();
+        new PluginComponentProviderRegistry(serviceProvider).Create<TestComponent>("always_on", ConfigProperties.Empty);
+
+        var registered = Assert.Single(listener.Messages, e => e.EventId == 31);
+        Assert.Equal("always_on", registered.Payload![1]);
+        Assert.Contains(nameof(TestComponentProvider), registered.Payload[2] as string, StringComparison.Ordinal);
+
+        var created = Assert.Single(listener.Messages, e => e.EventId == 32);
+        Assert.Contains(nameof(TestComponent), created.Payload![0] as string, StringComparison.Ordinal);
+        Assert.Equal("always_on", created.Payload[1]);
+    }
+
     private static TestEventListener CreateVerboseListener()
     {
         var listener = new TestEventListener();

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/PluginComponentProviderRegistrationTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/PluginComponentProviderRegistrationTests.cs
@@ -1,0 +1,247 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+public sealed class PluginComponentProviderRegistrationTests
+{
+    [Fact]
+    public void AddPluginComponentProviderOnBuilder_RegistersProviderAndReturnsBuilder()
+    {
+        var services = new ServiceCollection();
+        IOpenTelemetryBuilder builder = new TestOpenTelemetryBuilder(services);
+
+        var returned = builder.AddPluginComponentProvider("always_on", new TestComponentProvider());
+
+        Assert.Same(builder, returned);
+        using var serviceProvider = services.BuildServiceProvider();
+        var component = serviceProvider
+            .GetRequiredService<PluginComponentProviderRegistry>()
+            .Create<TestComponent>("always_on", ConfigProperties.Empty);
+        Assert.NotNull(component);
+    }
+
+    [Fact]
+    public void AddPluginComponentProviderByTypeOnBuilder_RegistersProviderAndReturnsBuilder()
+    {
+        var services = new ServiceCollection();
+        IOpenTelemetryBuilder builder = new TestOpenTelemetryBuilder(services);
+
+        var returned = builder
+            .AddPluginComponentProvider<TestComponent, FixedNameTestComponentProvider>(
+                FixedNameTestComponentProvider.FixedName);
+
+        Assert.Same(builder, returned);
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(FixedNameTestComponentProvider));
+    }
+
+    [Fact]
+    public void AddPluginComponentProviderOnBuilder_NullBuilder_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => OpenTelemetryBuilderPluginComponentProviderExtensions.AddPluginComponentProvider(
+                null!,
+                "always_on",
+                new TestComponentProvider()));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddPluginComponentProviderByTypeOnBuilder_NullBuilder_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => OpenTelemetryBuilderPluginComponentProviderExtensions
+                .AddPluginComponentProvider<TestComponent, FixedNameTestComponentProvider>(
+                    null!,
+                    FixedNameTestComponentProvider.FixedName));
+
+        Assert.Equal("builder", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_RegistersOneDescriptorAndReturnsServices()
+    {
+        var services = new ServiceCollection();
+
+        var returned = services.AddPluginComponentProvider("always_on", new TestComponentProvider());
+
+        Assert.Same(services, returned);
+        var descriptor = Assert.Single(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IPluginComponentProviderRegistration));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_SameProviderClassDifferentNames_BothSurvive()
+    {
+        var services = new ServiceCollection();
+        var provider = new TestComponentProvider();
+
+        services.AddPluginComponentProvider("always_on", provider);
+        services.AddPluginComponentProvider("always_off", provider);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        Assert.NotNull(registry.Create<TestComponent>("always_on", ConfigProperties.Empty));
+        Assert.NotNull(registry.Create<TestComponent>("always_off", ConfigProperties.Empty));
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_SameComponentTypeAndName_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider("always_on", new TestComponentProvider());
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddPluginComponentProvider("always_on", new TestComponentProvider()));
+
+        Assert.Contains("always_on", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponent), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponentProvider), exception.Message, StringComparison.Ordinal);
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IPluginComponentProviderRegistration));
+    }
+
+    [Fact]
+    public void AddPluginComponentProviderByType_DuplicateIsRejectedAtRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider<TestComponent, FixedNameTestComponentProvider>("same");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddPluginComponentProvider<TestComponent, FixedNameTestComponentProvider>("same"));
+
+        Assert.Contains("same", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponent), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(FixedNameTestComponentProvider), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_InstanceAndTypeDuplicateIsRejectedAtRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider("same", new TestComponentProvider());
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddPluginComponentProvider<TestComponent, FixedNameTestComponentProvider>("same"));
+
+        Assert.Contains(nameof(TestComponentProvider), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(FixedNameTestComponentProvider), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_SameNameUnderDifferentComponentTypes_BothRegister()
+    {
+        var services = new ServiceCollection();
+
+        services.AddPluginComponentProvider("shared_name", new TestComponentProvider());
+        services.AddPluginComponentProvider("shared_name", new OtherTestComponentProvider());
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        Assert.NotNull(registry.Create<TestComponent>("shared_name", ConfigProperties.Empty));
+        Assert.NotNull(registry.Create<OtherTestComponent>("shared_name", ConfigProperties.Empty));
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_NullServices_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => PluginComponentProviderServiceCollectionExtensions.AddPluginComponentProvider(
+                null!,
+                "always_on",
+                new TestComponentProvider()));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddPluginComponentProvider_NullProvider_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new ServiceCollection()
+                .AddPluginComponentProvider<TestComponent>("always_on", null!));
+
+        Assert.Equal("provider", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddPluginComponentProvider_InvalidName_Throws(string? name)
+    {
+        var exception = Assert.ThrowsAny<ArgumentException>(
+            () => new ServiceCollection()
+                .AddPluginComponentProvider(name!, new TestComponentProvider()));
+
+        Assert.Equal("name", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddPluginComponentProviderByType_NullServices_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => PluginComponentProviderServiceCollectionExtensions
+                .AddPluginComponentProvider<TestComponent, FixedNameTestComponentProvider>(
+                    null!,
+                    FixedNameTestComponentProvider.FixedName));
+
+        Assert.Equal("services", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddPluginComponentProviderByType_InvalidName_Throws(string? name)
+    {
+        var exception = Assert.ThrowsAny<ArgumentException>(
+            () => new ServiceCollection()
+                .AddPluginComponentProvider<TestComponent, FixedNameTestComponentProvider>(name!));
+
+        Assert.Equal("name", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddPluginComponentProviderByType_ProviderIsConstructedWithItsDependencies()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestDependency>();
+        services.AddPluginComponentProvider<TestComponent, InjectedTestComponentProvider>("injected");
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        Assert.NotNull(registry.Create<TestComponent>("injected", ConfigProperties.Empty));
+    }
+
+    [Fact]
+    public void AddPluginComponentProviderByType_SameProviderUnderDifferentNamesUsesOneProviderRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TestDependency>();
+        services.AddPluginComponentProvider<TestComponent, InjectedTestComponentProvider>("first");
+        services.AddPluginComponentProvider<TestComponent, InjectedTestComponentProvider>("second");
+
+        Assert.Single(
+            services,
+            descriptor => descriptor.ServiceType == typeof(InjectedTestComponentProvider));
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        Assert.NotNull(registry.Create<TestComponent>("first", ConfigProperties.Empty));
+        Assert.NotNull(registry.Create<TestComponent>("second", ConfigProperties.Empty));
+    }
+
+    private sealed class TestOpenTelemetryBuilder(IServiceCollection services) : IOpenTelemetryBuilder
+    {
+        public IServiceCollection Services { get; } = services;
+    }
+}

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/PluginComponentProviderRegistryTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/PluginComponentProviderRegistryTests.cs
@@ -1,0 +1,277 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+public sealed class PluginComponentProviderRegistryTests
+{
+    [Fact]
+    public void Constructor_NullServiceProvider_Throws()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new PluginComponentProviderRegistry(null!));
+
+        Assert.Equal("serviceProvider", exception.ParamName);
+    }
+
+    [Fact]
+    public void Create_PassesPropertiesAndContainerToProvider()
+    {
+        var properties = new ConfigPropertiesBuilder().Add("ratio", 0.25).Build();
+        using var serviceProvider = BuildServiceProvider(("trace_id_ratio_based", new TestComponentProvider()));
+
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+        var component = registry.Create<TestComponent>("trace_id_ratio_based", properties);
+
+        Assert.Same(properties, component.Properties);
+        Assert.Same(
+            registry,
+            component.ServiceProvider.GetRequiredService<PluginComponentProviderRegistry>());
+    }
+
+    [Fact]
+    public void Create_ReturnsANewComponentOnEveryCall()
+    {
+        using var serviceProvider = BuildServiceProvider(("always_on", new TestComponentProvider()));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        var first = registry.Create<TestComponent>("always_on", ConfigProperties.Empty);
+        var second = registry.Create<TestComponent>("always_on", ConfigProperties.Empty);
+
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void Create_NameMatchingIsOrdinal()
+    {
+        using var serviceProvider = BuildServiceProvider(("always_on", new TestComponentProvider()));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        Assert.Throws<DeclarativeConfigurationException>(
+            () => registry.Create<TestComponent>("Always_On", ConfigProperties.Empty));
+    }
+
+    [Fact]
+    public void Create_ComponentTypeMatchingIsExact()
+    {
+        using var serviceProvider = BuildServiceProvider(("always_on", new TestComponentProvider()));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        Assert.Throws<DeclarativeConfigurationException>(
+            () => registry.Create<OtherTestComponent>("always_on", ConfigProperties.Empty));
+    }
+
+    [Fact]
+    public void Create_UnknownName_ThrowsListingTheRegisteredNames()
+    {
+        using var serviceProvider = BuildServiceProvider(
+            ("always_on", new TestComponentProvider()),
+            ("trace_id_ratio_based", new TestComponentProvider()));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        var exception = Assert.Throws<DeclarativeConfigurationException>(
+            () => registry.Create<TestComponent>("always_upside_down", ConfigProperties.Empty));
+
+        Assert.Contains("always_upside_down", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponent), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("always_on", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("trace_id_ratio_based", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Create_NoProvidersForTheComponentType_SaysSo()
+    {
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider("always_on", new OtherTestComponentProvider());
+        using var serviceProvider = services.BuildServiceProvider();
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        var exception = Assert.Throws<DeclarativeConfigurationException>(
+            () => registry.Create<TestComponent>("always_on", ConfigProperties.Empty));
+
+        Assert.Contains("No component providers are registered", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Create_ProviderThrows_PropagatesTheSameException()
+    {
+        var thrown = new NotSupportedException("the provider rejected its configuration");
+        using var serviceProvider = BuildServiceProvider(
+            ("always_on", new ThrowingTestComponentProvider(thrown)));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        var caught = Assert.Throws<NotSupportedException>(
+            () => registry.Create<TestComponent>("always_on", ConfigProperties.Empty));
+
+        Assert.Same(thrown, caught);
+    }
+
+    [Fact]
+    public void Create_ProviderReturnsNull_ThrowsNamingTheProviderAndExpectedType()
+    {
+        using var serviceProvider = BuildServiceProvider(("always_on", new NullTestComponentProvider()));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => registry.Create<TestComponent>("always_on", ConfigProperties.Empty));
+
+        Assert.Contains(nameof(NullTestComponentProvider), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponent), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("always_on", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("null", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Create_UntrustedRegistrationReturnsIncompatibleType_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPluginComponentProviderRegistration>(
+            new UntrustedPluginComponentProviderRegistration("always_on", new OtherTestComponent()));
+        services.AddSingleton<PluginComponentProviderRegistry>();
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => serviceProvider
+                .GetRequiredService<PluginComponentProviderRegistry>()
+                .Create<TestComponent>("always_on", ConfigProperties.Empty));
+
+        Assert.Contains(nameof(UntrustedPluginComponentProviderRegistration), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(OtherTestComponent), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Create_NullArguments_Throw()
+    {
+        using var serviceProvider = BuildServiceProvider(("always_on", new TestComponentProvider()));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        var nullNameException = Assert.Throws<ArgumentNullException>(
+            () => registry.Create<TestComponent>(null!, ConfigProperties.Empty));
+        var nullPropertiesException = Assert.Throws<ArgumentNullException>(
+            () => registry.Create<TestComponent>("always_on", null!));
+
+        Assert.Equal("name", nullNameException.ParamName);
+        Assert.Equal("properties", nullPropertiesException.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_SeesOnlyProvidersRegisteredInItsContainer()
+    {
+        using var first = BuildServiceProvider(("always_on", new TestComponentProvider()));
+        using var second = BuildServiceProvider(("always_off", new TestComponentProvider()));
+
+        var registry = first.GetRequiredService<PluginComponentProviderRegistry>();
+
+        Assert.NotNull(registry.Create<TestComponent>("always_on", ConfigProperties.Empty));
+        Assert.Throws<DeclarativeConfigurationException>(
+            () => registry.Create<TestComponent>("always_off", ConfigProperties.Empty));
+    }
+
+    [Fact]
+    public async Task Create_IsSafeToCallConcurrently()
+    {
+        var properties = new ConfigPropertiesBuilder().Add("ratio", 0.5).Build();
+        using var serviceProvider = BuildServiceProvider(
+            ("always_on", new TestComponentProvider()),
+            ("trace_id_ratio_based", new TestComponentProvider()));
+        var registry = serviceProvider.GetRequiredService<PluginComponentProviderRegistry>();
+
+        var names = Enumerable.Range(0, 128)
+            .Select(index => index % 2 == 0 ? "always_on" : "trace_id_ratio_based")
+            .ToArray();
+
+        var components = await Task.WhenAll(
+            names.Select(name => Task.Run(
+                () => registry.Create<TestComponent>(name, properties))));
+
+        Assert.Equal(names.Length, components.Length);
+        Assert.All(components, component => Assert.Same(properties, component.Properties));
+        Assert.Equal(names.Length, components.Distinct().Count());
+    }
+
+    [Fact]
+    public void Registry_DoesNotOwnComponentsItCreates()
+    {
+        Assert.False(typeof(IDisposable).IsAssignableFrom(typeof(PluginComponentProviderRegistry)));
+
+        DisposableTestComponent component;
+        var services = new ServiceCollection();
+        services.AddPluginComponentProvider("batch", new DisposableTestComponentProvider());
+
+        using (var serviceProvider = services.BuildServiceProvider())
+        {
+            component = serviceProvider
+                .GetRequiredService<PluginComponentProviderRegistry>()
+                .Create<DisposableTestComponent>("batch", ConfigProperties.Empty);
+        }
+
+        Assert.False(component.Disposed);
+    }
+
+    [Fact]
+    public void Create_ReceivesProperties()
+    {
+        var headers = new ConfigPropertiesBuilder()
+            .Add("authorization", "secret")
+            .Build();
+        var expectedTags = new[] { "one", "two" };
+        var properties = new ConfigPropertiesBuilder()
+            .Add("endpoint", "https://collector.example")
+            .Add("enabled", true)
+            .Add("timeout", 10)
+            .Add("ratio", 0.25)
+            .Add("headers", headers)
+            .AddScalarList("tags", expectedTags)
+            .Build();
+        using var serviceProvider = BuildServiceProvider(("custom", new TestComponentProvider()));
+
+        var component = serviceProvider
+            .GetRequiredService<PluginComponentProviderRegistry>()
+            .Create<TestComponent>("custom", properties);
+
+        Assert.Equal("https://collector.example", component.Properties.GetString("endpoint").Value);
+        Assert.True(component.Properties.GetBoolean("enabled").Value);
+        Assert.Equal(10, component.Properties.GetInt("timeout").Value);
+        Assert.Equal(0.25, component.Properties.GetDouble("ratio").Value);
+        Assert.Equal(
+            "secret",
+            component.Properties.GetProperties("headers").Value!.GetString("authorization").Value);
+        Assert.Equal(
+            expectedTags,
+            component.Properties.GetScalarList<string>("tags").Value);
+    }
+
+    private static ServiceProvider BuildServiceProvider(
+        params (string Name, PluginComponentProvider<TestComponent> Provider)[] registrations)
+    {
+        var services = new ServiceCollection();
+
+        foreach (var registration in registrations)
+        {
+            services.AddPluginComponentProvider(registration.Name, registration.Provider);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class UntrustedPluginComponentProviderRegistration : IPluginComponentProviderRegistration
+    {
+        private readonly object component;
+
+        public UntrustedPluginComponentProviderRegistration(string name, object component)
+        {
+            this.Name = name;
+            this.component = component;
+        }
+
+        public Type ComponentType => typeof(TestComponent);
+
+        public string Name { get; }
+
+        public Type ProviderType => this.GetType();
+
+        public object Create(ConfigProperties properties, IServiceProvider serviceProvider) => this.component;
+    }
+}

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/PluginComponentProviderRegistryTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/PluginComponentProviderRegistryTests.cs
@@ -16,6 +16,51 @@ public sealed class PluginComponentProviderRegistryTests
         Assert.Equal("serviceProvider", exception.ParamName);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_RegistrationWithoutName_Throws(string? name)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPluginComponentProviderRegistration>(
+            new UntrustedPluginComponentProviderRegistration(name, new object()));
+        services.AddSingleton<PluginComponentProviderRegistry>();
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            serviceProvider.GetRequiredService<PluginComponentProviderRegistry>);
+
+        Assert.Contains(nameof(UntrustedPluginComponentProviderRegistration), exception.Message, StringComparison.Ordinal);
+        Assert.Contains("has no name", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Constructor_DuplicateRegistration_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPluginComponentProviderRegistration>(
+            new UntrustedPluginComponentProviderRegistration(
+                "always_on",
+                new object(),
+                typeof(TestComponentProvider)));
+        services.AddSingleton<IPluginComponentProviderRegistration>(
+            new UntrustedPluginComponentProviderRegistration(
+                "always_on",
+                new object(),
+                typeof(FixedNameTestComponentProvider)));
+        services.AddSingleton<PluginComponentProviderRegistry>();
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            serviceProvider.GetRequiredService<PluginComponentProviderRegistry>);
+
+        Assert.Contains("always_on", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponent), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(TestComponentProvider), exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(FixedNameTestComponentProvider), exception.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Create_PassesPropertiesAndContainerToProvider()
     {
@@ -260,17 +305,21 @@ public sealed class PluginComponentProviderRegistryTests
     {
         private readonly object component;
 
-        public UntrustedPluginComponentProviderRegistration(string name, object component)
+        public UntrustedPluginComponentProviderRegistration(
+            string? name,
+            object component,
+            Type? providerType = null)
         {
-            this.Name = name;
+            this.Name = name!;
             this.component = component;
+            this.ProviderType = providerType ?? this.GetType();
         }
 
         public Type ComponentType => typeof(TestComponent);
 
         public string Name { get; }
 
-        public Type ProviderType => this.GetType();
+        public Type ProviderType { get; }
 
         public object Create(ConfigProperties properties, IServiceProvider serviceProvider) => this.component;
     }

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/Shared/TestComponent.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/Shared/TestComponent.cs
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes - the container builds them
+
+namespace OpenTelemetry.Configuration.Declarative.Tests;
+
+internal sealed class TestComponent
+{
+    public TestComponent(ConfigProperties properties, IServiceProvider serviceProvider)
+    {
+        this.Properties = properties;
+        this.ServiceProvider = serviceProvider;
+    }
+
+    public ConfigProperties Properties { get; }
+
+    public IServiceProvider ServiceProvider { get; }
+}
+
+internal sealed class OtherTestComponent;
+
+internal sealed class DisposableTestComponent : IDisposable
+{
+    public bool Disposed { get; private set; }
+
+    public void Dispose() => this.Disposed = true;
+}
+
+internal sealed class TestDependency
+{
+    public string Value { get; } = "injected";
+}
+
+internal sealed class TestComponentProvider : PluginComponentProvider<TestComponent>
+{
+    public override TestComponent Create(ConfigProperties properties, IServiceProvider serviceProvider)
+        => new(properties, serviceProvider);
+}
+
+internal sealed class OtherTestComponentProvider : PluginComponentProvider<OtherTestComponent>
+{
+    public override OtherTestComponent Create(ConfigProperties properties, IServiceProvider serviceProvider)
+        => new();
+}
+
+internal sealed class FixedNameTestComponentProvider : PluginComponentProvider<TestComponent>
+{
+    public const string FixedName = "fixed_name";
+
+    public override TestComponent Create(ConfigProperties properties, IServiceProvider serviceProvider)
+        => new(properties, serviceProvider);
+}
+
+internal sealed class InjectedTestComponentProvider : PluginComponentProvider<TestComponent>
+{
+    private readonly TestDependency dependency;
+
+    public InjectedTestComponentProvider(TestDependency dependency)
+    {
+        this.dependency = dependency;
+    }
+
+    public override TestComponent Create(ConfigProperties properties, IServiceProvider serviceProvider)
+    {
+        _ = this.dependency.Value;
+        return new(properties, serviceProvider);
+    }
+}
+
+internal sealed class ThrowingTestComponentProvider : PluginComponentProvider<TestComponent>
+{
+    private readonly Exception exception;
+
+    public ThrowingTestComponentProvider(Exception exception)
+    {
+        this.exception = exception;
+    }
+
+    public override TestComponent Create(ConfigProperties properties, IServiceProvider serviceProvider)
+        => throw this.exception;
+}
+
+internal sealed class NullTestComponentProvider : PluginComponentProvider<TestComponent>
+{
+    public override TestComponent Create(ConfigProperties properties, IServiceProvider serviceProvider)
+        => null!;
+}
+
+internal sealed class DisposableTestComponentProvider : PluginComponentProvider<DisposableTestComponent>
+{
+    public override DisposableTestComponent Create(ConfigProperties properties, IServiceProvider serviceProvider)
+        => new();
+}


### PR DESCRIPTION
Contibutes to #7658

## Changes

Adds abstractions for defining component providers, a registry for storing them and methods to register them with the SDK.

Key pieces:
- `PluginComponentProvider<TComponent>` - abstract base for provider implementations
- `PluginComponentProviderRegistry` - builds a frozen, concurrent-safe index at
  startup and routes configuration nodes to the correct factory
- `ConfigPropertiesBuilder` extended to support provider-driven component creation
- DI extension methods on both `IOpenTelemetryBuilder` and `IServiceCollection`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~