### PR TITLE
[API] Pass capacity to StringBuilder

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -138,7 +138,12 @@ public class BaggagePropagator : TextMapPropagator
         if (e.MoveNext())
         {
             var itemCount = 0;
-            var baggage = new StringBuilder();
+
+            // Pre-size the builder to avoid repeated internal buffer growth. This
+            // value is a rough estimate (16 chars/item covers most "key=value" pairs).
+            var estimatedCapacity = Math.Min(MaxBaggageLength, context.Baggage.Count * 16);
+            var baggage = new StringBuilder(estimatedCapacity);
+
             do
             {
                 var item = e.Current;

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -140,8 +140,10 @@ public class BaggagePropagator : TextMapPropagator
             var itemCount = 0;
 
             // Pre-size the builder to avoid repeated internal buffer growth. This
-            // value is a rough estimate (16 chars/item covers most "key=value" pairs).
-            var estimatedCapacity = Math.Min(MaxBaggageLength, context.Baggage.Count * 16);
+            // value is a rough estimate (16 chars/item covers most "key=value" pairs),
+            // clamped to the maximum number of items that can be serialized.
+            var estimatedItemCount = Math.Min(context.Baggage.Count, MaxBaggageItems);
+            var estimatedCapacity = Math.Min(MaxBaggageLength, estimatedItemCount * 16);
             var baggage = new StringBuilder(estimatedCapacity);
 
             do


### PR DESCRIPTION
## Changes

Pass a capacity hint to `StringBuilder` when injecting baggage to reduce internal reallocations.

Allocation reduction measured using the `BaggagePropagatorBenchmarks` benchmarks:

| ItemCount | Baseline Allocated | Fixed Allocated | Reduction |
|---|---|---|---|
| 1  | 192 B | 192 B | 0% (no change, capacity coincides with default) |
| 5  | 688 B | 576 B | -16.3% |
| 20 | 2800 B | 2056 B | -26.6% |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
