### PR TITLE
Add checksums.txt to GitHub release assets

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -351,6 +351,13 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path: ./artifacts
 
+    - name: Generate checksums.txt for release assets
+      shell: pwsh
+      run: |
+        Import-Module .\build\scripts\post-release.psm1
+
+        CreateChecksumsFile -directory "${env:GITHUB_WORKSPACE}/artifacts"
+
     - name: Create GitHub Release draft
       shell: pwsh
       env:

--- a/README.md
+++ b/README.md
@@ -254,6 +254,22 @@ gh attestation verify --owner open-telemetry .\OpenTelemetry.dll
 For more verification options please refer to the [`gh attestation verify`
 documentation](https://cli.github.com/manual/gh_attestation_verify).
 
+### Checksums
+
+Every [release](https://github.com/open-telemetry/opentelemetry-dotnet/releases)
+published from this repo includes a `checksums.txt` file listing the SHA256
+checksum of every other file attached to the release, such as the NuGet
+packages, the symbol packages, and the SBOM.
+
+To verify a downloaded release asset against `checksums.txt`:
+
+```bash
+sha256sum --ignore-missing -c checksums.txt
+```
+
+> [!NOTE]
+> A successful verification outputs `OK` for each verified file.
+
 ## Contributing
 
 For information about contributing to the project see:

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -1,3 +1,22 @@
+function CreateChecksumsFile {
+  param(
+    [Parameter(Mandatory=$true)][string]$directory
+  )
+
+  $ErrorActionPreference = "Stop"
+
+  $files = Get-ChildItem -Path $directory -File | Sort-Object -Property Name
+
+  $lines = foreach ($file in $files) {
+    $hash = (Get-FileHash -Path $file.FullName -Algorithm SHA256).Hash.ToLower()
+    "$hash  $($file.Name)"
+  }
+
+  Set-Content -Path (Join-Path -Path $directory -ChildPath "checksums.txt") -Value $lines -Encoding utf8NoBOM
+}
+
+Export-ModuleMember -Function CreateChecksumsFile
+
 function CreateDraftRelease {
   param(
     [Parameter(Mandatory=$true)][string]$gitRepository,

--- a/build/scripts/tests/post-release.Tests.ps1
+++ b/build/scripts/tests/post-release.Tests.ps1
@@ -72,6 +72,30 @@ Describe "GetCoreDependenciesForProjects" {
     }
 }
 
+Describe "CreateChecksumsFile" {
+
+    It "writes a checksums.txt with SHA256 hashes for every file in the directory" {
+        $directory = Join-Path -Path $TestDrive -ChildPath (New-Guid)
+        New-Item -Path $directory -ItemType Directory -Force | Out-Null
+
+        Set-Content -Path (Join-Path -Path $directory -ChildPath "b.nupkg") -Value "second"
+        Set-Content -Path (Join-Path -Path $directory -ChildPath "a.nupkg") -Value "first"
+
+        CreateChecksumsFile -directory $directory
+
+        $checksumsPath = Join-Path -Path $directory -ChildPath "checksums.txt"
+        Test-Path -Path $checksumsPath | Should-BeTrue -Because "a checksums.txt file should be written to the directory"
+
+        $expectedHashA = (Get-FileHash -Path (Join-Path -Path $directory -ChildPath "a.nupkg") -Algorithm SHA256).Hash.ToLower()
+        $expectedHashB = (Get-FileHash -Path (Join-Path -Path $directory -ChildPath "b.nupkg") -Algorithm SHA256).Hash.ToLower()
+
+        $lines = Get-Content -Path $checksumsPath
+        @($lines).Count | Should-Be 2 -Because "one line should be written per file in the directory"
+        $lines[0] | Should-Be "$expectedHashA  a.nupkg" -Because "files should be listed in alphabetical order with their lowercase SHA256 hash"
+        $lines[1] | Should-Be "$expectedHashB  b.nupkg" -Because "files should be listed in alphabetical order with their lowercase SHA256 hash"
+    }
+}
+
 Describe "CreateDraftRelease" {
 
     BeforeEach {


### PR DESCRIPTION
## Summary
- Every GitHub release published from this repo now includes a `checksums.txt` file listing the SHA256 checksum of every other asset attached to the release (the NuGet packages, symbol packages, and SBOM).
- Adds a `CreateChecksumsFile` function to `build/scripts/post-release.psm1` and calls it from the `post-build` job in `publish-packages-1.0.yml` before the draft release is created, so the file is included in the `gh release create` asset glob alongside the existing files.
- Documents the new file in the README, alongside the existing digital signing and attestation sections.

This gives downstream consumers that download release assets over HTTPS (for example the [opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging) build) a way to verify integrity beyond TLS by pinning and checking against published checksums.

Related: open-telemetry/opentelemetry-packaging#21

## Test plan
- [x] Added a Pester unit test for `CreateChecksumsFile` in `build/scripts/tests/post-release.Tests.ps1` and ran the full `post-release.Tests.ps1` suite locally with Pester 6 — the new test passes; the two pre-existing failures are unrelated (they require a `dotnet` binary that isn't available in this sandbox) and fail identically on `main` without this change.
- [ ] CI: verify `publish-packages-1.0.yml` still produces a valid draft release with `checksums.txt` attached on the next tagged run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QReT4F1xwqYza28bbPzpfi