### PR TITLE
Add IHostApplicationBuilder.AddOpenTelemetry() extension

### DIFF
--- a/docs/builders/README.md
+++ b/docs/builders/README.md
@@ -5,7 +5,7 @@ application model.
 
 | Entry Point | Best For | Multi-Signal | Lifecycle |
 | --- | --- | --- | --- |
-| [`services.AddOpenTelemetry()`][add] | ASP.NET Core, worker services, hosted apps | Yes | Managed by the host |
+| [`AddOpenTelemetry()`][add] | ASP.NET Core, worker services, hosted apps | Yes | Managed by the host |
 | [`OpenTelemetrySdk.Create()`][create] | Console apps, background jobs, CLI tools | Yes | Single `Dispose()` call |
 | [`Sdk.CreateTracerProviderBuilder()`][tracer] | Legacy / <= 1.9.0 codebases, single-signal tests | No (per-signal) | Dispose each provider individually |
 
@@ -13,6 +13,9 @@ application model.
 > For new projects, use `AddOpenTelemetry()` (hosted) or
 > `OpenTelemetrySdk.Create()` (non-hosted). The per-signal `Sdk.Create*Builder`
 > methods are retained for backward compatibility.
+>
+> On a host, call `AddOpenTelemetry()` on the builder itself
+> (`builder.AddOpenTelemetry()`) rather than on `builder.Services`.
 
 ## Quick links
 

--- a/docs/builders/add-opentelemetry.md
+++ b/docs/builders/add-opentelemetry.md
@@ -1,4 +1,4 @@
-# services.AddOpenTelemetry()
+# AddOpenTelemetry()
 
 > [!NOTE]
 > This is the recommended approach for any application using the .NET Generic
@@ -20,8 +20,7 @@ using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetry()
-    .ConfigureResource(r => r.AddService("my-web-api"))
+builder.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddAspNetCoreInstrumentation()
         .AddConsoleExporter());
@@ -29,6 +28,17 @@ builder.Services.AddOpenTelemetry()
 var app = builder.Build();
 app.MapGet("/", () => "Hello World");
 app.Run();
+```
+
+`service.name` defaults to `IHostEnvironment.ApplicationName` and
+`deployment.environment.name` defaults to `IHostEnvironment.EnvironmentName`.
+To set an explicit name or add `service.version`, use `ConfigureResource`:
+
+```csharp
+builder.AddOpenTelemetry()
+    .ConfigureResource(r => r
+        .AddService(serviceName: "my-web-api", serviceVersion: "1.0.0"))
+    .WithTracing(...);
 ```
 
 ## Full multi-signal example
@@ -43,7 +53,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Clear default log providers if you want OTel to be the sole log sink
 builder.Logging.ClearProviders();
 
-builder.Services.AddOpenTelemetry()
+builder.AddOpenTelemetry()
     .ConfigureResource(r => r
         .AddService(
             serviceName: "my-web-api",
@@ -73,8 +83,7 @@ using OpenTelemetry.Trace;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.Services.AddOpenTelemetry()
-    .ConfigureResource(r => r.AddService("my-worker"))
+builder.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddSource("MyWorker")
         .AddOtlpExporter());
@@ -83,6 +92,19 @@ builder.Services.AddHostedService<MyWorker>();
 
 var host = builder.Build();
 host.Run();
+```
+
+## Non-host scenarios
+
+When the application does not use the .NET Generic Host, call `AddOpenTelemetry`
+on `IServiceCollection` directly:
+
+```csharp
+services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService("my-app"))
+    .WithTracing(tracing => tracing
+        .AddSource("MyApp")
+        .AddOtlpExporter());
 ```
 
 ## API surface
@@ -124,7 +146,7 @@ app.MapGet("/trace-id", (TracerProvider tp) =>
 ### Registering a custom processor
 
 ```csharp
-builder.Services.AddOpenTelemetry()
+builder.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddProcessor<MyFilteringProcessor>());  // resolved from DI
 

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/OpenTelemetry.Api.ProviderBuilderExtensions.csproj
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/OpenTelemetry.Api.ProviderBuilderExtensions.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="OpenTelemetry" PublicKey="$(StrongNamePublicKey)" />
     <InternalsVisibleTo Include="OpenTelemetry.Api.ProviderBuilderExtensions.Tests" PublicKey="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="OpenTelemetry.Configuration.Declarative" PublicKey="$(StrongNamePublicKey)" />
     <InternalsVisibleTo Include="OpenTelemetry.Exporter.Console" PublicKey="$(StrongNamePublicKey)" />
     <InternalsVisibleTo Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" PublicKey="$(StrongNamePublicKey)" />
     <InternalsVisibleTo Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests" PublicKey="$(StrongNamePublicKey)" />

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/OpenTelemetryBuilderConfigurationAccessor.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/OpenTelemetryBuilderConfigurationAccessor.cs
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry;
+
+// Carries IConfiguration across the assembly boundary without introducing a dependency on
+// Microsoft.Extensions.Configuration.Abstractions in OpenTelemetry.Api.ProviderBuilderExtensions.
+// Callers in layers that already reference that assembly cast Configuration to IConfiguration themselves.
+internal sealed class OpenTelemetryBuilderConfigurationAccessor(object configuration)
+{
+    internal object Configuration { get; } = configuration;
+}

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/OpenTelemetryBuilderConfigurationAccessor.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/OpenTelemetryBuilderConfigurationAccessor.cs
@@ -3,10 +3,10 @@
 
 namespace OpenTelemetry;
 
-// Carries IConfiguration across the assembly boundary without introducing a dependency on
-// Microsoft.Extensions.Configuration.Abstractions in OpenTelemetry.Api.ProviderBuilderExtensions.
-// Callers in layers that already reference that assembly cast Configuration to IConfiguration themselves.
+/// <summary>Provides access to the host's IConfiguration instance for OTel extensions resolving it from DI.</summary>
 internal sealed class OpenTelemetryBuilderConfigurationAccessor(object configuration)
 {
+    // Uses object to avoid a dependency on Microsoft.Extensions.Configuration.Abstractions in this assembly;
+    // callers that already reference that package cast Configuration to IConfiguration.
     internal object Configuration { get; } = configuration;
 }

--- a/src/OpenTelemetry.Configuration.Declarative/Extensions/OpenTelemetryBuilderDeclarativeConfigurationExtensions.cs
+++ b/src/OpenTelemetry.Configuration.Declarative/Extensions/OpenTelemetryBuilderDeclarativeConfigurationExtensions.cs
@@ -60,6 +60,11 @@ public static class OpenTelemetryBuilderDeclarativeConfigurationExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Adds declarative configuration to services configured by an OpenTelemetry builder.
+    /// </summary>
+    /// <param name="services">The services used to configure OpenTelemetry.</param>
+    /// <param name="filePath">The path to the declarative configuration file.</param>
     internal static void AddDeclarativeConfigurationOverlay(IServiceCollection services, FilePath filePath)
     {
         // Second call on the same IServiceCollection is a no-op (first file path wins).
@@ -74,8 +79,12 @@ public static class OpenTelemetryBuilderDeclarativeConfigurationExtensions
             return;
         }
 
-        // Last registered IConfiguration wins in DI.
-        var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(IConfiguration));
+        // A host registers IConfiguration as a factory, so the application's live configuration
+        // cannot be reached through the descriptor below. AddOpenTelemetry(IHostApplicationBuilder)
+        // contributes an accessor that makes the instance reachable here.
+        var configurationAccessor = services
+            .LastOrDefault(d => d.ServiceType == typeof(OpenTelemetryBuilderConfigurationAccessor))
+            ?.ImplementationInstance as OpenTelemetryBuilderConfigurationAccessor;
 
         // The accessor this call contributes if no declarative source is registered already. When one
         // is, the existing accessor wins and this instance is discarded unused.
@@ -85,14 +94,28 @@ public static class OpenTelemetryBuilderDeclarativeConfigurationExtensions
 
         OpenTelemetryDeclarativeConfigurationEventSource.Log.OverlayRegistrationStarted(filePath.DisplayPath);
 
-        // TODO(strict-mode): branch here on a future DeclarativeConfigurationMode (Default vs Strict). See https://github.com/open-telemetry/opentelemetry-dotnet/issues/6380.
+        // TODO(strict-mode): branch here on a future DeclarativeConfigurationMode (Default vs Strict).
+        // See https://github.com/open-telemetry/opentelemetry-dotnet/issues/6380.
 
-        if (descriptor?.ImplementationInstance is IConfigurationBuilder liveBuilder)
+        // Fast path: hosting API accessor exposes a live ConfigurationManager; mutate in-place and skip descriptor scan.
+        if (configurationAccessor?.Configuration is IConfigurationBuilder accessorBuilder)
         {
-            // ConfigurationManager registered as instance: mutate in-place, preserve reload.
-            liveBuilder.AddOpenTelemetryDeclarativeConfiguration(candidateAccessor);
+            accessorBuilder.AddOpenTelemetryDeclarativeConfiguration(candidateAccessor);
             services.TryAddSingleton(
-                DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(liveBuilder)
+                DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(accessorBuilder)
+                    ?? candidateAccessor);
+            return;
+        }
+
+        // Last registered IConfiguration wins in DI.
+        var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(IConfiguration));
+
+        // IConfiguration is a singleton instance that is also a live builder; mutate in-place.
+        if (descriptor?.ImplementationInstance is IConfigurationBuilder instanceBuilder)
+        {
+            instanceBuilder.AddOpenTelemetryDeclarativeConfiguration(candidateAccessor);
+            services.TryAddSingleton(
+                DeclarativeConfigurationDocumentAccessorResolver.FindInConfiguration(instanceBuilder)
                     ?? candidateAccessor);
             return;
         }

--- a/src/OpenTelemetry.Configuration.Declarative/README.md
+++ b/src/OpenTelemetry.Configuration.Declarative/README.md
@@ -24,7 +24,8 @@ OTEL_CONFIG_FILE=/path/to/otel-config.yaml
 
 ### 2. Wire it into your OTel setup
 
-**On `IHostApplicationBuilder` (`WebApplicationBuilder` / `HostApplicationBuilder`) - recommended:**
+**On `IHostApplicationBuilder` (`WebApplicationBuilder` /**
+**`HostApplicationBuilder`) - recommended:**
 
 ```csharp
 builder.AddOpenTelemetry()
@@ -40,7 +41,6 @@ hostBuilder.ConfigureAppConfiguration(b =>
 hostBuilder.ConfigureServices(services =>
     services.AddOpenTelemetry().WithTracing(...));
 ```
-
 
 **Without a host** (plain `IServiceCollection`), wire through
 `IOpenTelemetryBuilder` (reads `OTEL_CONFIG_FILE` when called without a path):

--- a/src/OpenTelemetry.Configuration.Declarative/README.md
+++ b/src/OpenTelemetry.Configuration.Declarative/README.md
@@ -24,11 +24,11 @@ OTEL_CONFIG_FILE=/path/to/otel-config.yaml
 
 ### 2. Wire it into your OTel setup
 
-**Recommended on `HostApplicationBuilder` / `WebApplicationBuilder`:**
+**On `IHostApplicationBuilder` (`WebApplicationBuilder` / `HostApplicationBuilder`) - recommended:**
 
 ```csharp
-builder.Configuration.AddOpenTelemetryDeclarativeConfiguration(); // reads OTEL_CONFIG_FILE
-builder.Services.AddOpenTelemetry()
+builder.AddOpenTelemetry()
+    .UseDeclarativeConfiguration()
     .WithTracing(b => b.AddSource("MyApp.*").AddConsoleExporter());
 ```
 
@@ -41,8 +41,9 @@ hostBuilder.ConfigureServices(services =>
     services.AddOpenTelemetry().WithTracing(...));
 ```
 
-**Alternative:** wire through `IOpenTelemetryBuilder` (reads `OTEL_CONFIG_FILE`
-when called without a path):
+
+**Without a host** (plain `IServiceCollection`), wire through
+`IOpenTelemetryBuilder` (reads `OTEL_CONFIG_FILE` when called without a path):
 
 ```csharp
 services.AddOpenTelemetry()
@@ -58,14 +59,8 @@ services.AddOpenTelemetry()
     .WithTracing(...);
 ```
 
-`UseDeclarativeConfiguration()` works best on modern hosts
-(`WebApplicationBuilder`, `HostApplicationBuilder`) where `IConfiguration` is
-already registered before `AddOpenTelemetry()` is called. With `HostBuilder`,
-use the `ConfigureAppConfiguration` approach instead so the YAML source is added
-before DI configuration is built. Calling `UseDeclarativeConfiguration()` twice
-on the same `IServiceCollection` is a no-op - the first file path wins and a
-warning is emitted via EventSource. Calling it with a different path does not
-replace the first registration.
+Calling `UseDeclarativeConfiguration()` twice on the same `IServiceCollection`
+is a no-op and the first file path wins.
 
 Only one declarative configuration file is supported per
 `IConfigurationBuilder`. Registering the same file again is a no-op. Registering
@@ -175,13 +170,16 @@ merged per key; the typed YAML document cannot, so exactly one document is used.
   provide the specification's strict mode that ignores other SDK environment
   variables when `OTEL_CONFIG_FILE` is set.
 - `UseDeclarativeConfiguration()` applies YAML values by extending the
-  `IConfiguration` registered at the time it is called. An application that
+  configuration available to it at the time it is called. An application that
   replaces its `IConfiguration` registration, or clears its configuration
   sources, *after* that call detaches the YAML source: flat keys lose the YAML
-  values while typed consumers still read the document. Register declarative
-  configuration after your configuration sources are settled, or use
-  `builder.Configuration.AddOpenTelemetryDeclarativeConfiguration()`, which adds
-  the source directly and is not affected.
+  values while typed consumers still read the document. Following
+  `builder.AddOpenTelemetry()` the source is added to `builder.Configuration`
+  directly, so a later `builder.Configuration.Sources.Clear()` detaches it;
+  following `services.AddOpenTelemetry()` (non-host) the source is added to the
+  `IConfiguration` resolved from the container, so a later registration of
+  `IConfiguration` detaches it. Register declarative configuration after your
+  configuration sources are settled.
 - Only string-valued structured resource attributes are emitted. Unsupported
   typed attributes are skipped and reported.
 - For duplicate structured resource attribute names, the first occurrence wins.

--- a/src/OpenTelemetry.Extensions.Hosting/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Hosting/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Extensions.Hosting.OpenTelemetryHostApplicationBuilderExtensions
+static Microsoft.Extensions.Hosting.OpenTelemetryHostApplicationBuilderExtensions.AddOpenTelemetry(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder) -> OpenTelemetry.OpenTelemetryBuilder!

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -6,6 +6,15 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added an `AddOpenTelemetry` extension method for `IHostApplicationBuilder`.
+  It registers the OpenTelemetry SDK services and additionally seeds
+  `service.name` from `IHostEnvironment.ApplicationName` and
+  `deployment.environment.name` from `IHostEnvironment.EnvironmentName` as
+  low-priority resource defaults. It also registers the host's live
+  configuration into DI so that extensions receiving only `IServiceCollection`
+  can contribute configuration sources during setup.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.18.0
 
 Released 2026-Aug-21

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -13,7 +13,7 @@ Notes](../../RELEASENOTES.md).
   low-priority resource defaults. It also registers the host's live
   configuration into DI so that extensions receiving only `IServiceCollection`
   can contribute configuration sources during setup.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#7723](https://github.com/open-telemetry/opentelemetry-dotnet/pull/7723))
 
 ## 1.18.0
 

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Resources;
+
+namespace OpenTelemetry.Extensions.Hosting.Implementation;
+
+// Contributes service.name and deployment.environment.name from the host environment as
+// low-priority defaults. Runs after the SDK's OtelEnvResourceDetector and
+// OtelServiceNameEnvVarDetector in the ResourceBuilder pipeline, so it actively skips keys
+// that those detectors would supply to preserve their higher-priority values. Application
+// ConfigureResource callbacks run after this detector and win.
+internal sealed class HostEnvironmentResourceDetector(
+    IHostEnvironment environment,
+    IConfiguration? configuration) : IResourceDetector
+{
+    private const string OtelServiceNameKey = "OTEL_SERVICE_NAME";
+    private const string OtelResourceAttributesKey = "OTEL_RESOURCE_ATTRIBUTES";
+
+    public Resource Detect()
+    {
+        var attributes = new List<KeyValuePair<string, object>>();
+
+        if (!this.IsAttributeSetInConfiguration("service.name") &&
+            !string.IsNullOrWhiteSpace(environment.ApplicationName))
+        {
+            attributes.Add(new("service.name", environment.ApplicationName));
+        }
+
+        if (!this.IsAttributeInOtelResourceAttributes("deployment.environment.name") &&
+            !string.IsNullOrWhiteSpace(environment.EnvironmentName))
+        {
+            attributes.Add(new("deployment.environment.name", environment.EnvironmentName));
+        }
+
+        return new Resource(attributes);
+    }
+
+    internal bool IsAttributeSetInConfiguration(string attributeName)
+    {
+        if (configuration == null)
+        {
+            // IConfiguration is optional; without it no env-var suppression is possible.
+            return false;
+        }
+
+        if (attributeName == "service.name" && !string.IsNullOrWhiteSpace(configuration[OtelServiceNameKey]))
+        {
+            return true;
+        }
+
+        return this.IsAttributeInOtelResourceAttributes(attributeName);
+    }
+
+    internal bool IsAttributeInOtelResourceAttributes(string attributeName)
+    {
+        var raw = configuration?[OtelResourceAttributesKey];
+        if (raw == null)
+        {
+            return false;
+        }
+
+        foreach (var pair in raw.Split(','))
+        {
+#if NETFRAMEWORK || NETSTANDARD2_0
+            var eq = pair.IndexOf('=');
+#else
+            var eq = pair.IndexOf('=', StringComparison.Ordinal);
+#endif
+            if (eq > 0 && string.Equals(pair.Substring(0, eq).Trim(), attributeName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Extensions.Hosting.Implementation;
@@ -37,7 +38,7 @@ internal sealed class HostEnvironmentResourceDetector(
             attributes.Add(new(DeploymentEnvironmentNameAttribute, NormalizeEnvironmentName(environment.EnvironmentName)));
         }
 
-        return attributes.Count < 1 ? Resource.Empty : new Resource(attributes);
+        return attributes.Count < 1 ? Resource.Empty : new Resource(attributes, SchemaUrls.Get(SemanticConventionsVersion.Current));
     }
 
     internal bool IsAttributeSetInConfiguration(string attributeName)

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
@@ -18,21 +18,23 @@ internal sealed class HostEnvironmentResourceDetector(
 {
     private const string OtelServiceNameKey = "OTEL_SERVICE_NAME";
     private const string OtelResourceAttributesKey = "OTEL_RESOURCE_ATTRIBUTES";
+    private const string ServiceNameAttribute = "service.name";
+    private const string DeploymentEnvironmentNameAttribute = "deployment.environment.name";
 
     public Resource Detect()
     {
         var attributes = new List<KeyValuePair<string, object>>();
 
-        if (!this.IsAttributeSetInConfiguration("service.name") &&
+        if (!this.IsAttributeSetInConfiguration(ServiceNameAttribute) &&
             !string.IsNullOrWhiteSpace(environment.ApplicationName))
         {
-            attributes.Add(new("service.name", environment.ApplicationName));
+            attributes.Add(new(ServiceNameAttribute, environment.ApplicationName));
         }
 
-        if (!this.IsAttributeInOtelResourceAttributes("deployment.environment.name") &&
+        if (!this.IsAttributeInOtelResourceAttributes(DeploymentEnvironmentNameAttribute) &&
             !string.IsNullOrWhiteSpace(environment.EnvironmentName))
         {
-            attributes.Add(new("deployment.environment.name", environment.EnvironmentName));
+            attributes.Add(new(DeploymentEnvironmentNameAttribute, NormalizeEnvironmentName(environment.EnvironmentName)));
         }
 
         return new Resource(attributes);
@@ -46,7 +48,7 @@ internal sealed class HostEnvironmentResourceDetector(
             return false;
         }
 
-        if (attributeName == "service.name" && !string.IsNullOrWhiteSpace(configuration[OtelServiceNameKey]))
+        if (attributeName == ServiceNameAttribute && !string.IsNullOrWhiteSpace(configuration[OtelServiceNameKey]))
         {
             return true;
         }
@@ -65,11 +67,11 @@ internal sealed class HostEnvironmentResourceDetector(
         foreach (var pair in raw.Split(','))
         {
 #if NETFRAMEWORK || NETSTANDARD2_0
-            var eq = pair.IndexOf('=');
+            var index = pair.IndexOf('=');
 #else
-            var eq = pair.IndexOf('=', StringComparison.Ordinal);
+            var index = pair.IndexOf('=', StringComparison.Ordinal);
 #endif
-            if (eq > 0 && string.Equals(pair.Substring(0, eq).Trim(), attributeName, StringComparison.Ordinal))
+            if (index > 0 && string.Equals(pair.Substring(0, index).Trim(), attributeName, StringComparison.Ordinal))
             {
                 return true;
             }
@@ -77,4 +79,14 @@ internal sealed class HostEnvironmentResourceDetector(
 
         return false;
     }
+
+    // The spec (https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/#deployment-attributes) mandates these four well-known values in lowercase.
+    private static string NormalizeEnvironmentName(string name) => name switch
+    {
+        _ when string.Equals(name, "development", StringComparison.OrdinalIgnoreCase) => "development",
+        _ when string.Equals(name, "production", StringComparison.OrdinalIgnoreCase) => "production",
+        _ when string.Equals(name, "staging", StringComparison.OrdinalIgnoreCase) => "staging",
+        _ when string.Equals(name, "test", StringComparison.OrdinalIgnoreCase) => "test",
+        _ => name,
+    };
 }

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostEnvironmentResourceDetector.cs
@@ -23,7 +23,7 @@ internal sealed class HostEnvironmentResourceDetector(
 
     public Resource Detect()
     {
-        var attributes = new List<KeyValuePair<string, object>>();
+        var attributes = new List<KeyValuePair<string, object>>(2);
 
         if (!this.IsAttributeSetInConfiguration(ServiceNameAttribute) &&
             !string.IsNullOrWhiteSpace(environment.ApplicationName))
@@ -37,7 +37,7 @@ internal sealed class HostEnvironmentResourceDetector(
             attributes.Add(new(DeploymentEnvironmentNameAttribute, NormalizeEnvironmentName(environment.EnvironmentName)));
         }
 
-        return new Resource(attributes);
+        return attributes.Count < 1 ? Resource.Empty : new Resource(attributes);
     }
 
     internal bool IsAttributeSetInConfiguration(string attributeName)
@@ -80,7 +80,7 @@ internal sealed class HostEnvironmentResourceDetector(
         return false;
     }
 
-    // The spec (https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/#deployment-attributes) mandates these four well-known values in lowercase.
+    // The spec (https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/registry/attributes/deployment.md) mandates these four well-known values in lowercase.
     private static string NormalizeEnvironmentName(string name) => name switch
     {
         _ when string.Equals(name, "development", StringComparison.OrdinalIgnoreCase) => "development",

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryHostApplicationBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryHostApplicationBuilderExtensions.cs
@@ -109,5 +109,4 @@ public static class OpenTelemetryHostApplicationBuilderExtensions
                     environment,
                     serviceProvider.GetService<IConfiguration>()));
     }
-
 }

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryHostApplicationBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryHostApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry;
+using OpenTelemetry.Extensions.Hosting.Implementation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -109,74 +110,4 @@ public static class OpenTelemetryHostApplicationBuilderExtensions
                     serviceProvider.GetService<IConfiguration>()));
     }
 
-    // Contributes service.name and deployment.environment.name from the host environment as
-    // low-priority defaults. Runs after the SDK's OtelEnvResourceDetector and
-    // OtelServiceNameEnvVarDetector in the ResourceBuilder pipeline, so it actively skips keys
-    // that those detectors would supply to preserve their higher-priority values. Application
-    // ConfigureResource callbacks run after this detector and win.
-    private sealed class HostEnvironmentResourceDetector(
-        IHostEnvironment environment,
-        IConfiguration? configuration) : IResourceDetector
-    {
-        private const string OtelServiceNameKey = "OTEL_SERVICE_NAME";
-        private const string OtelResourceAttributesKey = "OTEL_RESOURCE_ATTRIBUTES";
-
-        public Resource Detect()
-        {
-            var attributes = new List<KeyValuePair<string, object>>();
-
-            if (!this.IsAttributeSetInConfiguration("service.name") &&
-                !string.IsNullOrWhiteSpace(environment.ApplicationName))
-            {
-                attributes.Add(new("service.name", environment.ApplicationName));
-            }
-
-            if (!this.IsAttributeInOtelResourceAttributes("deployment.environment.name") &&
-                !string.IsNullOrWhiteSpace(environment.EnvironmentName))
-            {
-                attributes.Add(new("deployment.environment.name", environment.EnvironmentName));
-            }
-
-            return new Resource(attributes);
-        }
-
-        private bool IsAttributeSetInConfiguration(string attributeName)
-        {
-            if (configuration == null)
-            {
-                return false;
-            }
-
-            if (attributeName == "service.name" && !string.IsNullOrWhiteSpace(configuration[OtelServiceNameKey]))
-            {
-                return true;
-            }
-
-            return this.IsAttributeInOtelResourceAttributes(attributeName);
-        }
-
-        private bool IsAttributeInOtelResourceAttributes(string attributeName)
-        {
-            var raw = configuration?[OtelResourceAttributesKey];
-            if (raw == null)
-            {
-                return false;
-            }
-
-            foreach (var pair in raw.Split(','))
-            {
-#if NETFRAMEWORK || NETSTANDARD2_0
-                var eq = pair.IndexOf('=');
-#else
-                var eq = pair.IndexOf('=', StringComparison.Ordinal);
-#endif
-                if (eq > 0 && string.Equals(pair.Substring(0, eq).Trim(), attributeName, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-    }
 }

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryHostApplicationBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryHostApplicationBuilderExtensions.cs
@@ -1,0 +1,182 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Extension methods for configuring OpenTelemetry on an application host.
+/// </summary>
+public static class OpenTelemetryHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds OpenTelemetry SDK services to the application host.
+    /// </summary>
+    /// <remarks>
+    /// <para>This method is safe to call multiple times. OpenTelemetry services are
+    /// started and stopped with the host.</para>
+    /// <para>This method registers <see cref="IHostEnvironment.ApplicationName"/>
+    /// as the default <c>service.name</c> resource attribute and
+    /// <see cref="IHostEnvironment.EnvironmentName"/> as the default
+    /// <c>deployment.environment.name</c> resource attribute. Both defaults are
+    /// overridden by the <c>OTEL_SERVICE_NAME</c> / <c>OTEL_RESOURCE_ATTRIBUTES</c>
+    /// environment variables or by any
+    /// <see cref="OpenTelemetryBuilderSdkExtensions.ConfigureResource"/> call.</para>
+    /// </remarks>
+    /// <param name="builder">The application host builder.</param>
+    /// <returns>An <see cref="OpenTelemetryBuilder"/> for configuring OpenTelemetry.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    public static OpenTelemetryBuilder AddOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        Guard.ThrowIfNull(builder);
+
+        // Captures configuration at registration time so SDK-internal code in lower-level assemblies
+        // can access it without those assemblies taking a hard dependency on IConfiguration.
+        builder.Services.TryAddSingleton(new OpenTelemetryBuilderConfigurationAccessor(builder.Configuration));
+
+        // IHostApplicationBuilder does not register IConfigurationManager in DI; registering
+        // the live builder instance lets extensions that only receive IServiceCollection contribute
+        // configuration sources during setup.
+        builder.Services.TryAddSingleton(builder.Configuration);
+
+        var openTelemetryBuilder = builder.Services.AddOpenTelemetry();
+
+        if (!builder.Services.Any(
+            static descriptor => descriptor.ServiceType == typeof(HostEnvironmentResourceConfigurationMarker)))
+        {
+            builder.Services.AddSingleton<HostEnvironmentResourceConfigurationMarker>();
+
+            var resourceConfiguration = new HostEnvironmentResourceConfiguration(builder.Environment);
+
+            // Resource defaults must run before any application configuration regardless of
+            // registration order. Insert the callbacks at the start of the service collection,
+            // while preserving registration order for all application callbacks.
+            builder.Services.Insert(
+                0,
+                ServiceDescriptor.Singleton<IConfigureTracerProviderBuilder>(resourceConfiguration));
+            builder.Services.Insert(
+                0,
+                ServiceDescriptor.Singleton<IConfigureMeterProviderBuilder>(resourceConfiguration));
+            builder.Services.Insert(
+                0,
+                ServiceDescriptor.Singleton<IConfigureLoggerProviderBuilder>(resourceConfiguration));
+        }
+
+        return openTelemetryBuilder;
+    }
+
+    private sealed class HostEnvironmentResourceConfigurationMarker;
+
+    private sealed class HostEnvironmentResourceConfiguration(IHostEnvironment environment) :
+        IConfigureTracerProviderBuilder,
+        IConfigureMeterProviderBuilder,
+        IConfigureLoggerProviderBuilder
+    {
+        void IConfigureTracerProviderBuilder.ConfigureBuilder(
+            IServiceProvider serviceProvider,
+            TracerProviderBuilder tracerProviderBuilder)
+            => tracerProviderBuilder.ConfigureResource(
+                resourceBuilder => this.ConfigureResource(serviceProvider, resourceBuilder));
+
+        void IConfigureMeterProviderBuilder.ConfigureBuilder(
+            IServiceProvider serviceProvider,
+            MeterProviderBuilder meterProviderBuilder)
+            => meterProviderBuilder.ConfigureResource(
+                resourceBuilder => this.ConfigureResource(serviceProvider, resourceBuilder));
+
+        void IConfigureLoggerProviderBuilder.ConfigureBuilder(
+            IServiceProvider serviceProvider,
+            LoggerProviderBuilder loggerProviderBuilder)
+            => loggerProviderBuilder.ConfigureResource(
+                resourceBuilder => this.ConfigureResource(serviceProvider, resourceBuilder));
+
+        private void ConfigureResource(
+            IServiceProvider serviceProvider,
+            ResourceBuilder resourceBuilder)
+            => resourceBuilder.AddDetector(
+                new HostEnvironmentResourceDetector(
+                    environment,
+                    serviceProvider.GetService<IConfiguration>()));
+    }
+
+    // Contributes service.name and deployment.environment.name from the host environment as
+    // low-priority defaults. Runs after the SDK's OtelEnvResourceDetector and
+    // OtelServiceNameEnvVarDetector in the ResourceBuilder pipeline, so it actively skips keys
+    // that those detectors would supply to preserve their higher-priority values. Application
+    // ConfigureResource callbacks run after this detector and win.
+    private sealed class HostEnvironmentResourceDetector(
+        IHostEnvironment environment,
+        IConfiguration? configuration) : IResourceDetector
+    {
+        private const string OtelServiceNameKey = "OTEL_SERVICE_NAME";
+        private const string OtelResourceAttributesKey = "OTEL_RESOURCE_ATTRIBUTES";
+
+        public Resource Detect()
+        {
+            var attributes = new List<KeyValuePair<string, object>>();
+
+            if (!this.IsAttributeSetInConfiguration("service.name") &&
+                !string.IsNullOrWhiteSpace(environment.ApplicationName))
+            {
+                attributes.Add(new("service.name", environment.ApplicationName));
+            }
+
+            if (!this.IsAttributeInOtelResourceAttributes("deployment.environment.name") &&
+                !string.IsNullOrWhiteSpace(environment.EnvironmentName))
+            {
+                attributes.Add(new("deployment.environment.name", environment.EnvironmentName));
+            }
+
+            return new Resource(attributes);
+        }
+
+        private bool IsAttributeSetInConfiguration(string attributeName)
+        {
+            if (configuration == null)
+            {
+                return false;
+            }
+
+            if (attributeName == "service.name" && !string.IsNullOrWhiteSpace(configuration[OtelServiceNameKey]))
+            {
+                return true;
+            }
+
+            return this.IsAttributeInOtelResourceAttributes(attributeName);
+        }
+
+        private bool IsAttributeInOtelResourceAttributes(string attributeName)
+        {
+            var raw = configuration?[OtelResourceAttributesKey];
+            if (raw == null)
+            {
+                return false;
+            }
+
+            foreach (var pair in raw.Split(','))
+            {
+#if NETFRAMEWORK || NETSTANDARD2_0
+                var eq = pair.IndexOf('=');
+#else
+                var eq = pair.IndexOf('=', StringComparison.Ordinal);
+#endif
+                if (eq > 0 && string.Equals(pair.Substring(0, eq).Trim(), attributeName, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -57,6 +57,48 @@ Targeting `Microsoft.Extensions.DependencyInjection.IServiceCollection`:
   * `WithMetrics`: Enables metrics and optionally configures the
   `MeterProvider`.
 
+Targeting `Microsoft.Extensions.Hosting.IHostApplicationBuilder`:
+
+* `AddOpenTelemetry`: Does everything the `IServiceCollection` method above
+  does, using
+  [IHostApplicationBuilder.Services](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostapplicationbuilder.services),
+  and additionally:
+
+  - Seeds `service.name` from
+    [`IHostEnvironment.ApplicationName`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostenvironment.applicationname)
+    and `deployment.environment.name` from
+    [`IHostEnvironment.EnvironmentName`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostenvironment.environmentname)
+    as low-priority resource defaults. Both are superseded by the
+    `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` environment variables or
+    by any explicit
+    [`ConfigureResource`](https://learn.microsoft.com/dotnet/api/opentelemetry.opentelemetrybuildersdk-extensions.configureresource)
+    call.
+
+  - Makes the host's
+    [Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostapplicationbuilder.configuration)
+    available to OpenTelemetry extensions during setup. It also registers that
+    configuration as an `IConfigurationManager` singleton when the application
+    has not already registered one.
+
+  It returns the same `OpenTelemetryBuilder` class, so the only change to an
+  existing setup is the first line:
+
+  ```csharp
+  var builder = Host.CreateApplicationBuilder(args);
+
+  builder.AddOpenTelemetry()
+      .WithTracing(tracing => tracing.AddSource("MyApp"));
+  ```
+
+  > [!NOTE]
+  > A host registers `IConfiguration` as a factory so that the container owns
+  its disposal, which leaves the underlying configuration unreachable while the
+  application is still being built. Registering it makes the application's
+  configuration available to OpenTelemetry extensions that only receive an
+  `IServiceCollection`, so they can contribute configuration sources during
+  setup rather than replacing the `IConfiguration` registration afterwards. An
+  `IConfigurationManager` already registered by the application is left in place.
+
 ## Usage
 
 The following example shows how to register OpenTelemetry tracing & metrics in
@@ -64,14 +106,12 @@ an ASP.NET Core host using the OpenTelemetry.Extensions.Hosting extensions.
 
 ```csharp
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 var appBuilder = WebApplication.CreateBuilder(args);
 
-appBuilder.Services.AddOpenTelemetry()
-    .ConfigureResource(builder => builder.AddService(serviceName: "MyService"))
+appBuilder.AddOpenTelemetry()
     .WithTracing(builder => builder.AddConsoleExporter())
     .WithMetrics(builder => builder.AddConsoleExporter());
 

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -64,7 +64,7 @@ Targeting `Microsoft.Extensions.Hosting.IHostApplicationBuilder`:
   [IHostApplicationBuilder.Services](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostapplicationbuilder.services),
   and additionally:
 
-  - Seeds `service.name` from
+  * Seeds `service.name` from
     [`IHostEnvironment.ApplicationName`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostenvironment.applicationname)
     and `deployment.environment.name` from
     [`IHostEnvironment.EnvironmentName`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostenvironment.environmentname)
@@ -74,7 +74,7 @@ Targeting `Microsoft.Extensions.Hosting.IHostApplicationBuilder`:
     [`ConfigureResource`](https://learn.microsoft.com/dotnet/api/opentelemetry.opentelemetrybuildersdk-extensions.configureresource)
     call.
 
-  - Makes the host's
+  * Makes the host's
     [Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.hosting.ihostapplicationbuilder.configuration)
     available to OpenTelemetry extensions during setup. It also registers that
     configuration as an `IConfigurationManager` singleton when the application

--- a/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationHostIntegrationTests.cs
+++ b/test/OpenTelemetry.Configuration.Declarative.Tests/DeclarativeConfigurationHostIntegrationTests.cs
@@ -344,4 +344,126 @@ public sealed class DeclarativeConfigurationHostIntegrationTests
         var config = host.Services.GetRequiredService<IConfiguration>();
         Assert.Equal("app-value", config["some-app-key"]);
     }
+
+    [Fact]
+    public void ModernHost_AddOpenTelemetryOnHostBuilder_YamlVisibleDuringSetup()
+    {
+        // AddOpenTelemetry(IHostApplicationBuilder) registers the host's live configuration, so
+        // the overlay inserts the YAML source in-place during setup. Without it the source is
+        // only inserted when IConfiguration is first resolved from the container, so values are
+        // invisible to anything reading builder.Configuration while the application is built.
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(
+            resourceAttributes: new Dictionary<string, string> { ["service.name"] = "setup-visible" });
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.AddOpenTelemetry()
+            .UseDeclarativeConfiguration(yamlFile.Path)
+            .WithTracing();
+
+        Assert.Equal("service.name=setup-visible", builder.Configuration["OTEL_RESOURCE_ATTRIBUTES"]);
+    }
+
+    [Fact]
+    public void ModernHost_AddOpenTelemetryOnHostBuilder_WithExistingConfigurationManager_UsesHostConfiguration()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(
+            resourceAttributes: new Dictionary<string, string> { ["service.name"] = "setup-visible" });
+
+        var builder = Host.CreateApplicationBuilder();
+        using var applicationConfiguration = new ConfigurationManager();
+        builder.Services.AddSingleton<IConfigurationManager>(applicationConfiguration);
+
+        builder.AddOpenTelemetry()
+            .UseDeclarativeConfiguration(yamlFile.Path)
+            .WithTracing();
+
+        Assert.Equal("service.name=setup-visible", builder.Configuration["OTEL_RESOURCE_ATTRIBUTES"]);
+        Assert.Null(applicationConfiguration["OTEL_RESOURCE_ATTRIBUTES"]);
+    }
+
+    [Fact]
+    public void ModernHost_AddOpenTelemetryOnServiceCollection_YamlNotVisibleDuringSetup()
+    {
+        // Characterises the difference the host-builder entry point makes. Reaching the overlay
+        // through IServiceCollection leaves the host's configuration unreachable, so the source
+        // is only inserted when IConfiguration is resolved from the container. The values still
+        // reach the SDK (see ModernHost_UseDeclarativeConfiguration_ResourceAttributesFlowToSdk),
+        // but not in time for code reading builder.Configuration during setup.
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(
+            resourceAttributes: new Dictionary<string, string> { ["service.name"] = "setup-visible" });
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddOpenTelemetry()
+            .UseDeclarativeConfiguration(yamlFile.Path)
+            .WithTracing();
+
+        Assert.Null(builder.Configuration["OTEL_RESOURCE_ATTRIBUTES"]);
+    }
+
+    [Fact]
+    public void ModernHost_AddOpenTelemetryOnHostBuilder_AddsSourceInPlace()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(disabled: false);
+
+        var builder = Host.CreateApplicationBuilder();
+        var sourcesBefore = builder.Configuration.Sources.Count;
+        var configurationDescriptorsBefore = builder.Services
+            .Count(d => d.ServiceType == typeof(IConfiguration));
+
+        builder.AddOpenTelemetry().UseDeclarativeConfiguration(yamlFile.Path);
+
+        // The YAML source is appended to the host's own sources, after env vars and appsettings.
+        Assert.Equal(sourcesBefore + 1, builder.Configuration.Sources.Count);
+        Assert.IsType<DeclarativeConfigurationSource>(
+            builder.Configuration.Sources[builder.Configuration.Sources.Count - 1]);
+
+        // No descriptor surgery: the application's IConfiguration registration is left alone.
+        Assert.Equal(
+            configurationDescriptorsBefore,
+            builder.Services.Count(d => d.ServiceType == typeof(IConfiguration)));
+    }
+
+    [Fact]
+    public void ModernHost_AddOpenTelemetryOnHostBuilder_ResourceAttributesFlowToSdk()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(
+            resourceAttributes: new Dictionary<string, string> { ["service.name"] = "modern-host-svc-via-builder" });
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.AddOpenTelemetry()
+            .UseDeclarativeConfiguration(yamlFile.Path)
+            .WithTracing();
+
+        using var host = builder.Build();
+
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(
+            resource.Attributes,
+            a => a.Key == "service.name" && (string)a.Value == "modern-host-svc-via-builder");
+    }
+
+    [Fact]
+    public void ModernHost_AddOpenTelemetryOnHostBuilder_YamlOverridesSourceAddedBeforeIt()
+    {
+        using var yamlFile = DeclarativeYamlTestFile.CreateDeclarativeYaml(
+            resourceAttributes: new Dictionary<string, string> { ["service.name"] = "from-yaml" });
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=from-in-memory",
+        });
+
+        builder.AddOpenTelemetry()
+            .UseDeclarativeConfiguration(yamlFile.Path)
+            .WithTracing();
+
+        using var host = builder.Build();
+
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+        Assert.Contains(
+            resource.Attributes,
+            a => a.Key == "service.name" && (string)a.Value == "from-yaml");
+    }
 }

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/HostEnvironmentResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/HostEnvironmentResourceDetectorTests.cs
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Extensions.Hosting.Implementation;
+
+namespace OpenTelemetry.Extensions.Hosting.Tests;
+
+public class HostEnvironmentResourceDetectorTests
+{
+    [Fact]
+    public void Detect_NullConfiguration_AppliesHostDefaults()
+    {
+        var env = CreateEnvironment("MyApp", "Staging");
+        var detector = new HostEnvironmentResourceDetector(env, configuration: null);
+
+        var resource = detector.Detect();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name"
+            && (string)a.Value == "MyApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name"
+            && (string)a.Value == "Staging");
+    }
+
+    [Fact]
+    public void IsAttributeSetInConfiguration_NullConfiguration_ReturnsFalse()
+    {
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), configuration: null);
+
+        Assert.False(detector.IsAttributeSetInConfiguration("service.name"));
+        Assert.False(detector.IsAttributeSetInConfiguration("deployment.environment.name"));
+    }
+
+    [Fact]
+    public void IsAttributeInOtelResourceAttributes_NullConfiguration_ReturnsFalse()
+    {
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), configuration: null);
+
+        Assert.False(detector.IsAttributeInOtelResourceAttributes("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeSetInConfiguration_OtelServiceNameSet_ReturnsTrueForServiceName()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_SERVICE_NAME"] = "env-service",
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.True(detector.IsAttributeSetInConfiguration("service.name"));
+        Assert.False(detector.IsAttributeSetInConfiguration("deployment.environment.name"));
+    }
+
+    [Fact]
+    public void IsAttributeSetInConfiguration_OtelServiceNameEmpty_ReturnsFalseForServiceName()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_SERVICE_NAME"] = string.Empty,
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.False(detector.IsAttributeSetInConfiguration("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeSetInConfiguration_OtelServiceNameWhitespace_ReturnsFalseForServiceName()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?> { ["OTEL_SERVICE_NAME"] = "   " });
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.False(detector.IsAttributeSetInConfiguration("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeInOtelResourceAttributes_AttributePresent_ReturnsTrue()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=from-env",
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.True(detector.IsAttributeInOtelResourceAttributes("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeInOtelResourceAttributes_AttributeAbsent_ReturnsFalse()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "other.key=value",
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.False(detector.IsAttributeInOtelResourceAttributes("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeInOtelResourceAttributes_LeadingEquals_ReturnsFalse()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "=value",
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.False(detector.IsAttributeInOtelResourceAttributes("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeInOtelResourceAttributes_KeyWithWhitespace_ReturnsTrue()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = " service.name = trimmed",
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.True(detector.IsAttributeInOtelResourceAttributes("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeInOtelResourceAttributes_DifferentCase_ReturnsFalse()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "SERVICE.NAME=value",
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.False(detector.IsAttributeInOtelResourceAttributes("service.name"));
+    }
+
+    [Fact]
+    public void IsAttributeInOtelResourceAttributes_MalformedEntryBeforeValid_SkipsMalformed()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "malformed,service.name=valid",
+        });
+
+        var detector = new HostEnvironmentResourceDetector(CreateEnvironment("App", "Prod"), config);
+
+        Assert.True(detector.IsAttributeInOtelResourceAttributes("service.name"));
+        Assert.False(detector.IsAttributeInOtelResourceAttributes("malformed"));
+    }
+
+    private static FakeHostEnvironment CreateEnvironment(string applicationName, string environmentName)
+        => new() { ApplicationName = applicationName, EnvironmentName = environmentName };
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = string.Empty;
+
+        public string ApplicationName { get; set; } = string.Empty;
+
+        public string ContentRootPath { get; set; } = string.Empty;
+
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/HostEnvironmentResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/HostEnvironmentResourceDetectorTests.cs
@@ -18,10 +18,35 @@ public class HostEnvironmentResourceDetectorTests
 
         var resource = detector.Detect();
 
-        Assert.Contains(resource.Attributes, a => a.Key == "service.name"
-            && (string)a.Value == "MyApp");
-        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name"
-            && (string)a.Value == "Staging");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
+    }
+
+    [Theory]
+    [InlineData("Development", "development")]
+    [InlineData("Production", "production")]
+    [InlineData("Staging", "staging")]
+    [InlineData("Test", "test")]
+    [InlineData("PRODUCTION", "production")]
+    public void Detect_WellKnownEnvironmentName_NormalizesToLowercase(string input, string expected)
+    {
+        var env = CreateEnvironment("App", input);
+        var detector = new HostEnvironmentResourceDetector(env, configuration: null);
+
+        var resource = detector.Detect();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == expected);
+    }
+
+    [Fact]
+    public void Detect_CustomEnvironmentName_PassesThroughUnchanged()
+    {
+        var env = CreateEnvironment("App", "MyCustomEnv");
+        var detector = new HostEnvironmentResourceDetector(env, configuration: null);
+
+        var resource = detector.Detect();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "MyCustomEnv");
     }
 
     [Fact]

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryHostApplicationBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryHostApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,784 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Extensions.Hosting.Implementation;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Extensions.Hosting.Tests;
+
+public class OpenTelemetryHostApplicationBuilderExtensionsTests
+{
+    [Fact]
+    public void AddOpenTelemetry_NullBuilder_Throws()
+    {
+        IHostApplicationBuilder? builder = null;
+
+        Assert.Throws<ArgumentNullException>(() => builder!.AddOpenTelemetry());
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ReturnsBuilderBackedByHostServices()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var openTelemetryBuilder = builder.AddOpenTelemetry();
+
+        Assert.Same(builder.Services, openTelemetryBuilder.Services);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_CalledTwice_RegistersSingleHostedService()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.AddOpenTelemetry();
+        builder.AddOpenTelemetry();
+
+        Assert.Single(builder.Services, IsTelemetryHostedService);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_MixedWithServiceCollectionOverload_RegistersSingleHostedService()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.AddOpenTelemetry();
+        builder.Services.AddOpenTelemetry();
+
+        Assert.Single(builder.Services, IsTelemetryHostedService);
+    }
+
+    [Fact]
+    public async Task AddOpenTelemetry_StartsTracerProviderWithHost()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.AddOpenTelemetry()
+            .WithTracing(tracing => tracing.AddSource("MyApp"));
+
+        using var host = builder.Build();
+
+        await host.StartAsync();
+
+        var tracerProvider = host.Services.GetRequiredService<TracerProvider>();
+        Assert.NotNull(tracerProvider);
+
+        using var activitySource = new ActivitySource("MyApp");
+        Assert.True(activitySource.HasListeners());
+
+        await host.StopAsync();
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_RegistersHostConfigurationAsInstance()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.AddOpenTelemetry();
+
+        var descriptor = Assert.Single(
+            builder.Services,
+            d => d.ServiceType == typeof(IConfigurationManager));
+
+        Assert.Same(builder.Configuration, descriptor.ImplementationInstance);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_RegisteredHostConfigurationResolvesToLiveConfiguration()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.AddOpenTelemetry();
+
+        using var host = builder.Build();
+
+        var configurationManager = host.Services.GetRequiredService<IConfigurationManager>();
+
+        Assert.Same(builder.Configuration, configurationManager);
+
+        // The live builder is what makes contributing a configuration source during setup
+        // possible. Verify the registered instance is still a usable builder.
+        Assert.IsType<IConfigurationBuilder>(configurationManager, exactMatch: false);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_DoesNotOverrideExistingConfigurationManagerRegistration()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        using var applicationConfiguration = new ConfigurationManager();
+        builder.Services.AddSingleton<IConfigurationManager>(applicationConfiguration);
+
+        builder.AddOpenTelemetry();
+
+        var descriptor = Assert.Single(
+            builder.Services,
+            d => d.ServiceType == typeof(IConfigurationManager));
+
+        Assert.Same(applicationConfiguration, descriptor.ImplementationInstance);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_DoesNotDisturbHostConfigurationRegistration()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        var descriptorsBefore = builder.Services
+            .Count(d => d.ServiceType == typeof(IConfiguration));
+
+        builder.AddOpenTelemetry();
+
+        Assert.Equal(
+            descriptorsBefore,
+            builder.Services.Count(d => d.ServiceType == typeof(IConfiguration)));
+
+        using var host = builder.Build();
+
+        Assert.Same(builder.Configuration, host.Services.GetRequiredService<IConfiguration>());
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_SetsDefaultServiceNameFromApplicationName()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_SetsDefaultDeploymentEnvironmentFromEnvironmentName()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.EnvironmentName = "Staging";
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_SetsHostEnvironmentDefaultsForAllSignals()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Staging";
+
+        builder.AddOpenTelemetry()
+            .WithLogging()
+            .WithMetrics()
+            .WithTracing();
+
+        using var host = builder.Build();
+
+        BaseProvider[] providers =
+        [
+            host.Services.GetRequiredService<LoggerProvider>(),
+            host.Services.GetRequiredService<MeterProvider>(),
+            host.Services.GetRequiredService<TracerProvider>(),
+        ];
+
+        foreach (var provider in providers)
+        {
+            var resource = provider.GetResource();
+            Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+            Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+        }
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelServiceNameInConfiguration_OverridesServiceNameDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_SERVICE_NAME"] = "env-service",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "env-service");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesServiceName_OverridesServiceNameDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=from-otel-resource-attributes",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "from-otel-resource-attributes");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesDeploymentEnv_OverridesDeploymentEnvDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.EnvironmentName = "Development";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "deployment.environment.name=staging",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Development");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_DifferentlyCasedResourceAttribute_DoesNotOverrideHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "SERVICE.NAME=from-otel-resource-attributes",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "SERVICE.NAME" && (string)a.Value == "from-otel-resource-attributes");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ExplicitConfigureResource_OverridesHostEnvironmentDefaults()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Development";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes(
+            [
+                new("service.name", "explicit-service"),
+                new("deployment.environment.name", "prod"),
+            ]))
+            .WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Development");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "explicit-service");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "prod");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ExplicitConfigurationRegisteredFirst_OverridesHostEnvironmentDefaults()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Development";
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes(
+            [
+                new("service.name", "explicit-service"),
+                new("deployment.environment.name", "prod"),
+            ]));
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Development");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "explicit-service");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "prod");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_CalledAgain_DoesNotOverrideExplicitConfiguration()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Development";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes(
+            [
+                new("service.name", "explicit-service"),
+                new("deployment.environment.name", "prod"),
+            ]));
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Development");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "explicit-service");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "prod");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_EmptyApplicationName_DoesNotSetServiceName()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = string.Empty;
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && string.IsNullOrEmpty((string)a.Value));
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_WhitespaceApplicationName_DoesNotSetServiceName()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "   ";
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "   ");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_EmptyEnvironmentName_DoesNotSetDeploymentEnvironmentName()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.EnvironmentName = string.Empty;
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesMultipleAttributes_OverridesBothDefaults()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Development";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=from-env,deployment.environment.name=staging",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "from-env");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Development");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesWithKeyWhitespace_OverridesDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = " service.name = trimmed-service",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelServiceNameEmptyString_DoesNotSuppressHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_SERVICE_NAME"] = string.Empty,
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_CalledTwice_RegistersSingleSetOfHostEnvironmentConfigureBuilders()
+    {
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.AddOpenTelemetry();
+
+        var serviceCountAfterFirst = builder.Services.Count;
+
+        builder.AddOpenTelemetry();
+
+        Assert.Equal(serviceCountAfterFirst, builder.Services.Count);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_PerSignalConfigureResourceInWithTracing_OverridesHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry()
+            .WithTracing(b => b.ConfigureResource(rb => rb.AddAttributes(
+            [
+                new("service.name", "per-signal-service"),
+            ])));
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "per-signal-service");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ConfigureResourceViaServicesAfterHostSetup_OverridesHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes(
+            [
+                new("service.name", "from-services"),
+            ]));
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "from-services");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_MultipleConfigureResourceSameKey_LastCallWins()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes([new("service.name", "first-call")]))
+            .ConfigureResource(rb => rb.AddAttributes([new("service.name", "second-call")]))
+            .WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "first-call");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "second-call");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_MultipleConfigureResourceDifferentKeys_BothAttributesPresent()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes([new("custom.key.a", "value-a")]))
+            .ConfigureResource(rb => rb.AddAttributes([new("custom.key.b", "value-b")]))
+            .WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "custom.key.a" && (string)a.Value == "value-a");
+        Assert.Contains(resource.Attributes, a => a.Key == "custom.key.b" && (string)a.Value == "value-b");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ConfigureResourcePartialOverride_HostDefaultFillsUnsetAttribute()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Staging";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes([new("service.name", "explicit-service")]))
+            .WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "explicit-service");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ConfigureResourceAddsCustomAttribute_CoexistsWithHostDefaults()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Staging";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddAttributes([new("custom.attr", "custom-value")]))
+            .WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+        Assert.Contains(resource.Attributes, a => a.Key == "custom.attr" && (string)a.Value == "custom-value");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_PerSignalConfigureResource_DoesNotAffectOtherSignals()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry()
+            .WithTracing(b => b.ConfigureResource(rb => rb.AddAttributes([new("service.name", "tracer-service")])))
+            .WithMetrics();
+
+        using var host = builder.Build();
+
+        var tracerResource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+        var meterResource = host.Services.GetRequiredService<MeterProvider>().GetResource();
+
+        Assert.DoesNotContain(tracerResource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(tracerResource.Attributes, a => a.Key == "service.name" && (string)a.Value == "tracer-service");
+        Assert.Contains(meterResource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ConfigureResourceAddService_OverridesHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddService("explicit-service"))
+            .WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "explicit-service");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_ConfigureResourceWithClear_RemovesHostDefaults()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+
+        builder.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.Clear().AddAttributes([new("service.name", "fresh-service")]))
+            .WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "fresh-service");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelServiceNameWhitespace_DoesNotSuppressHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_SERVICE_NAME"] = "   ",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_WhitespaceEnvironmentName_DoesNotSetDeploymentEnvironmentName()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.EnvironmentName = "   ";
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "deployment.environment.name");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelServiceNameSet_DoesNotSuppressDeploymentEnvironmentDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Staging";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_SERVICE_NAME"] = "env-service",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "env-service");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesMalformedEntryBeforeValid_SkipsMalformedAndAppliesValid()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "malformed,service.name=valid",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "valid");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesEmptyValue_SuppressesHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "service.name=",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        // The key is present (eq > 0) so the host default is suppressed even though the value is empty.
+        Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesLeadingEquals_DoesNotSuppressHostDefault()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "=value",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        // eq == 0 so eq > 0 is false; the pair is skipped and the host default is applied.
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_OtelResourceAttributesWhitespaceOnly_DoesNotSuppressHostDefaults()
+    {
+        var builder = CreateBuilderWithoutOtelResourceEnvironmentVariables();
+        builder.Environment.ApplicationName = "MyTestApp";
+        builder.Environment.EnvironmentName = "Staging";
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "   ",
+        });
+
+        builder.AddOpenTelemetry().WithTracing();
+
+        using var host = builder.Build();
+        var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+
+        Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+    }
+
+    private static HostApplicationBuilder CreateBuilderWithoutOtelResourceEnvironmentVariables()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OTEL_RESOURCE_ATTRIBUTES"] = null,
+            ["OTEL_SERVICE_NAME"] = null,
+        });
+
+        return builder;
+    }
+
+    private static bool IsTelemetryHostedService(ServiceDescriptor descriptor)
+        => descriptor.ServiceType == typeof(IHostedService)
+            && descriptor.ImplementationType == typeof(TelemetryHostedService);
+}

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryHostApplicationBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryHostApplicationBuilderExtensionsTests.cs
@@ -170,7 +170,7 @@ public class OpenTelemetryHostApplicationBuilderExtensionsTests
         using var host = builder.Build();
         var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
 
-        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
     }
 
     [Fact]
@@ -187,19 +187,17 @@ public class OpenTelemetryHostApplicationBuilderExtensionsTests
 
         using var host = builder.Build();
 
-        BaseProvider[] providers =
-        [
-            host.Services.GetRequiredService<LoggerProvider>(),
-            host.Services.GetRequiredService<MeterProvider>(),
-            host.Services.GetRequiredService<TracerProvider>(),
-        ];
+        var loggerResource = host.Services.GetRequiredService<LoggerProvider>().GetResource();
+        Assert.Contains(loggerResource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(loggerResource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
 
-        foreach (var provider in providers)
-        {
-            var resource = provider.GetResource();
-            Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
-            Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
-        }
+        var meterResource = host.Services.GetRequiredService<MeterProvider>().GetResource();
+        Assert.Contains(meterResource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(meterResource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
+
+        var tracerResource = host.Services.GetRequiredService<TracerProvider>().GetResource();
+        Assert.Contains(tracerResource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
+        Assert.Contains(tracerResource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
     }
 
     [Fact]
@@ -560,7 +558,7 @@ public class OpenTelemetryHostApplicationBuilderExtensionsTests
 
         Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
         Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "explicit-service");
-        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
     }
 
     [Fact]
@@ -578,7 +576,7 @@ public class OpenTelemetryHostApplicationBuilderExtensionsTests
         var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
 
         Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
-        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
         Assert.Contains(resource.Attributes, a => a.Key == "custom.attr" && (string)a.Value == "custom-value");
     }
 
@@ -686,7 +684,7 @@ public class OpenTelemetryHostApplicationBuilderExtensionsTests
 
         Assert.DoesNotContain(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
         Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "env-service");
-        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
     }
 
     [Fact]
@@ -763,7 +761,7 @@ public class OpenTelemetryHostApplicationBuilderExtensionsTests
         var resource = host.Services.GetRequiredService<TracerProvider>().GetResource();
 
         Assert.Contains(resource.Attributes, a => a.Key == "service.name" && (string)a.Value == "MyTestApp");
-        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "Staging");
+        Assert.Contains(resource.Attributes, a => a.Key == "deployment.environment.name" && (string)a.Value == "staging");
     }
 
     private static HostApplicationBuilder CreateBuilderWithoutOtelResourceEnvironmentVariables()


### PR DESCRIPTION
Fixes #7689

## Changes

- Adds `AddOpenTelemetry(this IHostApplicationBuilder)` to `OpenTelemetry.Extensions.Hosting`, completing the hosting API surface for applications that use `IHostApplicationBuilder` (e.g. `WebApplicationBuilder`, `HostApplicationBuilder`).
- Seeds `service.name` and `deployment.environment.name` from the host environment as low-priority defaults; OTEL environment variables and any `ConfigureResource` call take precedence.
- Registers the host's live configuration into DI so lower-level extensions that receive only `IServiceCollection` can contribute sources during setup.
- Adds `OpenTelemetryBuilderConfigurationAccessor` in `Api.ProviderBuilderExtensions` to carry `IConfiguration` across the assembly boundary without adding a new package dependency to that assembly.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~Changes in public API reviewed (if applicable)~