### PR TITLE
[Infra] Avoid CS7027 error

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -81,7 +81,7 @@ finally
 
   <Target Name="GenerateAssemblyOriginatorKeyFile" BeforeTargets="ResolveKeySource" Condition="'$(SignAssembly)' == 'true'">
     <PropertyGroup>
-      <AssemblyOriginatorKeyFile>$([System.IO.Path]::Combine('$(BaseIntermediateOutputPath)', 'OpenTelemetry.snk'))</AssemblyOriginatorKeyFile>
+      <AssemblyOriginatorKeyFile>$([System.IO.Path]::Combine('$(IntermediateOutputPath)', 'OpenTelemetry.snk'))</AssemblyOriginatorKeyFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changes

Avoid CS7027 error during compilation if multiple CSC processes race to create the `.snk` file from the base64-encoded version ([example](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/34214226084/job/102022154410#step:7:417)).

The downside is more copies of the decoded file on disk (~1KB per assembly x TFM combination).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
